### PR TITLE
docs: add a human-friendly WSL starter config guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ The full RMUX documentation is available at [rmux.io/docs](https://rmux.io/docs/
 
 It includes [installation guides](https://rmux.io/docs/get-started/), [CLI references](https://rmux.io/docs/cli/), [SDK examples](https://rmux.io/docs/examples/), [terminal automation examples](https://rmux.io/docs/examples/#/terminal-playwright), and [API documentation](https://rmux.io/docs/api/).
 
+For an ergonomic, human-oriented WSL profile that keeps native terminal selection intuitive while adding easier split bindings and clipboard integration, see [docs/wsl-human-ux.md](docs/wsl-human-ux.md).
+
 ## CLI Quickstart
 
 ```sh

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,3 +3,7 @@
 The full RMUX documentation is available at [rmux.io/docs](https://rmux.io/docs/).
 
 It includes [installation guides](https://rmux.io/docs/get-started/), [CLI references](https://rmux.io/docs/cli/), [SDK examples](https://rmux.io/docs/examples/), [terminal automation examples](https://rmux.io/docs/examples/#/terminal-playwright), and [API documentation](https://rmux.io/docs/api/).
+
+Repository-local guides:
+
+- [Human-friendly WSL starter config](wsl-human-ux.md)

--- a/docs/examples/rmux-pane-shell
+++ b/docs/examples/rmux-pane-shell
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -e
+TARGET_DIR="${1:-$HOME}"
+if [ ! -d "$TARGET_DIR" ]; then
+  TARGET_DIR="$HOME"
+fi
+cd "$TARGET_DIR"
+exec "${SHELL:-/bin/bash}" -i

--- a/docs/examples/wsl-human.conf
+++ b/docs/examples/wsl-human.conf
@@ -1,0 +1,48 @@
+# Human-friendly WSL starter config for RMUX.
+# Drop into ~/.config/rmux/rmux.conf or ~/.rmux.conf and adjust to taste.
+
+# Safer prefix for heavy shell work.
+set -g prefix C-a
+unbind C-b
+bind C-a send-prefix
+
+# Native terminal selection and double-click selection stay intuitive by default.
+# Toggle pane mouse mode on demand with prefix + T.
+set -g mouse off
+bind T if-shell -F '#{mouse}' 'set -g mouse off \; display-message "mouse OFF: native terminal selection enabled"' 'set -g mouse on \; display-message "mouse ON: pane mouse mode enabled"'
+
+# Quality-of-life.
+set -g history-limit 100000
+set -g renumber-windows on
+set -g base-index 1
+setw -g pane-base-index 1
+setw -g mode-keys vi
+set -g status-keys vi
+
+# Keep cwd when opening new panes or windows.
+bind % split-window -h -c "#{pane_current_path}"
+bind '"' split-window -v -c "#{pane_current_path}"
+bind c new-window -c "#{pane_current_path}"
+
+# Easier split bindings for PT-BR and other keyboard layouts.
+bind v split-window -h -c "#{pane_current_path}"
+bind b split-window -v -c "#{pane_current_path}"
+
+# Simple pane navigation.
+bind h select-pane -L
+bind j select-pane -D
+bind k select-pane -U
+bind l select-pane -R
+bind Tab last-window
+
+# WSL clipboard integration.
+set -s copy-command '/mnt/c/WINDOWS/System32/clip.exe'
+bind [ copy-mode
+bind -T copy-mode-vi v send-keys -X begin-selection
+bind -T copy-mode-vi V send-keys -X select-line
+bind -T copy-mode-vi C-v send-keys -X rectangle-toggle
+bind -T copy-mode-vi y send-keys -X copy-pipe-and-cancel
+bind -T copy-mode-vi C-c send-keys -X copy-pipe-and-cancel
+
+# Quick reload.
+bind r source-file ~/.config/rmux/rmux.conf \; display-message "rmux.conf reloaded"

--- a/docs/examples/wsl-human.conf
+++ b/docs/examples/wsl-human.conf
@@ -20,13 +20,15 @@ setw -g mode-keys vi
 set -g status-keys vi
 
 # Keep cwd when opening new panes or windows.
-bind % split-window -h -c "#{pane_current_path}"
-bind '"' split-window -v -c "#{pane_current_path}"
+# new-window supports -c; for split-window, use a helper script because
+# current RMUX preview builds may not expose tmux-style `-c <cwd>` there.
+bind % split-window -h ~/.local/bin/rmux-pane-shell "#{pane_current_path}"
+bind '"' split-window -v ~/.local/bin/rmux-pane-shell "#{pane_current_path}"
 bind c new-window -c "#{pane_current_path}"
 
 # Easier split bindings for PT-BR and other keyboard layouts.
-bind v split-window -h -c "#{pane_current_path}"
-bind b split-window -v -c "#{pane_current_path}"
+bind v split-window -h ~/.local/bin/rmux-pane-shell "#{pane_current_path}"
+bind b split-window -v ~/.local/bin/rmux-pane-shell "#{pane_current_path}"
 
 # Simple pane navigation.
 bind h select-pane -L

--- a/docs/wsl-human-ux.md
+++ b/docs/wsl-human-ux.md
@@ -1,0 +1,88 @@
+# Human-friendly WSL starter config
+
+RMUX is tmux-compatible by design, which is great for existing tmux users and for automation. On WSL, however, a few defaults can feel surprising for people who are treating RMUX like an everyday interactive terminal:
+
+- enabling `mouse` lets RMUX capture drag and double-click events instead of the terminal doing native text selection
+- `%`, `"`, and `|` can be awkward on PT-BR and other keyboard layouts
+- many users expect new panes and windows to start in the current working directory
+- clipboard integration is much nicer when WSL explicitly forwards copies to `clip.exe`
+
+This guide keeps RMUX defaults intact and shows one ergonomic user config you can drop into `~/.config/rmux/rmux.conf` or `~/.rmux.conf`.
+
+## Starter config
+
+See [`docs/examples/wsl-human.conf`](examples/wsl-human.conf) for the full file.
+
+```tmux
+# Safer prefix for heavy shell work.
+set -g prefix C-a
+unbind C-b
+bind C-a send-prefix
+
+# Native selection works like a normal terminal until you opt into pane mouse mode.
+set -g mouse off
+bind T if-shell -F '#{mouse}' 'set -g mouse off \; display-message "mouse OFF: native terminal selection enabled"' 'set -g mouse on \; display-message "mouse ON: pane mouse mode enabled"'
+
+# Keep cwd when opening new panes or windows.
+bind % split-window -h -c "#{pane_current_path}"
+bind '"' split-window -v -c "#{pane_current_path}"
+bind c new-window -c "#{pane_current_path}"
+
+# Easier split bindings for keyboard layouts where %, ", or | are awkward.
+bind v split-window -h -c "#{pane_current_path}"
+bind b split-window -v -c "#{pane_current_path}"
+
+# WSL clipboard integration.
+set -s copy-command '/mnt/c/WINDOWS/System32/clip.exe'
+bind [ copy-mode
+bind -T copy-mode-vi v send-keys -X begin-selection
+bind -T copy-mode-vi y send-keys -X copy-pipe-and-cancel
+bind -T copy-mode-vi C-c send-keys -X copy-pipe-and-cancel
+```
+
+## Why `mouse off` is the ergonomic default here
+
+When RMUX mouse mode is on, the multiplexer receives mouse drag and double-click events. That is what enables pane-aware selection, resizing, and copy-mode interactions, but it also means native terminal selection no longer behaves like a plain shell.
+
+A common compromise for interactive WSL usage is:
+
+- keep `mouse off` by default so drag and double-click selection feel normal
+- toggle it on only when you want pane mouse behavior with `prefix + T`
+
+Many terminals also offer a modifier such as `Shift` plus drag to force native selection even when the multiplexer has mouse mode enabled.
+
+## Keyboard-layout friendly splits
+
+The classic tmux-compatible split bindings remain important:
+
+- `prefix + %` for left/right panes
+- `prefix + "` for top/bottom panes
+
+For users on PT-BR and similar layouts, it is useful to add plain-letter alternatives that do the same thing:
+
+- `prefix + v` for left/right panes
+- `prefix + b` for top/bottom panes
+
+Keeping both bindings means the session stays familiar to tmux users while also becoming easier to operate on non-US keyboards.
+
+## Copying text on WSL
+
+With `copy-command` pointed at `clip.exe`, copy-mode actions can send text directly to the Windows clipboard.
+
+One practical flow is:
+
+1. `prefix + [` to enter copy-mode
+2. move with arrows or `h/j/k/l`
+3. press `v` to begin selection
+4. press `y`, `Enter`, or a custom `C-c` binding to copy and exit
+
+This keeps shell `Ctrl+C` behavior unchanged outside copy-mode while still giving a fast copy shortcut inside copy-mode.
+
+## Window vs pane mental model
+
+If you come from a regular terminal, the biggest usability confusion is usually this:
+
+- `new-window` creates a new tab-like screen
+- `split-window` creates another visible pane in the current screen
+
+If you only see one shell after creating a new window, nothing is broken — you opened a new window, not a split pane.

--- a/docs/wsl-human-ux.md
+++ b/docs/wsl-human-ux.md
@@ -11,7 +11,7 @@ This guide keeps RMUX defaults intact and shows one ergonomic user config you ca
 
 ## Starter config
 
-See [`docs/examples/wsl-human.conf`](examples/wsl-human.conf) for the full file.
+See [`docs/examples/wsl-human.conf`](examples/wsl-human.conf) for the full file and [`docs/examples/rmux-pane-shell`](examples/rmux-pane-shell) for the tiny helper used to preserve the current working directory on pane splits.
 
 ```tmux
 # Safer prefix for heavy shell work.
@@ -24,13 +24,15 @@ set -g mouse off
 bind T if-shell -F '#{mouse}' 'set -g mouse off \; display-message "mouse OFF: native terminal selection enabled"' 'set -g mouse on \; display-message "mouse ON: pane mouse mode enabled"'
 
 # Keep cwd when opening new panes or windows.
-bind % split-window -h -c "#{pane_current_path}"
-bind '"' split-window -v -c "#{pane_current_path}"
+# new-window supports -c, but split-window may not on current RMUX preview builds.
+# Use a tiny helper for cwd-preserving pane splits.
+bind % split-window -h ~/.local/bin/rmux-pane-shell "#{pane_current_path}"
+bind '"' split-window -v ~/.local/bin/rmux-pane-shell "#{pane_current_path}"
 bind c new-window -c "#{pane_current_path}"
 
 # Easier split bindings for keyboard layouts where %, ", or | are awkward.
-bind v split-window -h -c "#{pane_current_path}"
-bind b split-window -v -c "#{pane_current_path}"
+bind v split-window -h ~/.local/bin/rmux-pane-shell "#{pane_current_path}"
+bind b split-window -v ~/.local/bin/rmux-pane-shell "#{pane_current_path}"
 
 # WSL clipboard integration.
 set -s copy-command '/mnt/c/WINDOWS/System32/clip.exe'
@@ -50,6 +52,36 @@ A common compromise for interactive WSL usage is:
 - toggle it on only when you want pane mouse behavior with `prefix + T`
 
 Many terminals also offer a modifier such as `Shift` plus drag to force native selection even when the multiplexer has mouse mode enabled.
+
+## Cwd-preserving splits on current preview builds
+
+On current RMUX preview builds, `new-window --help` exposes `-c <cwd>`, but `split-window --help` may not. If you apply tmux-style `split-window -c "#{pane_current_path}"` blindly, RMUX can interpret `-c` as part of the child command instead of as a start-directory flag.
+
+The symptom can look like a blank pane, a dead pane, or an attach/detach feeling where the split appears and then immediately becomes unusable.
+
+The safe pattern is:
+
+1. keep `new-window -c "#{pane_current_path}"`
+2. use a small helper for pane splits that `cd`s into the requested path and then `exec`s the shell
+
+Example helper (also provided in [`docs/examples/rmux-pane-shell`](examples/rmux-pane-shell)):
+
+```bash
+#!/usr/bin/env bash
+set -e
+TARGET_DIR="${1:-$HOME}"
+if [ ! -d "$TARGET_DIR" ]; then
+  TARGET_DIR="$HOME"
+fi
+cd "$TARGET_DIR"
+exec "${SHELL:-/bin/bash}" -i
+```
+
+Install it locally with:
+
+```sh
+install -m 755 docs/examples/rmux-pane-shell ~/.local/bin/rmux-pane-shell
+```
 
 ## Keyboard-layout friendly splits
 


### PR DESCRIPTION
## Summary
- add a repository-local WSL usability guide for interactive human workflows
- add a starter config example covering native selection, mouse toggle, easier split bindings, helper-based cwd-preserving splits, and WSL clipboard integration
- add a tiny example helper script for cwd-preserving pane splits on current preview builds
- link the new guide from the main README and docs index

## Validation
- loaded the example with `rmux source-file docs/examples/wsl-human.conf`
- verified `docs/examples/rmux-pane-shell` parses with `bash -n`
- verified relative markdown links resolve inside the repo
- ran `git diff --check`

Closes #5