### PR TITLE
fix(lexer): normalize CRLF/CR line endings to LF at lex input

### DIFF
--- a/crates/rmux-core/src/command_parser/lexer.rs
+++ b/crates/rmux-core/src/command_parser/lexer.rs
@@ -44,7 +44,7 @@ pub(super) struct Lexer<'a> {
 impl<'a> Lexer<'a> {
     pub(super) fn new(input: &str, context: &'a CommandParser) -> Self {
         Self {
-            input: input.chars().collect(),
+            input: Self::normalize_newlines(input),
             offset: 0,
             ungot: Vec::new(),
             pending_backslashes: 0,
@@ -55,6 +55,26 @@ impl<'a> Lexer<'a> {
             line: 1,
             context,
         }
+    }
+
+    /// Collapse Windows (`\r\n`) and old-Mac (`\r`) line endings to `\n` so the
+    /// rest of the lexer only ever sees LF. Without this, a trailing `\r` from a
+    /// CRLF-saved config is swallowed into the preceding word by `read_word`, and
+    /// backslash line-continuation (which only checks for `\n`) fails on `\r\n`.
+    fn normalize_newlines(input: &str) -> Vec<char> {
+        let mut chars = Vec::with_capacity(input.len());
+        let mut iter = input.chars().peekable();
+        while let Some(ch) = iter.next() {
+            if ch == '\r' {
+                if iter.peek() == Some(&'\n') {
+                    iter.next();
+                }
+                chars.push('\n');
+            } else {
+                chars.push(ch);
+            }
+        }
+        chars
     }
 
     pub(super) fn next_token(&mut self) -> Result<SpannedToken, CommandParseError> {


### PR DESCRIPTION
## Problem

A `.rmux.conf` saved with CRLF (the Windows default) breaks parsing:

- `read_word` (`command_parser/lexer.rs`) only stops on `' '`, `'\t'`, `'\n'`, so a trailing `\r` from a CRLF line is folded into the preceding token (e.g. `off\r`), producing errors like `unknown key: %\r`.
- Backslash line-continuation only matches `'\n'`, so it fails on `\r\n`.

This makes the multiplexer hard to configure on Windows, where editors emit CRLF by default. (`next_token` already collapses `\r\n` at the top level, but `read_word`/continuation predate that and still see raw `\r`.)

## Fix

Normalize `\r\n` and lone `\r` to `\n` once when constructing the lexer input (`Lexer::new`), so the rest of the lexer only ever sees LF. Minimal and localized.

Fixes #20