### PR TITLE
fix: send ?1000h before ?1002h to match tmux mouse mode order

### DIFF
--- a/crates/rmux-server/src/outer_terminal.rs
+++ b/crates/rmux-server/src/outer_terminal.rs
@@ -375,13 +375,23 @@ impl OuterTerminal {
     }
 
     fn mouse_sequence(&self) -> Option<String> {
+        // Enable in the same order tmux uses in tty_mouse_mode():
+        //   ?1006h  SGR extended coordinates
+        //   ?1000h  normal button tracking   ← must come before ?1002h
+        //   ?1002h  button-event tracking
+        //
+        // Some terminals (e.g. Termius) require ?1000h to be set before
+        // ?1002h; reversing the order causes them to fall back to sending
+        // cursor keys (ESC [ A / ESC [ B) for scroll instead of SGR mouse
+        // events, so WheelUpPane / WheelDownPane bindings never fire.
         (self.supports_mouse && self.mouse_reporting_enabled)
-            .then_some("\x1b[?1006h\x1b[?1002h\x1b[?1000h".to_owned())
+            .then_some("\x1b[?1006h\x1b[?1000h\x1b[?1002h".to_owned())
     }
 
     fn disable_mouse_sequence(&self) -> Option<String> {
+        // Disable in reverse order.
         self.supports_mouse
-            .then_some("\x1b[?1000l\x1b[?1002l\x1b[?1006l".to_owned())
+            .then_some("\x1b[?1002l\x1b[?1000l\x1b[?1006l".to_owned())
     }
 
     fn extkeys_sequence(&self) -> Option<String> {

--- a/crates/rmux-server/src/outer_terminal/tests.rs
+++ b/crates/rmux-server/src/outer_terminal/tests.rs
@@ -13,6 +13,9 @@ fn make_session() -> Session {
     Session::new(session_name("alpha"), TerminalSize { cols: 80, rows: 24 })
 }
 
+const MOUSE_ENABLE_SEQUENCE: &str = "\u{1b}[?1006h\u{1b}[?1000h\u{1b}[?1002h";
+const MOUSE_DISABLE_SEQUENCE: &str = "\u{1b}[?1002l\u{1b}[?1000l\u{1b}[?1006l";
+
 #[test]
 fn terminal_features_match_globs_and_case_insensitive_feature_names() {
     let mut options = OptionStore::new();
@@ -169,12 +172,14 @@ fn attach_sequences_follow_focus_and_extended_key_options() {
     assert!(start.contains("\u{1b}[?1006h"));
     assert!(start.contains("\u{1b}[?1002h"));
     assert!(start.contains("\u{1b}[?1000h"));
+    assert!(start.contains(MOUSE_ENABLE_SEQUENCE));
     assert!(start.contains("\u{1b}[?1004h"));
     assert!(start.contains("\u{1b}[>4;2m"));
     assert!(stop.contains("\u{1b}[?2004l"));
     assert!(stop.contains("\u{1b}[?1000l"));
     assert!(stop.contains("\u{1b}[?1002l"));
     assert!(stop.contains("\u{1b}[?1006l"));
+    assert!(stop.contains(MOUSE_DISABLE_SEQUENCE));
     assert!(stop.contains("\u{1b}[?1004l"));
     assert!(stop.contains("\u{1b}[>4m"));
     assert!(stop.ends_with("\u{1b}[?1049l\u{1b}[23;0;0t"));
@@ -207,9 +212,11 @@ fn client_mouse_feature_enables_mouse_attach_sequences_when_mouse_option_is_on()
     assert!(start.contains("\u{1b}[?1006h"));
     assert!(start.contains("\u{1b}[?1002h"));
     assert!(start.contains("\u{1b}[?1000h"));
+    assert!(start.contains(MOUSE_ENABLE_SEQUENCE));
     assert!(stop.contains("\u{1b}[?1000l"));
     assert!(stop.contains("\u{1b}[?1002l"));
     assert!(stop.contains("\u{1b}[?1006l"));
+    assert!(stop.contains(MOUSE_DISABLE_SEQUENCE));
 }
 
 #[test]
@@ -613,11 +620,13 @@ fn transition_sequence_toggles_mouse_reporting_with_session_scope() {
     assert!(seq.contains("\u{1b}[?1000l"));
     assert!(seq.contains("\u{1b}[?1002l"));
     assert!(seq.contains("\u{1b}[?1006l"));
+    assert!(seq.contains(MOUSE_DISABLE_SEQUENCE));
 
     let seq = String::from_utf8(enabled.transition_sequence_from(&disabled)).expect("utf8");
     assert!(seq.contains("\u{1b}[?1006h"));
     assert!(seq.contains("\u{1b}[?1002h"));
     assert!(seq.contains("\u{1b}[?1000h"));
+    assert!(seq.contains(MOUSE_ENABLE_SEQUENCE));
 }
 
 #[test]


### PR DESCRIPTION
## Problem

Mouse wheel scroll does not work in terminals that require `?1000h` (normal button tracking) to be enabled before `?1002h` (button-event tracking). With the current order (`?1006h ?1002h ?1000h`), those terminals fall back to sending cursor keys (`ESC [ A` / `ESC [ B`) for scroll gestures instead of SGR mouse events, so `WheelUpPane` / `WheelDownPane` bindings never fire.

Confirmed on **Termius** (iOS/macOS/Windows SSH client).

## Fix

Swap the order to match what tmux's `tty_mouse_mode()` sends:

```
?1006h  SGR extended coordinates
?1000h  normal button tracking   ← must come before ?1002h
?1002h  button-event tracking
```

Also updates the disable sequence to the correct reverse order: `?1002l ?1000l ?1006l`.

## How it was found

A PTY man-in-the-middle proxy was used to capture bytes in both directions between the terminal and the multiplexer simultaneously. Comparing tmux (scroll works) vs rmux v0.3.1 (scroll broken) showed an identical three-mode enable sequence — but in different order. Switching to tmux's order immediately fixed the issue: Termius sends `SGR-Mouse(WheelUp/Down,...)` events instead of cursor keys.