### PR TITLE
feat: bring modernity, embrace Rust edition 2024

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.95.0
         with:
           components: clippy, rustfmt
 
@@ -64,7 +64,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.95.0
 
       - name: Cache cargo
         uses: actions/cache@v4
@@ -105,7 +105,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.95.0
 
       - name: Cache cargo
         uses: actions/cache@v4
@@ -146,7 +146,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.95.0
 
       - name: Cache cargo
         uses: actions/cache@v4
@@ -171,7 +171,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.95.0
 
       - name: Cache cargo
         uses: actions/cache@v4
@@ -194,7 +194,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.95.0
 
       - name: Cache cargo
         uses: actions/cache@v4
@@ -234,7 +234,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.95.0
 
       - name: Cache cargo
         uses: actions/cache@v4
@@ -271,7 +271,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.95.0
         with:
           targets: x86_64-pc-windows-gnu
 
@@ -302,7 +302,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.95.0
 
       - name: Cache cargo
         uses: actions/cache@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           ref: ${{ env.RELEASE_REF }}
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.95.0
         with:
           targets: ${{ matrix.target }}
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,8 @@ resolver = "2"
 
 [workspace.package]
 version = "0.2.5"
-edition = "2021"
+edition = "2024"
+rust-version = "1.95"
 publish = false
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/helvesec/rmux"
@@ -27,6 +28,7 @@ repository = "https://github.com/helvesec/rmux"
 name = "rmux"
 version = "0.2.5"
 edition.workspace = true
+rust-version.workspace = true
 publish = true
 license.workspace = true
 repository.workspace = true

--- a/crates/ratatui-rmux/Cargo.toml
+++ b/crates/ratatui-rmux/Cargo.toml
@@ -2,6 +2,7 @@
 name = "ratatui-rmux"
 version = "0.2.5"
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Ratatui integration crate for the RMUX terminal multiplexer that paints daemon-backed pane state into a ratatui Buffer."

--- a/crates/ratatui-rmux/tests/ratatui_real_daemon_render_smoke.rs
+++ b/crates/ratatui-rmux/tests/ratatui_real_daemon_render_smoke.rs
@@ -282,7 +282,8 @@ struct EnvGuard {
 impl EnvGuard {
     fn set(key: &'static str, value: &std::ffi::OsStr) -> Self {
         let previous = std::env::var_os(key);
-        std::env::set_var(key, value);
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::set_var(key, value) };
         Self { key, previous }
     }
 }
@@ -290,8 +291,10 @@ impl EnvGuard {
 impl Drop for EnvGuard {
     fn drop(&mut self) {
         match &self.previous {
-            Some(value) => std::env::set_var(self.key, value),
-            None => std::env::remove_var(self.key),
+            // TODO: Audit that the environment access only happens in single-threaded code.
+            Some(value) => unsafe { std::env::set_var(self.key, value) },
+            // TODO: Audit that the environment access only happens in single-threaded code.
+            None => unsafe { std::env::remove_var(self.key) },
         }
     }
 }

--- a/crates/rmux-client/Cargo.toml
+++ b/crates/rmux-client/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rmux-client"
 version = "0.2.5"
 edition.workspace = true
+rust-version.workspace = true
 publish = true
 license.workspace = true
 repository.workspace = true

--- a/crates/rmux-client/src/connection/tests.rs
+++ b/crates/rmux-client/src/connection/tests.rs
@@ -127,10 +127,11 @@ fn default_socket_path_matches_server_path() {
 fn default_socket_path_matches_server_path_when_rmux_tmpdir_is_unresolved() {
     let _guard = RMUX_TMPDIR_ENV_LOCK.lock().expect("rmux tmpdir env lock");
     let original = std::env::var_os("RMUX_TMPDIR");
-    std::env::set_var(
+    // TODO: Audit that the environment access only happens in single-threaded code.
+    unsafe { std::env::set_var(
         "RMUX_TMPDIR",
         "relative-rmux-test-path-that-does-not-exist",
-    );
+    ) };
 
     let client_path = super::default_socket_path().expect("client socket path");
     let server_path = rmux_server::default_socket_path().expect("server socket path");
@@ -144,8 +145,10 @@ fn default_socket_path_matches_server_path_when_rmux_tmpdir_is_unresolved() {
     );
 
     match original {
-        Some(value) => std::env::set_var("RMUX_TMPDIR", value),
-        None => std::env::remove_var("RMUX_TMPDIR"),
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        Some(value) => unsafe { std::env::set_var("RMUX_TMPDIR", value) },
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        None => unsafe { std::env::remove_var("RMUX_TMPDIR") },
     }
 }
 
@@ -153,7 +156,8 @@ fn default_socket_path_matches_server_path_when_rmux_tmpdir_is_unresolved() {
 fn resolve_socket_path_prefers_socket_path_over_socket_name_and_rmux_env() {
     let _guard = RMUX_TMPDIR_ENV_LOCK.lock().expect("rmux tmpdir env lock");
     let original_rmux = std::env::var_os("RMUX");
-    std::env::set_var("RMUX", "/tmp/from-rmux,1,0");
+    // TODO: Audit that the environment access only happens in single-threaded code.
+    unsafe { std::env::set_var("RMUX", "/tmp/from-rmux,1,0") };
 
     let path = super::resolve_socket_path(
         Some(OsStr::new("named")),
@@ -163,8 +167,10 @@ fn resolve_socket_path_prefers_socket_path_over_socket_name_and_rmux_env() {
 
     assert_eq!(path, PathBuf::from("/tmp/from-flag"));
     match original_rmux {
-        Some(value) => std::env::set_var("RMUX", value),
-        None => std::env::remove_var("RMUX"),
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        Some(value) => unsafe { std::env::set_var("RMUX", value) },
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        None => unsafe { std::env::remove_var("RMUX") },
     }
 }
 
@@ -172,14 +178,17 @@ fn resolve_socket_path_prefers_socket_path_over_socket_name_and_rmux_env() {
 fn resolve_socket_path_uses_rmux_env_before_default_label() {
     let _guard = RMUX_TMPDIR_ENV_LOCK.lock().expect("rmux tmpdir env lock");
     let original_rmux = std::env::var_os("RMUX");
-    std::env::set_var("RMUX", "/tmp/rmux-1000/from-rmux,1,0");
+    // TODO: Audit that the environment access only happens in single-threaded code.
+    unsafe { std::env::set_var("RMUX", "/tmp/rmux-1000/from-rmux,1,0") };
 
     let path = super::resolve_socket_path(None, None).expect("resolved socket path");
 
     assert_eq!(path, PathBuf::from("/tmp/rmux-1000/from-rmux"));
     match original_rmux {
-        Some(value) => std::env::set_var("RMUX", value),
-        None => std::env::remove_var("RMUX"),
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        Some(value) => unsafe { std::env::set_var("RMUX", value) },
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        None => unsafe { std::env::remove_var("RMUX") },
     }
 }
 
@@ -187,15 +196,18 @@ fn resolve_socket_path_uses_rmux_env_before_default_label() {
 fn resolve_socket_path_ignores_non_rmux_env_socket() {
     let _guard = RMUX_TMPDIR_ENV_LOCK.lock().expect("rmux tmpdir env lock");
     let original_rmux = std::env::var_os("RMUX");
-    std::env::set_var("RMUX", "/tmp/other-1000/default,1,0");
+    // TODO: Audit that the environment access only happens in single-threaded code.
+    unsafe { std::env::set_var("RMUX", "/tmp/other-1000/default,1,0") };
 
     let path = super::resolve_socket_path(None, None).expect("resolved socket path");
     let default = super::default_socket_path().expect("default socket path");
 
     assert_eq!(path, default);
     match original_rmux {
-        Some(value) => std::env::set_var("RMUX", value),
-        None => std::env::remove_var("RMUX"),
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        Some(value) => unsafe { std::env::set_var("RMUX", value) },
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        None => unsafe { std::env::remove_var("RMUX") },
     }
 }
 
@@ -203,15 +215,18 @@ fn resolve_socket_path_ignores_non_rmux_env_socket() {
 fn resolve_socket_path_ignores_empty_rmux_env() {
     let _guard = RMUX_TMPDIR_ENV_LOCK.lock().expect("rmux tmpdir env lock");
     let original_rmux = std::env::var_os("RMUX");
-    std::env::set_var("RMUX", "");
+    // TODO: Audit that the environment access only happens in single-threaded code.
+    unsafe { std::env::set_var("RMUX", "") };
 
     let path = super::resolve_socket_path(None, None).expect("resolved socket path");
     let default = super::default_socket_path().expect("default socket path");
 
     assert_eq!(path, default);
     match original_rmux {
-        Some(value) => std::env::set_var("RMUX", value),
-        None => std::env::remove_var("RMUX"),
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        Some(value) => unsafe { std::env::set_var("RMUX", value) },
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        None => unsafe { std::env::remove_var("RMUX") },
     }
 }
 
@@ -219,15 +234,18 @@ fn resolve_socket_path_ignores_empty_rmux_env() {
 fn resolve_socket_path_ignores_nonempty_malformed_rmux_env() {
     let _guard = RMUX_TMPDIR_ENV_LOCK.lock().expect("rmux tmpdir env lock");
     let original_rmux = std::env::var_os("RMUX");
-    std::env::set_var("RMUX", "malformed-rmux-value");
+    // TODO: Audit that the environment access only happens in single-threaded code.
+    unsafe { std::env::set_var("RMUX", "malformed-rmux-value") };
 
     let path = super::resolve_socket_path(None, None).expect("resolved socket path");
     let default = super::default_socket_path().expect("default socket path");
 
     assert_eq!(path, default);
     match original_rmux {
-        Some(value) => std::env::set_var("RMUX", value),
-        None => std::env::remove_var("RMUX"),
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        Some(value) => unsafe { std::env::set_var("RMUX", value) },
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        None => unsafe { std::env::remove_var("RMUX") },
     }
 }
 

--- a/crates/rmux-client/src/nested.rs
+++ b/crates/rmux-client/src/nested.rs
@@ -125,17 +125,21 @@ mod tests {
         let _guard = RMUX_ENV_LOCK.lock().expect("rmux env lock");
         let original = std::env::var_os("RMUX");
 
-        std::env::remove_var("RMUX");
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::remove_var("RMUX") };
         assert_eq!(super::detect_context(), ClientContext::Outside);
         assert_eq!(require_nested_context(), Err(NestedContextError));
 
-        std::env::set_var("RMUX", "/tmp/rmux-1000/default,1,0");
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::set_var("RMUX", "/tmp/rmux-1000/default,1,0") };
         assert_eq!(super::detect_context(), ClientContext::Nested);
         assert_eq!(require_nested_context(), Ok(()));
 
         match original {
-            Some(value) => std::env::set_var("RMUX", value),
-            None => std::env::remove_var("RMUX"),
+            // TODO: Audit that the environment access only happens in single-threaded code.
+            Some(value) => unsafe { std::env::set_var("RMUX", value) },
+            // TODO: Audit that the environment access only happens in single-threaded code.
+            None => unsafe { std::env::remove_var("RMUX") },
         }
     }
 }

--- a/crates/rmux-client/tests/session_lifecycle.rs
+++ b/crates/rmux-client/tests/session_lifecycle.rs
@@ -358,7 +358,8 @@ fn assert_absent_server_does_not_spawn_daemon(label: &str) -> Result<(), Box<dyn
 
     fs::create_dir_all(&marker_dir)?;
     write_fake_launcher(&launcher_path, &marker_path)?;
-    std::env::set_var(BINARY_OVERRIDE_ENV, &launcher_path);
+    // TODO: Audit that the environment access only happens in single-threaded code.
+    unsafe { std::env::set_var(BINARY_OVERRIDE_ENV, &launcher_path) };
 
     let result = connect_or_absent(harness.socket_path())?;
     assert!(matches!(result, ConnectResult::Absent));
@@ -404,8 +405,10 @@ impl EnvVarGuard {
 impl Drop for EnvVarGuard {
     fn drop(&mut self) {
         match self.previous_value.as_ref() {
-            Some(value) => std::env::set_var(self.name, value),
-            None => std::env::remove_var(self.name),
+            // TODO: Audit that the environment access only happens in single-threaded code.
+            Some(value) => unsafe { std::env::set_var(self.name, value) },
+            // TODO: Audit that the environment access only happens in single-threaded code.
+            None => unsafe { std::env::remove_var(self.name) },
         }
     }
 }

--- a/crates/rmux-core/Cargo.toml
+++ b/crates/rmux-core/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rmux-core"
 version = "0.2.5"
 edition.workspace = true
+rust-version.workspace = true
 publish = true
 license.workspace = true
 repository.workspace = true

--- a/crates/rmux-core/src/command_parser.rs
+++ b/crates/rmux-core/src/command_parser.rs
@@ -416,8 +416,8 @@ impl CommandParser {
         };
 
         for mut command in commands.commands {
-            if !no_alias {
-                if let Some(alias) = self.find_command_alias(&command.name) {
+            if !no_alias
+                && let Some(alias) = self.find_command_alias(&command.name) {
                     let mut alias_parser = self.clone();
                     alias_parser.environment.extend(
                         assignments
@@ -435,7 +435,6 @@ impl CommandParser {
                     output.append(replacement);
                     continue;
                 }
-            }
 
             for argument in &mut command.arguments {
                 if let CommandArgument::Commands(nested) = argument {

--- a/crates/rmux-core/src/command_parser/grammar.rs
+++ b/crates/rmux-core/src/command_parser/grammar.rs
@@ -60,11 +60,10 @@ impl<'a> GrammarParser<'a> {
                     if let Some(assignment) = assignment {
                         commands.push_assignment(assignment);
                     }
-                    if active {
-                        if let Some(command) = command {
+                    if active
+                        && let Some(command) = command {
                             commands.push_command(command);
                         }
-                    }
                 }
                 LexToken::If => {
                     commands.append(self.parse_condition(active)?);

--- a/crates/rmux-core/src/environment.rs
+++ b/crates/rmux-core/src/environment.rs
@@ -143,15 +143,14 @@ impl EnvironmentStore {
     /// Resolves a single variable using session-local then global lookup.
     #[must_use]
     pub fn resolve(&self, session_name: Option<&SessionName>, name: &str) -> Option<&str> {
-        if let Some(session_name) = session_name {
-            if let Some(entry) = self
+        if let Some(session_name) = session_name
+            && let Some(entry) = self
                 .sessions
                 .get(session_name)
                 .and_then(|values| values.get(name))
             {
                 return entry.value();
             }
-        }
 
         self.global.get(name).and_then(EnvironmentEntry::value)
     }
@@ -181,13 +180,12 @@ impl EnvironmentStore {
             apply_entry_to_child_environment(values, name, entry);
         }
 
-        if let Some(session_name) = session_name {
-            if let Some(session_values) = self.sessions.get(session_name) {
+        if let Some(session_name) = session_name
+            && let Some(session_values) = self.sessions.get(session_name) {
                 for (name, entry) in session_values {
                     apply_entry_to_child_environment(values, name, entry);
                 }
             }
-        }
     }
 
     /// Merges client variables into a session environment using tmux `update-environment`.

--- a/crates/rmux-core/src/events/coalescing.rs
+++ b/crates/rmux-core/src/events/coalescing.rs
@@ -120,19 +120,17 @@ impl SnapshotCoalescer {
     /// `None` if the revision was held back, suppressed as a duplicate, or
     /// stored as pending for a future poll.
     pub fn observe(&mut self, revision: u64, now: Instant) -> Option<u64> {
-        if let Some(emitted) = self.last_emitted {
-            if emitted.revision == revision {
-                if let Some(pending) = self.pending {
-                    if pending.revision == revision {
+        if let Some(emitted) = self.last_emitted
+            && emitted.revision == revision {
+                if let Some(pending) = self.pending
+                    && pending.revision == revision {
                         // The pending slot only carries the newest unemitted
                         // revision; if it equals the last emitted value
                         // there is nothing left to deliver.
                         self.pending = None;
                     }
-                }
                 return None;
             }
-        }
 
         if self.may_emit_at(now) {
             self.commit_emission(revision, now);
@@ -159,12 +157,11 @@ impl SnapshotCoalescer {
         if !self.may_emit_at(now) {
             return None;
         }
-        if let Some(emitted) = self.last_emitted {
-            if emitted.revision == pending.revision {
+        if let Some(emitted) = self.last_emitted
+            && emitted.revision == pending.revision {
                 self.pending = None;
                 return None;
             }
-        }
         self.commit_emission(pending.revision, now);
         self.pending = None;
         Some(pending.revision)

--- a/crates/rmux-core/src/formats.rs
+++ b/crates/rmux-core/src/formats.rs
@@ -199,11 +199,10 @@ where
                 b'q' => {
                     if fm.argv.is_empty() {
                         flags |= MOD_QUOTE_SHELL;
-                    } else if let Some(arg) = fm.argv.first() {
-                        if arg.contains('e') || arg.contains('h') {
+                    } else if let Some(arg) = fm.argv.first()
+                        && (arg.contains('e') || arg.contains('h')) {
                             flags |= MOD_QUOTE_STYLE;
                         }
-                    }
                 }
                 b'E' => flags |= MOD_EXPAND,
                 b'T' => flags |= MOD_EXPAND_TIME,
@@ -235,11 +234,10 @@ where
         }
     }
 
-    if let Some(scope) = deferred_loop_scope {
-        if let Some(value) = variables.format_loop(scope, body, false) {
+    if let Some(scope) = deferred_loop_scope
+        && let Some(value) = variables.format_loop(scope, body, false) {
             return value;
         }
-    }
     if let Some(modifier) = name_exists {
         let scope = match modifier.argv.first().map(String::as_str) {
             None | Some("") | Some("w") => None,
@@ -376,11 +374,10 @@ where
     }
 
     // Basename.
-    if flags & MOD_BASENAME != 0 {
-        if let Some(pos) = result.rfind('/') {
+    if flags & MOD_BASENAME != 0
+        && let Some(pos) = result.rfind('/') {
             result = result[pos + 1..].to_owned();
         }
-    }
 
     // Dirname.
     if flags & MOD_DIRNAME != 0 {

--- a/crates/rmux-core/src/grid/render.rs
+++ b/crates/rmux-core/src/grid/render.rs
@@ -109,8 +109,8 @@ pub(super) fn append_grid_string_code(
         });
     }
 
-    if let Some(hyperlinks) = hyperlinks {
-        if lastgc.link() != gc.link() {
+    if let Some(hyperlinks) = hyperlinks
+        && lastgc.link() != gc.link() {
             if let Some(link) = hyperlinks.get(gc.link()) {
                 append_hyperlink(output, &link.internal_id, &link.uri, escape_sequences);
                 *has_link = true;
@@ -119,7 +119,6 @@ pub(super) fn append_grid_string_code(
                 *has_link = false;
             }
         }
-    }
 }
 
 fn append_colour_code(

--- a/crates/rmux-core/src/input/sgr.rs
+++ b/crates/rmux-core/src/input/sgr.rs
@@ -18,14 +18,13 @@ pub(crate) fn dispatch_sgr(parser: &mut InputParser) {
     let mut i: u32 = 0;
     while i < parser.param_list.len() {
         // Check for colon-separated ISO form (InputParam::Str).
-        if let Some(param) = parser.param_list.param_at(i) {
-            if let ParamType::Str(s) = &param.ptype {
+        if let Some(param) = parser.param_list.param_at(i)
+            && let ParamType::Str(s) = &param.ptype {
                 let s = s.clone();
                 dispatch_sgr_colon(&mut parser.cell.cell, &s);
                 i += 1;
                 continue;
             }
-        }
 
         let n = parser.param_list.get(i, 0, 0);
         if n == -1 {

--- a/crates/rmux-core/src/layout/resize.rs
+++ b/crates/rmux-core/src/layout/resize.rs
@@ -140,8 +140,8 @@ impl LayoutTree {
             let child_index = *cell_path.last()?;
             let parent_path = cell_path[..cell_path.len() - 1].to_vec();
             let parent = cell_at_path(&self.root, &parent_path)?;
-            if let LayoutKind::Split(parent_direction, children) = &parent.kind {
-                if *parent_direction == direction {
+            if let LayoutKind::Split(parent_direction, children) = &parent.kind
+                && *parent_direction == direction {
                     let handle_index = if child_index + 1 == children.len() {
                         child_index.checked_sub(1)
                     } else {
@@ -151,7 +151,6 @@ impl LayoutTree {
                         return Some((parent_path, handle_index));
                     }
                 }
-            }
 
             cell_path.pop();
         }

--- a/crates/rmux-core/src/options/access.rs
+++ b/crates/rmux-core/src/options/access.rs
@@ -372,11 +372,10 @@ impl OptionStore {
         query: &OptionQuery,
     ) -> Option<&'a OptionEntry> {
         for node in self.chain_for_context(context, query) {
-            if let Some(entry) = node.entry(query.canonical_name()) {
-                if query.index().is_none() || entry.value(query.index()).is_some() {
+            if let Some(entry) = node.entry(query.canonical_name())
+                && (query.index().is_none() || entry.value(query.index()).is_some()) {
                     return Some(entry);
                 }
-            }
         }
         None
     }
@@ -490,11 +489,10 @@ impl OptionStore {
             }
             ResolveContext::Session(session_name) => {
                 let mut chain = Vec::new();
-                if scope_allows_session(query) {
-                    if let Some(node) = self.sessions.get(*session_name) {
+                if scope_allows_session(query)
+                    && let Some(node) = self.sessions.get(*session_name) {
                         chain.push(node);
                     }
-                }
                 push_known_global_roots(&mut chain, self, query);
                 chain
             }
@@ -506,11 +504,10 @@ impl OptionStore {
                         chain.push(node);
                     }
                 }
-                if scope_allows_session(query) {
-                    if let Some(node) = self.sessions.get(*session_name) {
+                if scope_allows_session(query)
+                    && let Some(node) = self.sessions.get(*session_name) {
                         chain.push(node);
                     }
-                }
                 push_known_global_roots(&mut chain, self, query);
                 chain
             }
@@ -533,11 +530,10 @@ impl OptionStore {
                         chain.push(node);
                     }
                 }
-                if scope_allows_session(query) {
-                    if let Some(node) = self.sessions.get(*session_name) {
+                if scope_allows_session(query)
+                    && let Some(node) = self.sessions.get(*session_name) {
                         chain.push(node);
                     }
-                }
                 push_known_global_roots(&mut chain, self, query);
                 chain
             }
@@ -562,11 +558,10 @@ impl OptionStore {
         I: IntoIterator<Item = Option<&'a OptionNode>>,
     {
         for node in nodes.into_iter().flatten() {
-            if let Some(entry) = node.entry(query.canonical_name()) {
-                if let Some(value) = entry.value(query.index()) {
+            if let Some(entry) = node.entry(query.canonical_name())
+                && let Some(value) = entry.value(query.index()) {
                     return Some(value.to_owned());
                 }
-            }
         }
         None
     }

--- a/crates/rmux-core/src/options/mutation.rs
+++ b/crates/rmux-core/src/options/mutation.rs
@@ -43,15 +43,14 @@ fn validate_query_mutation(
     value: Option<&str>,
     unset: bool,
 ) -> Result<(), RmuxError> {
-    if let Some(metadata) = query.metadata() {
-        if !metadata.supports_scope(scope) {
+    if let Some(metadata) = query.metadata()
+        && !metadata.supports_scope(scope) {
             return Err(RmuxError::InvalidSetOption(format!(
                 "{} is only supported at {} scope",
                 query.canonical_name(),
                 allowed_scope_message(metadata),
             )));
         }
-    }
 
     if mode == SetOptionMode::Append
         && !query.is_array()

--- a/crates/rmux-core/src/screen.rs
+++ b/crates/rmux-core/src/screen.rs
@@ -378,13 +378,11 @@ impl Screen {
         };
 
         let current_is_padding = line.is_padding_cell(x);
-        if current_is_padding {
-            if let Some(owner_x) = line.owning_cell_x(x).filter(|owner_x| *owner_x != x) {
-                if let Some(owner) = line.cell_mut(owner_x) {
+        if current_is_padding
+            && let Some(owner_x) = line.owning_cell_x(x).filter(|owner_x| *owner_x != x)
+                && let Some(owner) = line.cell_mut(owner_x) {
                     *owner = blank.clone();
                 }
-            }
-        }
 
         let clear_following_padding = width != 1
             || line

--- a/crates/rmux-core/src/screen/writer.rs
+++ b/crates/rmux-core/src/screen/writer.rs
@@ -108,11 +108,10 @@ impl ScreenWriter for Screen {
 
     fn linefeed(&mut self, wrapped: bool, bg: i32) {
         self.pending_wrap = false;
-        if wrapped {
-            if let Some(line) = self.current_line_mut() {
+        if wrapped
+            && let Some(line) = self.current_line_mut() {
                 line.set_wrapped(true);
             }
-        }
 
         if self.cursor_y == self.rlower {
             self.grid

--- a/crates/rmux-core/src/session.rs
+++ b/crates/rmux-core/src/session.rs
@@ -466,11 +466,10 @@ impl Session {
     }
 
     fn next_active_window_after_removal(&self, removed_index: u32) -> u32 {
-        if let Some(last_window) = self.last_window {
-            if last_window != removed_index && self.windows.contains_key(&last_window) {
+        if let Some(last_window) = self.last_window
+            && last_window != removed_index && self.windows.contains_key(&last_window) {
                 return last_window;
             }
-        }
 
         if let Some((window_index, _)) = self.windows.range(..removed_index).next_back() {
             return *window_index;
@@ -530,11 +529,10 @@ fn synchronized_active_window(
         return previous_active;
     }
 
-    if let Some(last_window) = previous_last {
-        if last_window != previous_active && windows.contains_key(&last_window) {
+    if let Some(last_window) = previous_last
+        && last_window != previous_active && windows.contains_key(&last_window) {
             return last_window;
         }
-    }
 
     if let Some((window_index, _)) = windows.range(..previous_active).next_back() {
         return *window_index;

--- a/crates/rmux-core/src/session/store.rs
+++ b/crates/rmux-core/src/session/store.rs
@@ -509,12 +509,11 @@ impl SessionStore {
             .expect("prevalidated session must exist");
         let previous_group_name = session.group_name().cloned();
         session.rename(new_name.clone());
-        if let Some(group_name) = previous_group_name {
-            if self.group_runtime_owners.get(&group_name) == Some(session_name) {
+        if let Some(group_name) = previous_group_name
+            && self.group_runtime_owners.get(&group_name) == Some(session_name) {
                 self.group_runtime_owners
                     .insert(group_name, new_name.clone());
             }
-        }
         let replaced = sessions.insert(new_name, session);
         debug_assert!(replaced.is_none());
         self.sessions = sessions;

--- a/crates/rmux-core/src/session/window_ops.rs
+++ b/crates/rmux-core/src/session/window_ops.rs
@@ -487,11 +487,10 @@ impl Session {
         removed_index: u32,
         previous_last: Option<u32>,
     ) -> u32 {
-        if let Some(last_window) = previous_last {
-            if last_window != removed_index && self.windows.contains_key(&last_window) {
+        if let Some(last_window) = previous_last
+            && last_window != removed_index && self.windows.contains_key(&last_window) {
                 return last_window;
             }
-        }
 
         if let Some((window_index, _)) = self.windows.range(..removed_index).next_back() {
             return *window_index;

--- a/crates/rmux-core/src/target_find.rs
+++ b/crates/rmux-core/src/target_find.rs
@@ -284,8 +284,8 @@ impl SessionStore {
             }
         }
 
-        if !value.starts_with(['+', '-']) {
-            if let Ok(window_index) = value.parse::<u32>() {
+        if !value.starts_with(['+', '-'])
+            && let Ok(window_index) = value.parse::<u32>() {
                 if session.window_at(window_index).is_some() {
                     return self.parts_for_window(session_name, window_index);
                 }
@@ -293,7 +293,6 @@ impl SessionStore {
                     return Ok(ResolvedParts::window(session_name.clone(), window_index));
                 }
             }
-        }
 
         if let Some(window_index) = unique_window_name_match(session, value, MatchMode::Exact)? {
             return self.parts_for_window(session_name, window_index);
@@ -323,19 +322,16 @@ impl SessionStore {
         context: &TargetFindContext,
     ) -> Result<ResolvedParts, RmuxError> {
         let window_id = crate::WindowId::new(parse_required_prefixed_id(value, '@')?);
-        if let Ok(current) = self.current_parts(context) {
-            if let Some(window) = self
+        if let Ok(current) = self.current_parts(context)
+            && let Some(window) = self
                 .session(&current.session_name)
                 .and_then(|session| session.window_at(current.window_index))
-            {
-                if window.id() == window_id {
+                && window.id() == window_id {
                     return Ok(ResolvedParts::window(
                         current.session_name,
                         current.window_index,
                     ));
                 }
-            }
-        }
 
         let mut matches = self
             .iter()
@@ -504,15 +500,14 @@ impl SessionStore {
             ));
         }
 
-        if let Ok(pane_index) = value.parse::<u32>() {
-            if window.pane(pane_index).is_some() {
+        if let Ok(pane_index) = value.parse::<u32>()
+            && window.pane(pane_index).is_some() {
                 return Ok(ResolvedParts::pane(
                     session_name.clone(),
                     window_index,
                     pane_index,
                 ));
             }
-        }
 
         if let Some(pane_index) = pane_description(window, value) {
             return Ok(ResolvedParts::pane(
@@ -535,17 +530,14 @@ impl SessionStore {
         context: &TargetFindContext,
     ) -> Result<ResolvedParts, RmuxError> {
         let pane_id = crate::PaneId::new(parse_required_prefixed_id(value, '%')?);
-        if let Ok(current) = self.current_parts(context) {
-            if let Some(pane) = self
+        if let Ok(current) = self.current_parts(context)
+            && let Some(pane) = self
                 .session(&current.session_name)
                 .and_then(|session| session.window_at(current.window_index))
                 .and_then(|window| window.pane(current.pane_index))
-            {
-                if pane.id() == pane_id {
+                && pane.id() == pane_id {
                     return Ok(current);
                 }
-            }
-        }
 
         let mut matches = self
             .iter()

--- a/crates/rmux-core/src/target_find/session.rs
+++ b/crates/rmux-core/src/target_find/session.rs
@@ -20,11 +20,10 @@ impl SessionStore {
                 .ok_or_else(|| target_not_found(value, "session"));
         }
 
-        if let Ok(name) = SessionName::new(value.to_owned()) {
-            if let Some(session) = self.session(&name) {
+        if let Ok(name) = SessionName::new(value.to_owned())
+            && let Some(session) = self.session(&name) {
                 return Ok(session.name().clone());
             }
-        }
 
         if flags.contains(TargetFindFlags::EXACT_SESSION) {
             return Err(target_not_found(value, "session"));

--- a/crates/rmux-core/src/window/panes.rs
+++ b/crates/rmux-core/src/window/panes.rs
@@ -283,11 +283,9 @@ impl Window {
         if let Some(last_pane) = self
             .last_pane
             .filter(|last_pane| *last_pane != removed_pane_index)
-        {
-            if let Some(pane_id) = self.pane(last_pane).map(Pane::id) {
+            && let Some(pane_id) = self.pane(last_pane).map(Pane::id) {
                 return pane_id;
             }
-        }
 
         if position > 0 {
             return self.panes[position - 1].id();

--- a/crates/rmux-ipc/Cargo.toml
+++ b/crates/rmux-ipc/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rmux-ipc"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 publish = true
 license.workspace = true
 repository.workspace = true

--- a/crates/rmux-os/Cargo.toml
+++ b/crates/rmux-os/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rmux-os"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 publish = true
 license.workspace = true
 repository.workspace = true

--- a/crates/rmux-proto/Cargo.toml
+++ b/crates/rmux-proto/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rmux-proto"
 version = "0.2.5"
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "RMUX detached IPC protocol DTOs, framing, and wire-safe error types."

--- a/crates/rmux-pty/Cargo.toml
+++ b/crates/rmux-pty/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rmux-pty"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 publish = true
 license.workspace = true
 repository.workspace = true

--- a/crates/rmux-render-core/Cargo.toml
+++ b/crates/rmux-render-core/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rmux-render-core"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 publish = false
 license.workspace = true
 repository.workspace = true

--- a/crates/rmux-sdk/Cargo.toml
+++ b/crates/rmux-sdk/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rmux-sdk"
 version = "0.2.5"
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Public, daemon-backed Rust SDK for the RMUX terminal multiplexer (facade, ensure-session, snapshots, events, detach helpers)."

--- a/crates/rmux-sdk/src/discovery.rs
+++ b/crates/rmux-sdk/src/discovery.rs
@@ -307,48 +307,42 @@ fn merge_tags(pane: &[String], window: &[String], session: Option<&Vec<String>>)
 
 impl PaneFilters {
     fn matches(&self, pane: &DiscoveredPane) -> bool {
-        if let Some(title) = &self.title {
-            if pane.title.as_deref() != Some(title.as_str()) {
+        if let Some(title) = &self.title
+            && pane.title.as_deref() != Some(title.as_str()) {
                 return false;
             }
-        }
-        if let Some(prefix) = &self.title_prefix {
-            if !pane
+        if let Some(prefix) = &self.title_prefix
+            && !pane
                 .title
                 .as_deref()
                 .is_some_and(|title| title.starts_with(prefix))
             {
                 return false;
             }
-        }
-        if let Some(needle) = &self.command_contains {
-            if !pane
+        if let Some(needle) = &self.command_contains
+            && !pane
                 .command
                 .as_ref()
                 .is_some_and(|argv| argv.iter().any(|arg| arg.contains(needle)))
             {
                 return false;
             }
-        }
-        if let Some(needle) = &self.cwd_contains {
-            if !pane
+        if let Some(needle) = &self.cwd_contains
+            && !pane
                 .working_directory
                 .as_deref()
                 .is_some_and(|cwd| cwd.contains(needle))
             {
                 return false;
             }
-        }
-        if let Some(running) = self.running {
-            if !pane.process_matches(running) {
+        if let Some(running) = self.running
+            && !pane.process_matches(running) {
                 return false;
             }
-        }
-        if let Some(window_index) = self.window_index {
-            if pane.window_index != window_index {
+        if let Some(window_index) = self.window_index
+            && pane.window_index != window_index {
                 return false;
             }
-        }
         true
     }
 }

--- a/crates/rmux-sdk/src/handles/rmux.rs
+++ b/crates/rmux-sdk/src/handles/rmux.rs
@@ -274,11 +274,10 @@ impl Rmux {
             .await?;
         match response {
             Response::KillServer(_) => {
-                if let Err(error) = client.shutdown().await {
-                    if !is_clean_shutdown_close(&error) {
+                if let Err(error) = client.shutdown().await
+                    && !is_clean_shutdown_close(&error) {
                         return Err(error);
                     }
-                }
                 Ok(())
             }
             Response::Error(error) => Err(error.into()),

--- a/crates/rmux-sdk/src/input.rs
+++ b/crates/rmux-sdk/src/input.rs
@@ -412,8 +412,8 @@ impl DetachDetector {
     /// internally.
     #[must_use]
     pub fn feed(&mut self, event: KeyEvent, now: Instant) -> DetachOutcome {
-        if let DetectorState::PrefixHeld { since } = self.state {
-            if now.saturating_duration_since(since) >= self.timeout {
+        if let DetectorState::PrefixHeld { since } = self.state
+            && now.saturating_duration_since(since) >= self.timeout {
                 self.state = DetectorState::Idle;
                 let mut forwarded = vec![self.chord.prefix];
                 match self.process_idle(event, now) {
@@ -428,7 +428,6 @@ impl DetachDetector {
                 }
                 return DetachOutcome::Forward(forwarded);
             }
-        }
 
         match self.state {
             DetectorState::Idle => self.process_idle(event, now),

--- a/crates/rmux-sdk/src/transport/failure.rs
+++ b/crates/rmux-sdk/src/transport/failure.rs
@@ -79,11 +79,10 @@ impl TransportFailure {
         operation: &str,
         command_name: &'static str,
     ) -> RmuxError {
-        if command_name == "handshake" {
-            if let Some(error) = self.protocol_error.as_ref() {
+        if command_name == "handshake"
+            && let Some(error) = self.protocol_error.as_ref() {
                 return handshake_protocol_error(error);
             }
-        }
 
         self.to_error(operation)
     }

--- a/crates/rmux-sdk/src/transport/mod.rs
+++ b/crates/rmux-sdk/src/transport/mod.rs
@@ -172,11 +172,10 @@ impl DropGuard {
     }
 
     pub(crate) fn trigger(&mut self) {
-        if let DropAction::BestEffort { client, request } = &mut self.action {
-            if let Some(request) = request.take() {
+        if let DropAction::BestEffort { client, request } = &mut self.action
+            && let Some(request) = request.take() {
                 client.try_send_best_effort(*request);
             }
-        }
         self.action = DropAction::None;
     }
 }

--- a/crates/rmux-sdk/src/wait.rs
+++ b/crates/rmux-sdk/src/wait.rs
@@ -86,14 +86,12 @@ impl Future for ArmedWait {
             Poll::Pending => {}
         }
 
-        if let Some(duration) = self.timeout_duration {
-            if let Some(timeout) = self.timeout.as_mut() {
-                if timeout.as_mut().poll(cx).is_ready() {
+        if let Some(duration) = self.timeout_duration
+            && let Some(timeout) = self.timeout.as_mut()
+                && timeout.as_mut().poll(cx).is_ready() {
                     self.cancel_guard.trigger();
                     return Poll::Ready(Err(wait_timeout_error(self.operation, duration)));
                 }
-            }
-        }
 
         Poll::Pending
     }

--- a/crates/rmux-sdk/tests/discovery.rs
+++ b/crates/rmux-sdk/tests/discovery.rs
@@ -23,7 +23,8 @@ fn timeout_resolution_uses_per_operation_builder_env_then_default() {
     let _env = EnvGuard::remove(SDK_TIMEOUT_MS_ENV);
 
     assert_eq!(resolve_timeout(None, None), Some(V1_DEFAULT_TIMEOUT));
-    env::set_var(SDK_TIMEOUT_MS_ENV, "1500");
+    // TODO: Audit that the environment access only happens in single-threaded code.
+    unsafe { env::set_var(SDK_TIMEOUT_MS_ENV, "1500") };
     assert_eq!(
         resolve_timeout(None, None),
         Some(Duration::from_millis(1500))
@@ -126,7 +127,8 @@ fn unix_endpoint_precedence_uses_explicit_then_sdk_env_then_default() {
         .expect("owned socket root")
         .join("sdk-env.sock");
     let _listener = bind_unix_socket(&env_path);
-    env::set_var(SDK_ENDPOINT_ENV, &env_path);
+    // TODO: Audit that the environment access only happens in single-threaded code.
+    unsafe { env::set_var(SDK_ENDPOINT_ENV, &env_path) };
 
     assert_eq!(
         expect_unix_endpoint(RmuxBuilder::new().resolved_endpoint()),
@@ -175,7 +177,8 @@ fn unix_rmux_tmpdir_canonicalization_feeds_default_and_sdk_allowlist() {
     let owned_root = default_path.parent().expect("owned socket root");
     let env_path = owned_root.join("sdk-env.sock");
     let _listener = bind_unix_socket(&env_path);
-    env::set_var(SDK_ENDPOINT_ENV, &env_path);
+    // TODO: Audit that the environment access only happens in single-threaded code.
+    unsafe { env::set_var(SDK_ENDPOINT_ENV, &env_path) };
 
     assert_eq!(
         expect_unix_endpoint(RmuxBuilder::new().resolved_endpoint()),
@@ -192,7 +195,8 @@ fn unix_malformed_env_endpoint_falls_back_to_platform_default() {
     let _endpoint = EnvGuard::remove(SDK_ENDPOINT_ENV);
     let default_path = expect_unix_endpoint(RmuxBuilder::new().resolved_endpoint());
 
-    env::set_var(SDK_ENDPOINT_ENV, "relative.sock");
+    // TODO: Audit that the environment access only happens in single-threaded code.
+    unsafe { env::set_var(SDK_ENDPOINT_ENV, "relative.sock") };
 
     assert_eq!(
         expect_unix_endpoint(RmuxBuilder::new().resolved_endpoint()),
@@ -212,7 +216,8 @@ fn unix_env_endpoint_accepts_missing_target_inside_owned_root() {
     std::fs::create_dir_all(owned_root).expect("create owned root");
 
     let env_path = owned_root.join("not-yet-bound.sock");
-    env::set_var(SDK_ENDPOINT_ENV, &env_path);
+    // TODO: Audit that the environment access only happens in single-threaded code.
+    unsafe { env::set_var(SDK_ENDPOINT_ENV, &env_path) };
 
     assert_eq!(
         expect_unix_endpoint(RmuxBuilder::new().resolved_endpoint()),
@@ -231,7 +236,8 @@ fn unix_disallowed_env_endpoint_falls_back_to_platform_default() {
 
     let disallowed = root.path().join("not-rmux-owned").join("sdk.sock");
     let _listener = bind_unix_socket(&disallowed);
-    env::set_var(SDK_ENDPOINT_ENV, &disallowed);
+    // TODO: Audit that the environment access only happens in single-threaded code.
+    unsafe { env::set_var(SDK_ENDPOINT_ENV, &disallowed) };
 
     assert_eq!(
         expect_unix_endpoint(RmuxBuilder::new().resolved_endpoint()),
@@ -253,7 +259,8 @@ fn unix_env_endpoint_rejects_parent_escape_and_symlinked_parent() {
     let escaped_socket = root.path().join("escaped").join("sdk.sock");
     let _escaped_listener = bind_unix_socket(&escaped_socket);
     let traversal_path = owned_root.join("..").join("escaped").join("sdk.sock");
-    env::set_var(SDK_ENDPOINT_ENV, &traversal_path);
+    // TODO: Audit that the environment access only happens in single-threaded code.
+    unsafe { env::set_var(SDK_ENDPOINT_ENV, &traversal_path) };
     assert_eq!(
         expect_unix_endpoint(RmuxBuilder::new().resolved_endpoint()),
         default_path
@@ -266,7 +273,8 @@ fn unix_env_endpoint_rejects_parent_escape_and_symlinked_parent() {
     let linked_socket = symlink_target.join("sdk.sock");
     let _linked_listener = bind_unix_socket(&linked_socket);
 
-    env::set_var(SDK_ENDPOINT_ENV, symlinked_parent.join("sdk.sock"));
+    // TODO: Audit that the environment access only happens in single-threaded code.
+    unsafe { env::set_var(SDK_ENDPOINT_ENV, symlinked_parent.join("sdk.sock")) };
     assert_eq!(
         expect_unix_endpoint(RmuxBuilder::new().resolved_endpoint()),
         default_path
@@ -286,7 +294,8 @@ fn unix_env_endpoint_rejects_symlink_and_regular_file_targets() {
 
     let regular = owned_root.join("regular-file.sock");
     std::fs::write(&regular, b"not a socket").expect("write regular file");
-    env::set_var(SDK_ENDPOINT_ENV, &regular);
+    // TODO: Audit that the environment access only happens in single-threaded code.
+    unsafe { env::set_var(SDK_ENDPOINT_ENV, &regular) };
     assert_eq!(
         expect_unix_endpoint(RmuxBuilder::new().resolved_endpoint()),
         default_path
@@ -296,7 +305,8 @@ fn unix_env_endpoint_rejects_symlink_and_regular_file_targets() {
     let _listener = bind_unix_socket(&real_socket);
     let symlink = owned_root.join("link.sock");
     std::os::unix::fs::symlink(&real_socket, &symlink).expect("create socket symlink");
-    env::set_var(SDK_ENDPOINT_ENV, &symlink);
+    // TODO: Audit that the environment access only happens in single-threaded code.
+    unsafe { env::set_var(SDK_ENDPOINT_ENV, &symlink) };
 
     assert_eq!(
         expect_unix_endpoint(RmuxBuilder::new().resolved_endpoint()),
@@ -385,13 +395,15 @@ impl EnvGuard {
 
     fn set_os(key: &'static str, value: &OsStr) -> Self {
         let previous = env::var_os(key);
-        env::set_var(key, value);
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { env::set_var(key, value) };
         Self { key, previous }
     }
 
     fn remove(key: &'static str) -> Self {
         let previous = env::var_os(key);
-        env::remove_var(key);
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { env::remove_var(key) };
         Self { key, previous }
     }
 }
@@ -399,8 +411,10 @@ impl EnvGuard {
 impl Drop for EnvGuard {
     fn drop(&mut self) {
         match &self.previous {
-            Some(value) => env::set_var(self.key, value),
-            None => env::remove_var(self.key),
+            // TODO: Audit that the environment access only happens in single-threaded code.
+            Some(value) => unsafe { env::set_var(self.key, value) },
+            // TODO: Audit that the environment access only happens in single-threaded code.
+            None => unsafe { env::remove_var(self.key) },
         }
     }
 }

--- a/crates/rmux-sdk/tests/session.rs
+++ b/crates/rmux-sdk/tests/session.rs
@@ -655,7 +655,8 @@ impl EnvGuard {
 
     fn set_os(key: &'static str, value: &OsStr) -> Self {
         let previous = std::env::var_os(key);
-        std::env::set_var(key, value);
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::set_var(key, value) };
         Self { key, previous }
     }
 }
@@ -663,8 +664,10 @@ impl EnvGuard {
 impl Drop for EnvGuard {
     fn drop(&mut self) {
         match self.previous.as_ref() {
-            Some(value) => std::env::set_var(self.key, value),
-            None => std::env::remove_var(self.key),
+            // TODO: Audit that the environment access only happens in single-threaded code.
+            Some(value) => unsafe { std::env::set_var(self.key, value) },
+            // TODO: Audit that the environment access only happens in single-threaded code.
+            None => unsafe { std::env::remove_var(self.key) },
         }
     }
 }

--- a/crates/rmux-sdk/tests/smoke_v1.rs
+++ b/crates/rmux-sdk/tests/smoke_v1.rs
@@ -384,7 +384,8 @@ struct EnvGuard {
 impl EnvGuard {
     fn set(key: &'static str, value: &std::ffi::OsStr) -> Self {
         let previous = std::env::var_os(key);
-        std::env::set_var(key, value);
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::set_var(key, value) };
         Self { key, previous }
     }
 }
@@ -392,8 +393,10 @@ impl EnvGuard {
 impl Drop for EnvGuard {
     fn drop(&mut self) {
         match &self.previous {
-            Some(value) => std::env::set_var(self.key, value),
-            None => std::env::remove_var(self.key),
+            // TODO: Audit that the environment access only happens in single-threaded code.
+            Some(value) => unsafe { std::env::set_var(self.key, value) },
+            // TODO: Audit that the environment access only happens in single-threaded code.
+            None => unsafe { std::env::remove_var(self.key) },
         }
     }
 }

--- a/crates/rmux-sdk/tests/smoke_v1_full.rs
+++ b/crates/rmux-sdk/tests/smoke_v1_full.rs
@@ -973,7 +973,8 @@ struct EnvGuard {
 impl EnvGuard {
     fn set(key: &'static str, value: &std::ffi::OsStr) -> Self {
         let previous = std::env::var_os(key);
-        std::env::set_var(key, value);
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::set_var(key, value) };
         Self { key, previous }
     }
 }
@@ -981,8 +982,10 @@ impl EnvGuard {
 impl Drop for EnvGuard {
     fn drop(&mut self) {
         match &self.previous {
-            Some(value) => std::env::set_var(self.key, value),
-            None => std::env::remove_var(self.key),
+            // TODO: Audit that the environment access only happens in single-threaded code.
+            Some(value) => unsafe { std::env::set_var(self.key, value) },
+            // TODO: Audit that the environment access only happens in single-threaded code.
+            None => unsafe { std::env::remove_var(self.key) },
         }
     }
 }

--- a/crates/rmux-server/Cargo.toml
+++ b/crates/rmux-server/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rmux-server"
 version = "0.2.5"
 edition.workspace = true
+rust-version.workspace = true
 publish = true
 license.workspace = true
 repository.workspace = true

--- a/crates/rmux-server/src/control_notifications.rs
+++ b/crates/rmux-server/src/control_notifications.rs
@@ -297,14 +297,13 @@ fn event_window_id(state: &HandlerState, event: &LifecycleEvent) -> Option<u32> 
 }
 
 fn event_window_id_and_name(state: &HandlerState, event: &LifecycleEvent) -> Option<(u32, String)> {
-    if let Some(target) = event.window_target() {
-        if let Some(window) = resolve_window(state, &target) {
+    if let Some(target) = event.window_target()
+        && let Some(window) = resolve_window(state, &target) {
             return Some((
                 window.id().as_u32(),
                 window.name().unwrap_or_default().to_owned(),
             ));
         }
-    }
 
     Some((event.window_id()?, event.window_name_snapshot()?.to_owned()))
 }

--- a/crates/rmux-server/src/copy_mode/args.rs
+++ b/crates/rmux-server/src/copy_mode/args.rs
@@ -29,13 +29,12 @@ pub(super) fn parse_flagged_args(
             positional_mode = true;
             continue;
         }
-        if let Some(flag_cluster) = arg.strip_prefix('-') {
-            if !flag_cluster.is_empty() && flag_cluster.chars().all(|ch| allowed_flags.contains(ch))
+        if let Some(flag_cluster) = arg.strip_prefix('-')
+            && !flag_cluster.is_empty() && flag_cluster.chars().all(|ch| allowed_flags.contains(ch))
             {
                 flags.extend(flag_cluster.chars());
                 continue;
             }
-        }
         positionals.push(arg.clone());
     }
     Ok(ParsedFlaggedArgs { flags, positionals })

--- a/crates/rmux-server/src/copy_mode/search.rs
+++ b/crates/rmux-server/src/copy_mode/search.rs
@@ -122,15 +122,14 @@ impl CopyModeState {
         self.rebuild_search_results(plain_text);
         self.search_highlighted = true;
         self.search_current = self.find_search_match(direction);
-        if let Some(index) = self.search_current {
-            if let Some(result) = self.search_results.get(index) {
+        if let Some(index) = self.search_current
+            && let Some(result) = self.search_results.get(index) {
                 self.cursor = match self.mode_keys {
                     ModeKeys::Vi => result.start,
                     ModeKeys::Emacs => result.end,
                 };
                 self.ensure_cursor_visible();
             }
-        }
         Ok(())
     }
 
@@ -223,15 +222,14 @@ impl CopyModeState {
             }
         };
         self.search_current = next;
-        if let Some(index) = next {
-            if let Some(result) = self.search_results.get(index) {
+        if let Some(index) = next
+            && let Some(result) = self.search_results.get(index) {
                 self.cursor = match self.mode_keys {
                     ModeKeys::Vi => result.start,
                     ModeKeys::Emacs => result.end,
                 };
                 self.ensure_cursor_visible();
             }
-        }
         self.search_highlighted = true;
     }
 

--- a/crates/rmux-server/src/copy_mode/selection.rs
+++ b/crates/rmux-server/src/copy_mode/selection.rs
@@ -138,11 +138,10 @@ impl CopyModeState {
     }
 
     pub(super) fn sync_selection_with_cursor(&mut self) {
-        if let Some(selection) = &mut self.selection {
-            if selection.active {
+        if let Some(selection) = &mut self.selection
+            && selection.active {
                 selection.end = self.cursor;
             }
-        }
     }
 
     pub(super) fn word_selection_range(&self, position: CopyPosition) -> CopyRange {

--- a/crates/rmux-server/src/format_runtime/path.rs
+++ b/crates/rmux-server/src/format_runtime/path.rs
@@ -38,15 +38,14 @@ fn percent_decode(value: &str) -> String {
     let mut index = 0;
 
     while index < bytes.len() {
-        if bytes[index] == b'%' && index + 2 < bytes.len() {
-            if let (Some(high), Some(low)) =
+        if bytes[index] == b'%' && index + 2 < bytes.len()
+            && let (Some(high), Some(low)) =
                 (hex_value(bytes[index + 1]), hex_value(bytes[index + 2]))
             {
                 decoded.push((high << 4) | low);
                 index += 3;
                 continue;
             }
-        }
 
         decoded.push(bytes[index]);
         index += 1;

--- a/crates/rmux-server/src/handler_alerts/automatic_names.rs
+++ b/crates/rmux-server/src/handler_alerts/automatic_names.rs
@@ -58,7 +58,8 @@ impl RequestHandler {
             return Vec::new();
         };
 
-        let sessions_to_refresh = {
+        
+        {
             let mut state = self.state.lock().await;
             let tracked =
                 state.tracks_auto_named_window(target.session_name(), target.window_index());
@@ -94,7 +95,6 @@ impl RequestHandler {
                     .synchronize_session_group_from(target.session_name())
                     .unwrap_or_else(|_| vec![target.session_name().clone()])
             }
-        };
-        sessions_to_refresh
+        }
     }
 }

--- a/crates/rmux-server/src/handler_attach.rs
+++ b/crates/rmux-server/src/handler_attach.rs
@@ -466,11 +466,10 @@ impl RequestHandler {
 }
 
 fn terminate_overlay_job(overlay: Option<super::overlay_support::ClientOverlayState>) {
-    if let Some(super::overlay_support::ClientOverlayState::Popup(popup)) = overlay {
-        if let Some(job) = popup.job {
+    if let Some(super::overlay_support::ClientOverlayState::Popup(popup)) = overlay
+        && let Some(job) = popup.job {
             job.terminate();
         }
-    }
 }
 
 pub(super) fn attach_target_for_session(
@@ -544,8 +543,8 @@ fn attach_target_for_session_with_prompt(
                 renderer::render_pane_screen(session, &state.options, pane, &screen).as_slice(),
             );
         }
-        if pane.index() == session.active_pane_index() && copy_screen.is_some() {
-            if let (Some(summary), Some(stats)) = (
+        if pane.index() == session.active_pane_index() && copy_screen.is_some()
+            && let (Some(summary), Some(stats)) = (
                 state.pane_copy_mode_summary(session_name, pane.id()),
                 state.pane_history_stats(session_name, pane.id()),
             ) {
@@ -561,12 +560,11 @@ fn attach_target_for_session_with_prompt(
                     .as_slice(),
                 );
             }
-        }
     }
     let live_pane =
         live_pane_render_for_target(state, session, &state.options, session_name, prompt);
-    if prompt.is_none() {
-        if let Some(active_pane) = active_pane.clone() {
+    if prompt.is_none()
+        && let Some(active_pane) = active_pane.clone() {
             let active_screen = state
                 .pane_copy_mode_render_screen(session_name, active_pane.id())
                 .or_else(|| state.pane_render_screen(session_name, active_pane.id()));
@@ -577,7 +575,6 @@ fn attach_target_for_session_with_prompt(
                 );
             }
         }
-    }
 
     let active_pane_geometry = active_pane.as_ref().map_or_else(
         || rmux_core::PaneGeometry::new(0, 0, 0, 0),

--- a/crates/rmux-server/src/handler_buffer.rs
+++ b/crates/rmux-server/src/handler_buffer.rs
@@ -338,14 +338,13 @@ impl RequestHandler {
         mut content: Vec<u8>,
     ) -> Result<Vec<u8>, RmuxError> {
         let state = self.state.lock().await;
-        if let Some(name) = name {
-            if let Some(existing) = state.buffers.get(name) {
+        if let Some(name) = name
+            && let Some(existing) = state.buffers.get(name) {
                 let mut combined = Vec::with_capacity(existing.len() + content.len());
                 combined.extend_from_slice(existing);
                 combined.append(&mut content);
                 return Ok(combined);
             }
-        }
         Ok(content)
     }
 

--- a/crates/rmux-server/src/handler_client.rs
+++ b/crates/rmux-server/src/handler_client.rs
@@ -92,11 +92,10 @@ impl RequestHandler {
         }
 
         let active_control = self.active_control.lock().await;
-        if let Ok(pid) = target_client.parse::<u32>() {
-            if active_control.by_pid.contains_key(&pid) {
+        if let Ok(pid) = target_client.parse::<u32>()
+            && active_control.by_pid.contains_key(&pid) {
                 return Ok(ManagedClient::Control(pid));
             }
-        }
 
         Err(RmuxError::Server(format!(
             "can't find client: {target_client}"

--- a/crates/rmux-server/src/handler_client/attach.rs
+++ b/crates/rmux-server/src/handler_client/attach.rs
@@ -80,14 +80,13 @@ impl RequestHandler {
             Ok(flags) => flags,
             Err(error) => return HandleOutcome::response(Response::Error(ErrorResponse { error })),
         };
-        if let Some(template) = request.working_directory.as_deref() {
-            if let Err(error) = self
+        if let Some(template) = request.working_directory.as_deref()
+            && let Err(error) = self
                 .update_session_cwd_from_template(&session_name, template)
                 .await
             {
                 return HandleOutcome::response(Response::Error(ErrorResponse { error }));
             }
-        }
         let client_environment = client_environment_snapshot(requester_pid);
         let client_terminal = effective_client_terminal_context(
             client_environment.as_ref(),
@@ -95,12 +94,11 @@ impl RequestHandler {
         );
         let terminal_context = OuterTerminalContext::from_environment(client_environment.as_ref())
             .with_client_terminal(&client_terminal);
-        if let Some(client_environment) = client_environment.as_ref() {
-            if !request.skip_environment_update {
+        if let Some(client_environment) = client_environment.as_ref()
+            && !request.skip_environment_update {
                 let mut state = self.state.lock().await;
                 update_environment_from_client(&mut state, &session_name, client_environment);
             }
-        }
         if request.detach_other_clients || request.kill_other_clients {
             self.detach_other_attach_clients_for_session(
                 &session_name,

--- a/crates/rmux-server/src/handler_client/switching.rs
+++ b/crates/rmux-server/src/handler_client/switching.rs
@@ -253,12 +253,11 @@ impl RequestHandler {
         session_name: rmux_proto::SessionName,
         skip_environment_update: bool,
     ) -> Response {
-        if !skip_environment_update {
-            if let Some(client_environment) = client_environment_snapshot(requester_pid) {
+        if !skip_environment_update
+            && let Some(client_environment) = client_environment_snapshot(requester_pid) {
                 let mut state = self.state.lock().await;
                 update_environment_from_client(&mut state, &session_name, &client_environment);
             }
-        }
         let attached_count = self
             .attached_count_after_switch(&session_name, client)
             .await;

--- a/crates/rmux-server/src/handler_clock_mode.rs
+++ b/crates/rmux-server/src/handler_clock_mode.rs
@@ -64,11 +64,11 @@ impl RequestHandler {
         let cleared = {
             let state = self.state.lock().await;
             let transcript = state.transcript_handle(target)?;
-            let cleared = transcript
+            
+            transcript
                 .lock()
                 .expect("pane transcript mutex must not be poisoned")
-                .clear_clock_mode();
-            cleared
+                .clear_clock_mode()
         };
         if !cleared {
             return Ok(false);
@@ -138,12 +138,12 @@ impl RequestHandler {
                     let Ok(transcript) = state.transcript_handle(&target) else {
                         return;
                     };
-                    let active = transcript
+                    
+                    transcript
                         .lock()
                         .expect("pane transcript mutex must not be poisoned")
                         .clock_mode_generation()
-                        == Some(generation);
-                    active
+                        == Some(generation)
                 };
                 if !active {
                     return;

--- a/crates/rmux-server/src/handler_config.rs
+++ b/crates/rmux-server/src/handler_config.rs
@@ -152,8 +152,8 @@ impl RequestHandler {
                 {
                     return Response::Error(ErrorResponse { error });
                 }
-            } else if let Some(command) = request.command.clone() {
-                if let Err(error) = state.hooks.set_with_options(
+            } else if let Some(command) = request.command.clone()
+                && let Err(error) = state.hooks.set_with_options(
                     request.scope.clone(),
                     request.hook,
                     command,
@@ -165,7 +165,6 @@ impl RequestHandler {
                 ) {
                     return Response::Error(ErrorResponse { error });
                 }
-            }
         }
 
         Response::SetHook(SetHookResponse {

--- a/crates/rmux-server/src/handler_control.rs
+++ b/crates/rmux-server/src/handler_control.rs
@@ -277,11 +277,9 @@ impl RequestHandler {
         let previous = active.session_name.clone();
         if let (Some(previous_session), Some(next_session)) =
             (previous.as_ref(), next_session_name.as_ref())
-        {
-            if previous_session != next_session {
+            && previous_session != next_session {
                 active.last_session = Some(previous_session.clone());
             }
-        }
         active.session_name = next_session_name.clone();
         if active
             .event_tx

--- a/crates/rmux-server/src/handler_lifecycle.rs
+++ b/crates/rmux-server/src/handler_lifecycle.rs
@@ -383,13 +383,12 @@ pub(in crate::handler) fn after_hook_format_values(
 
         if flags.len() == 1 {
             let flag = flags.chars().next().expect("single-char flag");
-            if let Some(value) = scalar_arguments.get(index + 1).copied() {
-                if !value.starts_with('-') {
+            if let Some(value) = scalar_arguments.get(index + 1).copied()
+                && !value.starts_with('-') {
                     flag_values.entry(flag).or_default().push(value.to_owned());
                     index += 2;
                     continue;
                 }
-            }
         }
 
         for flag in flags.chars() {
@@ -433,8 +432,8 @@ fn lifecycle_hook_formats(
     }
     if let Some(window_target) = event.window_target() {
         let mut resolved_window = false;
-        if let Some(session) = state.sessions.session(window_target.session_name()) {
-            if let Some(window) = session.window_at(window_target.window_index()) {
+        if let Some(session) = state.sessions.session(window_target.session_name())
+            && let Some(window) = session.window_at(window_target.window_index()) {
                 formats.push(("hook_window".to_owned(), window.id().to_string()));
                 formats.push((
                     "hook_window_name".to_owned(),
@@ -442,31 +441,26 @@ fn lifecycle_hook_formats(
                 ));
                 resolved_window = true;
             }
-        }
-        if !resolved_window {
-            if let Some(window_id) = event.window_id() {
+        if !resolved_window
+            && let Some(window_id) = event.window_id() {
                 formats.push(("hook_window".to_owned(), format!("@{window_id}")));
                 if let Some(window_name) = event.window_name_snapshot() {
                     formats.push(("hook_window_name".to_owned(), window_name.to_owned()));
                 }
             }
-        }
     }
     if let Some(pane_target) = event.pane_target() {
         let mut resolved_pane = false;
-        if let Some(session) = state.sessions.session(pane_target.session_name()) {
-            if let Some(window) = session.window_at(pane_target.window_index()) {
-                if let Some(pane) = window.pane(pane_target.pane_index()) {
+        if let Some(session) = state.sessions.session(pane_target.session_name())
+            && let Some(window) = session.window_at(pane_target.window_index())
+                && let Some(pane) = window.pane(pane_target.pane_index()) {
                     formats.push(("hook_pane".to_owned(), format!("%{}", pane.id().as_u32())));
                     resolved_pane = true;
                 }
-            }
-        }
-        if !resolved_pane {
-            if let Some(pane_id) = event.pane_id() {
+        if !resolved_pane
+            && let Some(pane_id) = event.pane_id() {
                 formats.push(("hook_pane".to_owned(), format!("%{pane_id}")));
             }
-        }
     }
     formats
 }

--- a/crates/rmux-server/src/handler_mode_tree/filter.rs
+++ b/crates/rmux-server/src/handler_mode_tree/filter.rs
@@ -9,11 +9,10 @@ pub(super) fn matches_mode_tree_filter(
     search_text: &str,
     format_filter: Option<&str>,
 ) -> bool {
-    if let Some(filter) = format_filter {
-        if !is_truthy(filter) {
+    if let Some(filter) = format_filter
+        && !is_truthy(filter) {
             return false;
         }
-    }
     let Some(filter) = mode.filter_text.as_deref() else {
         return true;
     };

--- a/crates/rmux-server/src/handler_mode_tree/order.rs
+++ b/crates/rmux-server/src/handler_mode_tree/order.rs
@@ -62,12 +62,11 @@ pub(super) fn visible_tree_order(
     expanded: &BTreeSet<String>,
 ) -> Vec<String> {
     let mut order = vec![id.to_owned()];
-    if let Some(item) = items.get(id) {
-        if !item.children.is_empty() && expanded.contains(id) {
+    if let Some(item) = items.get(id)
+        && !item.children.is_empty() && expanded.contains(id) {
             for child in &item.children {
                 order.extend(visible_tree_order(items, child, expanded));
             }
         }
-    }
     order
 }

--- a/crates/rmux-server/src/handler_mode_tree/runtime.rs
+++ b/crates/rmux-server/src/handler_mode_tree/runtime.rs
@@ -89,14 +89,13 @@ impl RequestHandler {
 
         self.activate_mode_tree_for_session(&session_name, &mode)
             .await?;
-        if let Some(target) = mode.host_pane.as_ref() {
-            if self.enter_mode_tree_for_target(target, mode.kind).await? {
+        if let Some(target) = mode.host_pane.as_ref()
+            && self.enter_mode_tree_for_target(target, mode.kind).await? {
                 self.emit(LifecycleEvent::PaneModeChanged {
                     target: target.clone(),
                 })
                 .await;
             }
-        }
         self.refresh_attached_session(&session_name).await;
 
         Ok(QueueCommandAction::Normal {
@@ -310,8 +309,8 @@ impl RequestHandler {
         let Some(mode) = removed else {
             return Ok(Vec::new());
         };
-        if let Some(target) = mode.host_pane.as_ref() {
-            if self.clear_mode_tree_for_target(target).await? {
+        if let Some(target) = mode.host_pane.as_ref()
+            && self.clear_mode_tree_for_target(target).await? {
                 self.sync_automatic_window_name_for_pane_target(target)
                     .await;
                 self.emit_without_attached_refresh(LifecycleEvent::PaneModeChanged {
@@ -319,7 +318,6 @@ impl RequestHandler {
                 })
                 .await;
             }
-        }
 
         let mut refresh = vec![mode.session_name.clone()];
         if let Some(target) = mode.zoom_restore {

--- a/crates/rmux-server/src/handler_mode_tree/selection.rs
+++ b/crates/rmux-server/src/handler_mode_tree/selection.rs
@@ -11,11 +11,10 @@ pub(super) fn selected_items<'a>(
         .values()
         .filter(|item| mode.tagged.contains(&item.id))
         .collect::<Vec<_>>();
-    if tagged.is_empty() {
-        if let Some(selected) = mode.selected_id.as_ref().and_then(|id| build.items.get(id)) {
+    if tagged.is_empty()
+        && let Some(selected) = mode.selected_id.as_ref().and_then(|id| build.items.get(id)) {
             tagged.push(selected);
         }
-    }
     tagged
 }
 
@@ -337,11 +336,9 @@ pub(super) fn clamp_scroll(mode: &mut ModeTreeClientState, build: &ModeTreeBuild
         .selected_id
         .as_ref()
         .and_then(|id| build.visible.iter().position(|visible| visible == id))
-    {
-        if selected < mode.scroll {
+        && selected < mode.scroll {
             mode.scroll = selected;
         }
-    }
 }
 
 pub(super) fn normalize_selection(mode: &mut ModeTreeClientState, build: &ModeTreeBuild) {

--- a/crates/rmux-server/src/handler_overlay/interactions.rs
+++ b/crates/rmux-server/src/handler_overlay/interactions.rs
@@ -340,13 +340,11 @@ impl RequestHandler {
                         }
                     })
                 };
-                if let Some(popup) = popup {
-                    if let Some(job) = &popup.job {
-                        if let Some(bytes) = encode_mouse_event(mode, &event, x, y) {
+                if let Some(popup) = popup
+                    && let Some(job) = &popup.job
+                        && let Some(bytes) = encode_mouse_event(mode, &event, x, y) {
                             let _ = job.write(&bytes);
                         }
-                    }
-                }
             }
             PopupMouseOutcome::OpenMenu { x, y } => {
                 self.open_popup_internal_menu(attach_pid, x, y)

--- a/crates/rmux-server/src/handler_overlay/target.rs
+++ b/crates/rmux-server/src/handler_overlay/target.rs
@@ -89,13 +89,12 @@ impl RequestHandler {
         match event.location {
             MouseLocation::StatusLeft => Ok(Some(Target::Session(attached_session))),
             MouseLocation::Status | MouseLocation::StatusDefault | MouseLocation::StatusRight => {
-                if let Some(window_id) = event.window_id {
-                    if let Some(target) =
+                if let Some(window_id) = event.window_id
+                    && let Some(target) =
                         find_window_target_by_id(&state, &attached_session, window_id)
                     {
                         return Ok(Some(Target::Window(target)));
                     }
-                }
                 if let Some(session_name) = find_session_name_by_id(&state, event.session_id) {
                     return Ok(Some(Target::Session(session_name)));
                 }

--- a/crates/rmux-server/src/handler_pane/attached_key_dispatch.rs
+++ b/crates/rmux-server/src/handler_pane/attached_key_dispatch.rs
@@ -273,8 +273,8 @@ impl RequestHandler {
             self.schedule_attached_repeat_timeout(attach_pid, repeat_deadline);
         }
 
-        if from_prefix_table {
-            if let Some(action) = step03_prefix_binding(lookup_key) {
+        if from_prefix_table
+            && let Some(action) = step03_prefix_binding(lookup_key) {
                 if let Err(error) = self.dispatch_step03_prefix_action(action, target).await {
                     if attached_live_input {
                         self.report_attached_command_error(&session_name, attach_pid, &error)
@@ -285,7 +285,6 @@ impl RequestHandler {
                 }
                 return Ok(true);
             }
-        }
 
         if let Some(command) = direct_copy_mode_command(binding.commands()) {
             Box::pin(self.execute_copy_mode_command(

--- a/crates/rmux-server/src/handler_pane/attached_key_dispatch/commands.rs
+++ b/crates/rmux-server/src/handler_pane/attached_key_dispatch/commands.rs
@@ -50,8 +50,8 @@ pub(super) async fn execute_attached_binding_commands(
         .await
     {
         Ok(output) => {
-            if attached_live_input && parsed_commands_open_attached_output(&commands) {
-                if let Err(error) = handler
+            if attached_live_input && parsed_commands_open_attached_output(&commands)
+                && let Err(error) = handler
                     .show_attached_command_output_popup(
                         attach_pid,
                         requester_pid,
@@ -65,7 +65,6 @@ pub(super) async fn execute_attached_binding_commands(
                         .report_attached_command_error(&session_name, attach_pid, &error)
                         .await;
                 }
-            }
         }
         Err(error) => {
             if attached_live_input {

--- a/crates/rmux-server/src/handler_pane/by_id.rs
+++ b/crates/rmux-server/src/handler_pane/by_id.rs
@@ -184,14 +184,13 @@ impl RequestHandler {
                 let _ = self.queue_shutdown_if_server_empty().await;
             } else {
                 self.sync_session_silence_timers(&session_name).await;
-                if let Response::KillPane(success) = &response {
-                    if !success.window_destroyed {
+                if let Response::KillPane(success) = &response
+                    && !success.window_destroyed {
                         self.emit(LifecycleEvent::WindowLayoutChanged {
                             target: WindowTarget::with_window(session_name.clone(), layout_window),
                         })
                         .await;
                     }
-                }
                 self.dismiss_mode_tree_for_session(&session_name).await;
                 self.refresh_attached_session(&session_name).await;
             }
@@ -212,8 +211,8 @@ impl RequestHandler {
                 Ok(target) => target,
                 Err(error) => return Response::Error(ErrorResponse { error }),
             };
-            if let Some(keep_alive) = request.keep_alive_on_exit {
-                if let Err(error) = state.options.set(
+            if let Some(keep_alive) = request.keep_alive_on_exit
+                && let Err(error) = state.options.set(
                     ScopeSelector::Pane(target.clone()),
                     OptionName::RemainOnExit,
                     if keep_alive { "on" } else { "off" }.to_owned(),
@@ -221,7 +220,6 @@ impl RequestHandler {
                 ) {
                     return Response::Error(ErrorResponse { error });
                 }
-            }
             let request = rmux_proto::RespawnPaneRequest {
                 target,
                 kill: request.kill,

--- a/crates/rmux-server/src/handler_pane/inspection.rs
+++ b/crates/rmux-server/src/handler_pane/inspection.rs
@@ -192,8 +192,8 @@ impl RequestHandler {
                 error: session_not_found(&request.target),
             });
         };
-        if let Some(window_index) = request.target_window_index {
-            if session.window_at(window_index).is_none() {
+        if let Some(window_index) = request.target_window_index
+            && session.window_at(window_index).is_none() {
                 return Response::Error(ErrorResponse {
                     error: RmuxError::invalid_target(
                         format!("{}:{window_index}", request.target),
@@ -201,7 +201,6 @@ impl RequestHandler {
                     ),
                 });
             }
-        }
 
         Response::ListPanes(ListPanesResponse {
             output: command_output_from_lines(&collect_list_pane_lines(

--- a/crates/rmux-server/src/handler_pane/lifecycle.rs
+++ b/crates/rmux-server/src/handler_pane/lifecycle.rs
@@ -391,8 +391,8 @@ impl RequestHandler {
         }
 
         let mut state = self.state.lock().await;
-        if retry_strip {
-            if let Err(error) =
+        if retry_strip
+            && let Err(error) =
                 state.strip_attached_submitted_line(&event.session_name, event.pane_id)
             {
                 warn!(
@@ -401,7 +401,6 @@ impl RequestHandler {
                     "failed to retry attached submitted line strip for dead pane: {error}"
                 );
             }
-        }
         if let Err(error) = append_remain_on_exit_message(&mut state, &event.session_name, target) {
             warn!(
                 session = %event.session_name,

--- a/crates/rmux-server/src/handler_pane/management.rs
+++ b/crates/rmux-server/src/handler_pane/management.rs
@@ -455,8 +455,8 @@ impl RequestHandler {
                 let _ = self.queue_shutdown_if_server_empty().await;
             } else {
                 self.sync_session_silence_timers(&session_name).await;
-                if let Response::KillPane(success) = &response {
-                    if !success.window_destroyed {
+                if let Response::KillPane(success) = &response
+                    && !success.window_destroyed {
                         self.emit(LifecycleEvent::WindowLayoutChanged {
                             target: WindowTarget::with_window(
                                 session_name.clone(),
@@ -465,7 +465,6 @@ impl RequestHandler {
                         })
                         .await;
                     }
-                }
                 self.dismiss_mode_tree_for_session(&session_name).await;
                 self.refresh_attached_session(&session_name).await;
             }

--- a/crates/rmux-server/src/handler_scripting.rs
+++ b/crates/rmux-server/src/handler_scripting.rs
@@ -496,8 +496,8 @@ impl RequestHandler {
         request: Request,
         outcome: crate::pane_io::HandleOutcome,
     ) -> Result<QueueCommandAction, RmuxError> {
-        if let Some(_attach) = outcome.attach {
-            if matches!(
+        if let Some(_attach) = outcome.attach
+            && matches!(
                 request,
                 Request::AttachSession(_) | Request::AttachSessionExt(_)
             ) {
@@ -518,7 +518,6 @@ impl RequestHandler {
                 self.emit_client_attached(requester_pid, response.session_name.clone())
                     .await;
             }
-        }
 
         queue_action_from_response(outcome.response)
     }

--- a/crates/rmux-server/src/handler_scripting/source_runtime.rs
+++ b/crates/rmux-server/src/handler_scripting/source_runtime.rs
@@ -100,11 +100,10 @@ impl RequestHandler {
         {
             errors.push(error);
         }
-        if queue_errors {
-            if let Some(error) = super::aggregate_rmux_errors(errors) {
+        if queue_errors
+            && let Some(error) = super::aggregate_rmux_errors(errors) {
                 self.startup_config_errors.lock().await.push(error);
             }
-        }
         self.config_loading_depth.fetch_sub(1, Ordering::Relaxed);
     }
 

--- a/crates/rmux-server/src/handler_scripting/targets.rs
+++ b/crates/rmux-server/src/handler_scripting/targets.rs
@@ -351,11 +351,10 @@ pub(super) fn parse_new_window_target_argument(
     sessions: &SessionStore,
     find_context: &TargetFindContext,
 ) -> Result<(SessionName, Option<u32>), RmuxError> {
-    if let Some((session_name, window_part)) = value.split_once(':') {
-        if window_part.is_empty() {
+    if let Some((session_name, window_part)) = value.split_once(':')
+        && window_part.is_empty() {
             return Ok((parse_session_name(session_name.to_owned())?, None));
         }
-    }
 
     if new_window_target_is_session(&value) {
         let resolved = resolve_target_argument_with_spec(

--- a/crates/rmux-server/src/handler_server_access.rs
+++ b/crates/rmux-server/src/handler_server_access.rs
@@ -85,21 +85,18 @@ impl RequestHandler {
             let should_add = request.add
                 || ((request.read_only || request.write)
                     && !server_access.contains_uid(resolved.uid));
-            if should_add {
-                if let Err(error) = server_access.set_mode(resolved.uid, AccessMode::ReadWrite) {
+            if should_add
+                && let Err(error) = server_access.set_mode(resolved.uid, AccessMode::ReadWrite) {
                     return Response::Error(ErrorResponse { error });
                 }
-            }
-            if request.write {
-                if let Err(error) = server_access.set_mode(resolved.uid, AccessMode::ReadWrite) {
+            if request.write
+                && let Err(error) = server_access.set_mode(resolved.uid, AccessMode::ReadWrite) {
                     return Response::Error(ErrorResponse { error });
                 }
-            }
-            if request.read_only {
-                if let Err(error) = server_access.set_mode(resolved.uid, AccessMode::ReadOnly) {
+            if request.read_only
+                && let Err(error) = server_access.set_mode(resolved.uid, AccessMode::ReadOnly) {
                     return Response::Error(ErrorResponse { error });
                 }
-            }
         }
 
         if request.write {

--- a/crates/rmux-server/src/handler_session.rs
+++ b/crates/rmux-server/src/handler_session.rs
@@ -69,8 +69,8 @@ impl RequestHandler {
             });
         }
 
-        if request.attach_if_exists && request.group_target.is_none() {
-            if let Some(existing) = request.session_name.as_ref() {
+        if request.attach_if_exists && request.group_target.is_none()
+            && let Some(existing) = request.session_name.as_ref() {
                 let session_exists = {
                     let state = self.state.lock().await;
                     state.sessions.contains_session(existing)
@@ -102,7 +102,6 @@ impl RequestHandler {
                     });
                 }
             }
-        }
 
         let size = request.size.unwrap_or(DEFAULT_SESSION_SIZE);
         let detached = request.detached;

--- a/crates/rmux-server/src/handler_subscriptions.rs
+++ b/crates/rmux-server/src/handler_subscriptions.rs
@@ -221,11 +221,10 @@ impl RequestHandler {
         match live_result {
             Ok(source) => Ok(source),
             Err(live_error) => {
-                if start == PaneOutputSubscriptionStart::Oldest {
-                    if let Some((target, retained)) = retained_lookup(self, target_ref, now)? {
+                if start == PaneOutputSubscriptionStart::Oldest
+                    && let Some((target, retained)) = retained_lookup(self, target_ref, now)? {
                         return Ok((target, retained.pane().clone(), retained.output().clone()));
                     }
-                }
                 Err(live_error)
             }
         }

--- a/crates/rmux-server/src/key_table.rs
+++ b/crates/rmux-server/src/key_table.rs
@@ -182,14 +182,13 @@ fn decode_escape_key(input: &[u8], backspace: Option<u8>) -> AttachedKeyDecode {
     }
 
     if input.len() < 3 {
-        if let Some(&byte) = input.get(1) {
-            if byte.is_ascii() && !byte.is_ascii_control() {
+        if let Some(&byte) = input.get(1)
+            && byte.is_ascii() && !byte.is_ascii_control() {
                 return AttachedKeyDecode::Matched {
                     size: 2,
                     key: u64::from(byte) | rmux_core::KEYC_META | rmux_core::KEYC_IMPLIED_META,
                 };
             }
-        }
         return AttachedKeyDecode::Partial;
     }
     let key = match &input[..3] {
@@ -204,14 +203,13 @@ fn decode_escape_key(input: &[u8], backspace: Option<u8>) -> AttachedKeyDecode {
         return AttachedKeyDecode::Matched { size: 3, key };
     }
 
-    if let Some(&byte) = input.get(1) {
-        if byte.is_ascii() && !byte.is_ascii_control() {
+    if let Some(&byte) = input.get(1)
+        && byte.is_ascii() && !byte.is_ascii_control() {
             return AttachedKeyDecode::Matched {
                 size: 2,
                 key: u64::from(byte) | rmux_core::KEYC_META | rmux_core::KEYC_IMPLIED_META,
             };
         }
-    }
 
     AttachedKeyDecode::Invalid
 }

--- a/crates/rmux-server/src/lib.rs
+++ b/crates/rmux-server/src/lib.rs
@@ -1,4 +1,4 @@
-#![forbid(unsafe_code)]
+#![deny(unsafe_code)]
 #![deny(missing_docs)]
 
 //! Tokio-based detached RPC server for RMUX.
@@ -96,6 +96,7 @@ mod status_ranges;
 #[cfg_attr(windows, allow(dead_code))]
 mod terminal;
 #[cfg(test)]
+#[allow(unsafe_code)]
 mod test_env;
 #[cfg(test)]
 mod test_shell;

--- a/crates/rmux-server/src/mouse.rs
+++ b/crates/rmux-server/src/mouse.rs
@@ -541,11 +541,10 @@ fn parse_scrollbar_style(value: Option<&str>) -> (u16, u16) {
             if let Ok(parsed) = parsed.parse::<u16>() {
                 width = parsed;
             }
-        } else if let Some(parsed) = token.strip_prefix("pad=") {
-            if let Ok(parsed) = parsed.parse::<u16>() {
+        } else if let Some(parsed) = token.strip_prefix("pad=")
+            && let Ok(parsed) = parsed.parse::<u16>() {
                 pad = parsed;
             }
-        }
     }
     (width, pad)
 }

--- a/crates/rmux-server/src/mouse/hit.rs
+++ b/crates/rmux-server/src/mouse/hit.rs
@@ -49,14 +49,13 @@ pub(super) fn resolve_mouse_hit(
     scrolling: bool,
     current: Option<&AttachedMouseEvent>,
 ) -> MouseHit {
-    if let Some(status_at) = layout.status_at {
-        if y >= status_at && y < status_at.saturating_add(layout.status_lines) {
+    if let Some(status_at) = layout.status_at
+        && y >= status_at && y < status_at.saturating_add(layout.status_lines) {
             if let Some(status) = &layout.status {
                 return status_hit(layout.session_id, status, x);
             }
             return MouseHit::status_default(layout.session_id);
         }
-    }
 
     if scrolling {
         return MouseHit {

--- a/crates/rmux-server/src/outer_terminal.rs
+++ b/crates/rmux-server/src/outer_terminal.rs
@@ -172,21 +172,18 @@ impl OuterTerminal {
         if let Some(sequence) = self.mouse_sequence().as_deref() {
             bytes.extend_from_slice(sequence.as_bytes());
         }
-        if self.focus_events_enabled {
-            if let Some(sequence) = &self.enable_focus {
+        if self.focus_events_enabled
+            && let Some(sequence) = &self.enable_focus {
                 bytes.extend_from_slice(sequence.as_bytes());
             }
-        }
-        if self.extended_keys_enabled {
-            if let Some(sequence) = &self.enable_extkeys {
+        if self.extended_keys_enabled
+            && let Some(sequence) = &self.enable_extkeys {
                 bytes.extend_from_slice(sequence.as_bytes());
             }
-        }
-        if self.supports_margins {
-            if let Some(sequence) = &self.enable_margins {
+        if self.supports_margins
+            && let Some(sequence) = &self.enable_margins {
                 bytes.extend_from_slice(sequence.as_bytes());
             }
-        }
         bytes
     }
 
@@ -198,21 +195,18 @@ impl OuterTerminal {
         if let Some(sequence) = self.render_cursor_style_reset().as_deref() {
             bytes.extend_from_slice(sequence.as_bytes());
         }
-        if self.focus_events_enabled {
-            if let Some(sequence) = &self.disable_focus {
+        if self.focus_events_enabled
+            && let Some(sequence) = &self.disable_focus {
                 bytes.extend_from_slice(sequence.as_bytes());
             }
-        }
-        if self.extended_keys_enabled {
-            if let Some(sequence) = &self.disable_extkeys {
+        if self.extended_keys_enabled
+            && let Some(sequence) = &self.disable_extkeys {
                 bytes.extend_from_slice(sequence.as_bytes());
             }
-        }
-        if self.supports_margins {
-            if let Some(sequence) = &self.disable_margins {
+        if self.supports_margins
+            && let Some(sequence) = &self.disable_margins {
                 bytes.extend_from_slice(sequence.as_bytes());
             }
-        }
         if let Some(sequence) = self.disable_mouse_sequence().as_deref() {
             bytes.extend_from_slice(sequence.as_bytes());
         }

--- a/crates/rmux-server/src/pane_terminals/pane_transcripts.rs
+++ b/crates/rmux-server/src/pane_terminals/pane_transcripts.rs
@@ -62,11 +62,10 @@ impl HandlerState {
                 pending
             });
         }
-        if request.use_mode_screen {
-            if let Some(captured) = transcript.capture_copy_mode(request.range, request.options) {
+        if request.use_mode_screen
+            && let Some(captured) = transcript.capture_copy_mode(request.range, request.options) {
                 return Ok(captured);
             }
-        }
         if request.alternate {
             return transcript
                 .capture_saved(request.range, request.options)

--- a/crates/rmux-server/src/pane_terminals/session_runtime.rs
+++ b/crates/rmux-server/src/pane_terminals/session_runtime.rs
@@ -85,12 +85,11 @@ impl HandlerState {
             completed.push(RenameSessionStep::Terminals);
         }
 
-        if runtime_session_name == *session_name {
-            if let Err(error) = self.rename_runtime_session_state(session_name, new_name) {
+        if runtime_session_name == *session_name
+            && let Err(error) = self.rename_runtime_session_state(session_name, new_name) {
                 self.rollback_session_rename(&completed, session_name, new_name, &error)?;
                 return Err(error);
             }
-        }
 
         if let Some(pixels) = self.attached_terminal_pixels.remove(session_name) {
             self.attached_terminal_pixels

--- a/crates/rmux-server/src/pane_terminals/window_links.rs
+++ b/crates/rmux-server/src/pane_terminals/window_links.rs
@@ -139,13 +139,12 @@ impl HandlerState {
             0
         };
 
-        if remaining <= 1 {
-            if let Some(group) = self.window_link_groups.remove(&group_id) {
+        if remaining <= 1
+            && let Some(group) = self.window_link_groups.remove(&group_id) {
                 for group_slot in group.slots {
                     let _ = self.window_link_slots.remove(&group_slot);
                 }
             }
-        }
 
         remaining.max(1)
     }

--- a/crates/rmux-server/src/pane_terminals/window_movement.rs
+++ b/crates/rmux-server/src/pane_terminals/window_movement.rs
@@ -55,13 +55,12 @@ impl HandlerState {
         if source.session_name() != target.session_name() {
             let sg_src = self.sessions.session_group_name(source.session_name());
             let sg_dst = self.sessions.session_group_name(target.session_name());
-            if let (Some(sg_src), Some(sg_dst)) = (sg_src, sg_dst) {
-                if sg_src == sg_dst {
+            if let (Some(sg_src), Some(sg_dst)) = (sg_src, sg_dst)
+                && sg_src == sg_dst {
                     return Err(RmuxError::Server(
                         "can't move window, sessions are grouped".to_owned(),
                     ));
                 }
-            }
         }
 
         if source.session_name() == target.session_name() {

--- a/crates/rmux-server/src/renderer/borders/layout.rs
+++ b/crates/rmux-server/src/renderer/borders/layout.rs
@@ -369,8 +369,8 @@ fn normalize_vertical_segments(
     let mut merged: Vec<VerticalBoundarySegment> = Vec::with_capacity(segments.len());
 
     for segment in segments {
-        if let Some(previous) = merged.last_mut() {
-            if previous.x == segment.x
+        if let Some(previous) = merged.last_mut()
+            && previous.x == segment.x
                 && previous.first_index == segment.first_index
                 && previous.second_index == segment.second_index
                 && segment.start <= previous.end.saturating_add(2)
@@ -378,7 +378,6 @@ fn normalize_vertical_segments(
                 previous.end = previous.end.max(segment.end);
                 continue;
             }
-        }
         merged.push(segment);
     }
 
@@ -392,8 +391,8 @@ fn normalize_horizontal_segments(
     let mut merged: Vec<HorizontalBoundarySegment> = Vec::with_capacity(segments.len());
 
     for segment in segments {
-        if let Some(previous) = merged.last_mut() {
-            if previous.y == segment.y
+        if let Some(previous) = merged.last_mut()
+            && previous.y == segment.y
                 && previous.first_index == segment.first_index
                 && previous.second_index == segment.second_index
                 && segment.start <= previous.end.saturating_add(2)
@@ -401,7 +400,6 @@ fn normalize_horizontal_segments(
                 previous.end = previous.end.max(segment.end);
                 continue;
             }
-        }
         merged.push(segment);
     }
 
@@ -427,8 +425,8 @@ fn border_cell_owner_and_activity(
         return (None, false);
     }
 
-    if indicators_colour && pane_geometries.len() == 2 {
-        if let Some((owner, active)) = two_pane_border_owner_and_activity(
+    if indicators_colour && pane_geometries.len() == 2
+        && let Some((owner, active)) = two_pane_border_owner_and_activity(
             x,
             y,
             adjacent_panes,
@@ -437,7 +435,6 @@ fn border_cell_owner_and_activity(
         ) {
             return (Some(owner), active);
         }
-    }
 
     if adjacent_panes.contains(&active_pane_index) {
         return (Some(active_pane_index), true);

--- a/crates/rmux-server/src/renderer/status.rs
+++ b/crates/rmux-server/src/renderer/status.rs
@@ -485,18 +485,14 @@ fn resolved_status_style(
 
     if let Some(colour) =
         parse_option_colour(options.resolve(Some(session_name), OptionName::StatusFg))
-    {
-        if !colour_inherits_base(colour) {
+        && !colour_inherits_base(colour) {
             style.cell.fg = colour;
         }
-    }
     if let Some(colour) =
         parse_option_colour(options.resolve(Some(session_name), OptionName::StatusBg))
-    {
-        if !colour_inherits_base(colour) {
+        && !colour_inherits_base(colour) {
             style.cell.bg = colour;
         }
-    }
 
     style
 }

--- a/crates/rmux-server/src/renderer/status/message.rs
+++ b/crates/rmux-server/src/renderer/status/message.rs
@@ -57,8 +57,8 @@ where
     let mut index = 0_usize;
 
     while index < bytes.len() {
-        if bytes[index] == b'#' && bytes.get(index + 1) == Some(&b'[') {
-            if let Some(end_offset) = format_skip_delimiter(&line[index + 2..], b"]") {
+        if bytes[index] == b'#' && bytes.get(index + 1) == Some(&b'[')
+            && let Some(end_offset) = format_skip_delimiter(&line[index + 2..], b"]") {
                 let clause_start = index + 2;
                 let clause_end = clause_start + end_offset;
                 expanded.push_str("#[");
@@ -71,7 +71,6 @@ where
                 index = clause_end + 1;
                 continue;
             }
-        }
 
         let Some(ch) = line[index..].chars().next() else {
             break;

--- a/crates/rmux-server/src/renderer/status/runs.rs
+++ b/crates/rmux-server/src/renderer/status/runs.rs
@@ -74,12 +74,11 @@ pub(in crate::renderer::status) fn push_status_run(
     if text.is_empty() {
         return;
     }
-    if let Some(last) = runs.last_mut() {
-        if last.style == style {
+    if let Some(last) = runs.last_mut()
+        && last.style == style {
             last.text.push_str(&text);
             return;
         }
-    }
     runs.push(StatusRun { text, style });
 }
 

--- a/crates/rmux-server/src/test_env.rs
+++ b/crates/rmux-server/src/test_env.rs
@@ -21,8 +21,10 @@ impl EnvVarGuard {
     pub(crate) fn set(name: &'static str, value: Option<&str>) -> Self {
         let previous = std::env::var(name).ok();
         match value {
-            Some(value) => std::env::set_var(name, value),
-            None => std::env::remove_var(name),
+            // TODO: Audit that the environment access only happens in single-threaded code.
+            Some(value) => unsafe { std::env::set_var(name, value) },
+            // TODO: Audit that the environment access only happens in single-threaded code.
+            None => unsafe { std::env::remove_var(name) },
         }
         Self { name, previous }
     }
@@ -31,8 +33,10 @@ impl EnvVarGuard {
 impl Drop for EnvVarGuard {
     fn drop(&mut self) {
         match &self.previous {
-            Some(value) => std::env::set_var(self.name, value),
-            None => std::env::remove_var(self.name),
+            // TODO: Audit that the environment access only happens in single-threaded code.
+            Some(value) => unsafe { std::env::set_var(self.name, value) },
+            // TODO: Audit that the environment access only happens in single-threaded code.
+            None => unsafe { std::env::remove_var(self.name) },
         }
     }
 }

--- a/crates/rmux-server/src/wait_for.rs
+++ b/crates/rmux-server/src/wait_for.rs
@@ -187,12 +187,11 @@ impl WaitForStore {
     }
 
     pub(crate) fn accept_lock(&mut self, channel: &str, waiter_id: u64) -> bool {
-        if let Some(state) = self.channels.get_mut(channel) {
-            if state.granted_lock_waiter == Some(waiter_id) {
+        if let Some(state) = self.channels.get_mut(channel)
+            && state.granted_lock_waiter == Some(waiter_id) {
                 state.granted_lock_waiter = None;
                 return true;
             }
-        }
 
         false
     }

--- a/crates/rmux-types/Cargo.toml
+++ b/crates/rmux-types/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rmux-types"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 publish = true
 license.workspace = true
 repository.workspace = true

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.95"
+components = ["rustfmt", "clippy"]
+profile = "minimal"

--- a/src/cli/diagnose_tests.rs
+++ b/src/cli/diagnose_tests.rs
@@ -20,8 +20,10 @@ impl EnvVarGuard {
 impl Drop for EnvVarGuard {
     fn drop(&mut self) {
         match self.value.as_ref() {
-            Some(value) => std::env::set_var(self.name, value),
-            None => std::env::remove_var(self.name),
+            // TODO: Audit that the environment access only happens in single-threaded code.
+            Some(value) => unsafe { std::env::set_var(self.name, value) },
+            // TODO: Audit that the environment access only happens in single-threaded code.
+            None => unsafe { std::env::remove_var(self.name) },
         }
     }
 }
@@ -63,7 +65,8 @@ fn path_redaction_replaces_home_prefix() {
     let _guard = ENV_LOCK.lock().expect("env lock");
     let _home = EnvVarGuard::capture("HOME");
     let home = std::env::temp_dir().join("rmux-diagnose-home");
-    std::env::set_var("HOME", &home);
+    // TODO: Audit that the environment access only happens in single-threaded code.
+    unsafe { std::env::set_var("HOME", &home) };
 
     assert_eq!(redact_path(&home.join("rmux.conf")), "~/rmux.conf");
 }

--- a/src/cli/top_level.rs
+++ b/src/cli/top_level.rs
@@ -156,8 +156,10 @@ mod utf8_env_tests {
     impl Drop for EnvVarGuard {
         fn drop(&mut self) {
             match self.value.as_ref() {
-                Some(value) => std::env::set_var(self.name, value),
-                None => std::env::remove_var(self.name),
+                // TODO: Audit that the environment access only happens in single-threaded code.
+                Some(value) => unsafe { std::env::set_var(self.name, value) },
+                // TODO: Audit that the environment access only happens in single-threaded code.
+                None => unsafe { std::env::remove_var(self.name) },
             }
         }
     }
@@ -179,10 +181,14 @@ mod utf8_env_tests {
         let _lc_ctype = EnvVarGuard::capture("LC_CTYPE");
         let _lang = EnvVarGuard::capture("LANG");
 
-        std::env::remove_var("RMUX");
-        std::env::set_var("LC_ALL", "");
-        std::env::set_var("LC_CTYPE", "");
-        std::env::set_var("LANG", "en_US.UTF-8");
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::remove_var("RMUX") };
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::set_var("LC_ALL", "") };
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::set_var("LC_CTYPE", "") };
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::set_var("LANG", "en_US.UTF-8") };
 
         assert!(infer_client_utf8_from_env());
     }
@@ -195,10 +201,14 @@ mod utf8_env_tests {
         let _lc_ctype = EnvVarGuard::capture("LC_CTYPE");
         let _lang = EnvVarGuard::capture("LANG");
 
-        std::env::set_var("RMUX", "/tmp/rmux-1000/default,123,0");
-        std::env::set_var("LC_ALL", "C");
-        std::env::remove_var("LC_CTYPE");
-        std::env::remove_var("LANG");
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::set_var("RMUX", "/tmp/rmux-1000/default,123,0") };
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::set_var("LC_ALL", "C") };
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::remove_var("LC_CTYPE") };
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::remove_var("LANG") };
 
         assert!(infer_client_utf8_from_env());
     }
@@ -211,10 +221,14 @@ mod utf8_env_tests {
         let _lc_ctype = EnvVarGuard::capture("LC_CTYPE");
         let _lang = EnvVarGuard::capture("LANG");
 
-        std::env::remove_var("RMUX");
-        std::env::set_var("LC_ALL", "C");
-        std::env::remove_var("LC_CTYPE");
-        std::env::remove_var("LANG");
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::remove_var("RMUX") };
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::set_var("LC_ALL", "C") };
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::remove_var("LC_CTYPE") };
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::remove_var("LANG") };
 
         assert!(!infer_client_utf8_from_env());
     }

--- a/src/cli_args/targets.rs
+++ b/src/cli_args/targets.rs
@@ -110,11 +110,10 @@ fn is_runtime_resolved_target_shape(value: &str) -> bool {
 }
 
 pub(super) fn parse_target(value: &str) -> Result<Target, String> {
-    if let Some(session_name) = value.strip_suffix(':') {
-        if !session_name.is_empty() {
+    if let Some(session_name) = value.strip_suffix(':')
+        && !session_name.is_empty() {
             return parse_session_name(session_name).map(Target::Session);
         }
-    }
 
     Target::parse(value).map_err(|error| error.to_string())
 }

--- a/src/process_locale.rs
+++ b/src/process_locale.rs
@@ -5,7 +5,7 @@ use std::ffi::CString;
 // SAFETY: This declares libc's process-global timezone refresh entrypoint.
 // Calls are wrapped in `LibcLocaleBackend::tzset`.
 #[cfg(unix)]
-extern "C" {
+unsafe extern "C" {
     fn tzset();
 }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -73,7 +73,8 @@ pub(crate) fn default_socket_path_in(tmpdir: &Path) -> Result<PathBuf, Box<dyn E
     let _guard = env_lock().lock().expect("env lock");
     let previous = std::env::var_os("RMUX_TMPDIR");
     let _restore = EnvVarGuard::new("RMUX_TMPDIR", previous);
-    std::env::set_var("RMUX_TMPDIR", tmpdir);
+    // TODO: Audit that the environment access only happens in single-threaded code.
+    unsafe { std::env::set_var("RMUX_TMPDIR", tmpdir) };
     Ok(default_socket_path()?)
 }
 
@@ -583,8 +584,10 @@ impl EnvVarGuard {
 impl Drop for EnvVarGuard {
     fn drop(&mut self) {
         match self.previous_value.as_ref() {
-            Some(value) => std::env::set_var(self.name, value),
-            None => std::env::remove_var(self.name),
+            // TODO: Audit that the environment access only happens in single-threaded code.
+            Some(value) => unsafe { std::env::set_var(self.name, value) },
+            // TODO: Audit that the environment access only happens in single-threaded code.
+            None => unsafe { std::env::remove_var(self.name) },
         }
     }
 }

--- a/tests/common/tmux_compat.rs
+++ b/tests/common/tmux_compat.rs
@@ -446,11 +446,10 @@ fn run_bounded(
             break;
         }
         if Instant::now() >= deadline {
-            if let Err(error) = child.kill() {
-                if error.kind() != io::ErrorKind::InvalidInput {
+            if let Err(error) = child.kill()
+                && error.kind() != io::ErrorKind::InvalidInput {
                     return Err(error.into());
                 }
-            }
             timed_out = true;
             break;
         }

--- a/tests/internal_daemon.rs
+++ b/tests/internal_daemon.rs
@@ -68,8 +68,10 @@ fn ensure_server_running_reexecs_the_hidden_rmux_daemon() -> Result<(), Box<dyn 
 
     fs::create_dir_all(launcher_dir)?;
     write_hidden_launcher(&launcher_path, &pid_path)?;
-    std::env::set_var(BINARY_OVERRIDE_ENV, &launcher_path);
-    std::env::set_var(BINARY_OVERRIDE_TEST_OPT_IN_ENV, "1");
+    // TODO: Audit that the environment access only happens in single-threaded code.
+    unsafe { std::env::set_var(BINARY_OVERRIDE_ENV, &launcher_path) };
+    // TODO: Audit that the environment access only happens in single-threaded code.
+    unsafe { std::env::set_var(BINARY_OVERRIDE_TEST_OPT_IN_ENV, "1") };
 
     let mut connection = ensure_server_running(&socket_path)?;
     let response = connection.roundtrip(&Request::NewSession(NewSessionRequest {

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -2,6 +2,7 @@
 name = "xtask"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 publish.workspace = true
 license.workspace = true
 repository.workspace = true


### PR DESCRIPTION
Bump workspace edition from 2021 to 2024 across all 13 crates, pin MSRV to 1.95 (with rust-toolchain.toml and CI workflows to match).

I added a bunch of TODOs that need double checking.