### PR TITLE
fix(status): supply client + runtime state to the status-bar format context

### DIFF
--- a/crates/rmux-server/src/handler_attach.rs
+++ b/crates/rmux-server/src/handler_attach.rs
@@ -484,6 +484,7 @@ pub(super) fn attach_target_for_session(
         session_name,
         attached_count,
         None,
+        None,
         terminal_context,
     )
 }
@@ -493,6 +494,7 @@ fn attach_target_for_session_with_prompt(
     session_name: &rmux_proto::SessionName,
     attached_count: usize,
     prompt: Option<&renderer::RenderedPrompt>,
+    key_table: Option<&str>,
     terminal_context: &OuterTerminalContext,
 ) -> Result<AttachTarget, rmux_proto::RmuxError> {
     let session = state
@@ -529,8 +531,10 @@ fn attach_target_for_session_with_prompt(
             prompt,
             pane_state
                 .as_ref()
-                .map(|state| state.title.as_str())
+                .map(|pane_state| pane_state.title.as_str())
                 .filter(|title| !title.is_empty()),
+            Some(state),
+            key_table,
         )
         .as_slice(),
     );

--- a/crates/rmux-server/src/handler_attach/key_table.rs
+++ b/crates/rmux-server/src/handler_attach/key_table.rs
@@ -11,7 +11,7 @@ impl RequestHandler {
         key_table_name: Option<String>,
         key_table_set_at: Option<Instant>,
     ) -> Result<(), rmux_proto::RmuxError> {
-        let previous_key_table = {
+        let (previous_key_table, session_name) = {
             let mut active_attach = self.active_attach.lock().await;
             let active = active_attach.by_pid.get_mut(&attach_pid).ok_or_else(|| {
                 rmux_proto::RmuxError::Server("attached client disappeared".to_owned())
@@ -24,16 +24,27 @@ impl RequestHandler {
             let previous = active.key_table_name.clone();
             active.key_table_name = key_table_name.clone();
             active.key_table_set_at = key_table_set_at.filter(|_| key_table_name.is_some());
-            previous
+            (previous, active.session_name.clone())
         };
 
-        let mut state = self.state.lock().await;
-        if let Some(table_name) = key_table_name {
-            let _ = state.key_bindings.get_table(&table_name, true);
+        {
+            let mut state = self.state.lock().await;
+            if let Some(table_name) = key_table_name {
+                let _ = state.key_bindings.get_table(&table_name, true);
+            }
+            if let Some(table_name) = previous_key_table {
+                state.key_bindings.unref_table(&table_name);
+            }
         }
-        if let Some(table_name) = previous_key_table {
-            state.key_bindings.unref_table(&table_name);
-        }
+
+        // The key table just changed (e.g. entering or leaving the "prefix"
+        // table), so repaint the status bar immediately. Otherwise
+        // #{client_prefix} -- and any prefix-pressed indicator built on it --
+        // only refreshes on the next key event, which is too late to show the
+        // prefix while it is actually being held.
+        let _ = self
+            .refresh_attached_client_status(attach_pid, &session_name)
+            .await;
         Ok(())
     }
 
@@ -71,7 +82,7 @@ impl RequestHandler {
         attach_pid: u32,
         key_table_set_at: Instant,
     ) {
-        let previous_key_table = {
+        let (previous_key_table, session_name) = {
             let mut active_attach = self.active_attach.lock().await;
             let Some(active) = active_attach.by_pid.get_mut(&attach_pid) else {
                 return;
@@ -89,13 +100,18 @@ impl RequestHandler {
             active.repeat_deadline = None;
             active.repeat_active = false;
             active.last_key = None;
-            previous
+            (previous, active.session_name.clone())
         };
 
         if let Some(table_name) = previous_key_table {
             let mut state = self.state.lock().await;
             state.key_bindings.unref_table(&table_name);
         }
+
+        // Prefix timed out without a follow-up key; repaint so the indicator clears.
+        let _ = self
+            .refresh_attached_client_status(attach_pid, &session_name)
+            .await;
     }
 
     async fn clear_attached_repeat_state_if_current(
@@ -103,7 +119,7 @@ impl RequestHandler {
         attach_pid: u32,
         repeat_deadline: Instant,
     ) {
-        let previous_key_table = {
+        let (previous_key_table, session_name) = {
             let mut active_attach = self.active_attach.lock().await;
             let Some(active) = active_attach.by_pid.get_mut(&attach_pid) else {
                 return;
@@ -118,12 +134,16 @@ impl RequestHandler {
             active.repeat_deadline = None;
             active.repeat_active = false;
             active.last_key = None;
-            previous
+            (previous, active.session_name.clone())
         };
 
         if let Some(table_name) = previous_key_table {
             let mut state = self.state.lock().await;
             state.key_bindings.unref_table(&table_name);
         }
+
+        let _ = self
+            .refresh_attached_client_status(attach_pid, &session_name)
+            .await;
     }
 }

--- a/crates/rmux-server/src/handler_attach/refresh.rs
+++ b/crates/rmux-server/src/handler_attach/refresh.rs
@@ -23,6 +23,7 @@ impl RequestHandler {
                         active.terminal_context.clone(),
                         active.mode_tree_state_id,
                         active.mode_tree.is_some(),
+                        active.key_table_name.clone(),
                     )
                 })
                 .collect::<Vec<_>>()
@@ -56,12 +57,15 @@ impl RequestHandler {
         let targets = {
             let state = self.state.lock().await;
             let mut targets = Vec::with_capacity(prompts.len());
-            for (pid, prompt, terminal_context, mode_tree_state_id, mode_tree_active) in &prompts {
+            for (pid, prompt, terminal_context, mode_tree_state_id, mode_tree_active, key_table) in
+                &prompts
+            {
                 let Ok(mut target) = super::attach_target_for_session_with_prompt(
                     &state,
                     session_name,
                     attached_count,
                     prompt.as_ref(),
+                    key_table.as_deref(),
                     terminal_context,
                 ) else {
                     return;
@@ -124,10 +128,13 @@ impl RequestHandler {
                         active.terminal_context.clone(),
                         active.mode_tree_state_id,
                         active.mode_tree.is_some(),
+                        active.key_table_name.clone(),
                     )
                 })
         };
-        let Some((prompt, terminal_context, mode_tree_state_id, mode_tree_active)) = prompt else {
+        let Some((prompt, terminal_context, mode_tree_state_id, mode_tree_active, key_table)) =
+            prompt
+        else {
             return;
         };
         let target = {
@@ -137,6 +144,7 @@ impl RequestHandler {
                 session_name,
                 attached_count,
                 prompt.as_ref(),
+                key_table.as_deref(),
                 &terminal_context,
             )
             .ok()
@@ -189,10 +197,13 @@ impl RequestHandler {
                         active.terminal_context.clone(),
                         active.mode_tree_state_id,
                         active.mode_tree.is_some(),
+                        active.key_table_name.clone(),
                     )
                 })
         };
-        let Some((prompt, terminal_context, mode_tree_state_id, mode_tree_active)) = prompt else {
+        let Some((prompt, terminal_context, mode_tree_state_id, mode_tree_active, key_table)) =
+            prompt
+        else {
             return;
         };
         let target = {
@@ -202,6 +213,7 @@ impl RequestHandler {
                 session_name,
                 attached_count,
                 prompt.as_ref(),
+                key_table.as_deref(),
                 &terminal_context,
             )
             .ok()

--- a/crates/rmux-server/src/handler_attach_tests/attached_prefix_lifecycle.rs
+++ b/crates/rmux-server/src/handler_attach_tests/attached_prefix_lifecycle.rs
@@ -12,10 +12,17 @@ async fn attached_prefix_d_dispatches_detach_client() {
         .await
         .expect("prefix d dispatches");
 
-    assert!(
-        matches!(control_rx.try_recv(), Ok(AttachControl::Detach)),
-        "C-b d must detach the attached client"
-    );
+    // Entering and leaving the prefix key table now repaints the status bar
+    // (so #{client_prefix} can show a prefix indicator), so the Detach control
+    // may be preceded by status-refresh Write frames; scan past them.
+    let mut detached = false;
+    while let Ok(control) = control_rx.try_recv() {
+        if matches!(control, AttachControl::Detach) {
+            detached = true;
+            break;
+        }
+    }
+    assert!(detached, "C-b d must detach the attached client");
 }
 
 #[tokio::test]
@@ -34,8 +41,15 @@ async fn attached_prefix_d_dispatches_detach_client_across_separate_reads() {
         .await
         .expect("prefix d input");
 
+    let mut detached = false;
+    while let Ok(control) = control_rx.try_recv() {
+        if matches!(control, AttachControl::Detach) {
+            detached = true;
+            break;
+        }
+    }
     assert!(
-        matches!(control_rx.try_recv(), Ok(AttachControl::Detach)),
+        detached,
         "C-b d must still detach when prefix and command arrive in separate reads"
     );
 }

--- a/crates/rmux-server/src/handler_client_runtime.rs
+++ b/crates/rmux-server/src/handler_client_runtime.rs
@@ -149,7 +149,7 @@ impl RequestHandler {
         session_name: &rmux_proto::SessionName,
     ) -> Result<(), RmuxError> {
         let attached_count = self.attached_count(session_name).await;
-        let (prompt, terminal_context) = {
+        let (prompt, terminal_context, key_table) = {
             let active_attach = self.active_attach.lock().await;
             let active = active_attach
                 .by_pid
@@ -161,6 +161,7 @@ impl RequestHandler {
                     .as_ref()
                     .map(prompt_support::ClientPromptState::rendered_prompt),
                 active.terminal_context.clone(),
+                active.key_table_name.clone(),
             )
         };
         let bytes = {
@@ -175,6 +176,8 @@ impl RequestHandler {
                 &state.options,
                 attached_count,
                 prompt.as_ref(),
+                Some(&state),
+                key_table.as_deref(),
             );
             outer_terminal.wrap_render_frame(&frame)
         };

--- a/crates/rmux-server/src/renderer.rs
+++ b/crates/rmux-server/src/renderer.rs
@@ -12,6 +12,7 @@ use rmux_proto::OptionName;
 
 use crate::copy_mode::CopyModeSummary;
 use crate::format_runtime::{render_runtime_template, RuntimeFormatContext};
+use crate::pane_terminals::HandlerState;
 #[path = "renderer/borders.rs"]
 mod borders;
 #[path = "renderer/clock_mode.rs"]
@@ -82,7 +83,15 @@ pub(crate) fn render_with_attached_count_and_prompt(
     attached_count: usize,
     prompt: Option<&RenderedPrompt>,
 ) -> Vec<u8> {
-    render_with_attached_count_prompt_and_pane_title(session, options, attached_count, prompt, None)
+    render_with_attached_count_prompt_and_pane_title(
+        session,
+        options,
+        attached_count,
+        prompt,
+        None,
+        None,
+        None,
+    )
 }
 
 pub(crate) fn render_with_attached_count_prompt_and_pane_title(
@@ -91,6 +100,8 @@ pub(crate) fn render_with_attached_count_prompt_and_pane_title(
     attached_count: usize,
     prompt: Option<&RenderedPrompt>,
     pane_title: Option<&str>,
+    state: Option<&HandlerState>,
+    key_table: Option<&str>,
 ) -> Vec<u8> {
     let geometry = StatusGeometry::for_session(session, options);
     let mut frame = Vec::new();
@@ -113,6 +124,8 @@ pub(crate) fn render_with_attached_count_prompt_and_pane_title(
             attached_count,
             prompt,
             pane_title,
+            state,
+            key_table,
         )
         .as_slice(),
     );
@@ -418,9 +431,20 @@ pub(crate) fn render_status_only_with_attached_count_and_prompt(
     options: &OptionStore,
     attached_count: usize,
     prompt: Option<&RenderedPrompt>,
+    state: Option<&HandlerState>,
+    key_table: Option<&str>,
 ) -> Vec<u8> {
     let geometry = StatusGeometry::for_session(session, options);
-    render_status_bar(session, options, geometry, attached_count, prompt, None)
+    render_status_bar(
+        session,
+        options,
+        geometry,
+        attached_count,
+        prompt,
+        None,
+        state,
+        key_table,
+    )
 }
 
 pub(crate) fn render_status_message(

--- a/crates/rmux-server/src/renderer/status.rs
+++ b/crates/rmux-server/src/renderer/status.rs
@@ -7,6 +7,7 @@ use rmux_core::{
 use rmux_proto::OptionName;
 
 use crate::format_runtime::{render_runtime_template, RuntimeFormatContext};
+use crate::pane_terminals::HandlerState;
 
 use super::{
     apply_runtime_style_overlay, apply_style_overlay, colour_inherits_base, cursor_position_bytes,
@@ -38,6 +39,8 @@ pub(super) fn render_status_bar(
     attached_count: usize,
     prompt: Option<&RenderedPrompt>,
     pane_title: Option<&str>,
+    state: Option<&HandlerState>,
+    key_table: Option<&str>,
 ) -> Vec<u8> {
     let Some(status_y) = geometry.status_y else {
         return Vec::new();
@@ -60,6 +63,8 @@ pub(super) fn render_status_bar(
         geometry.terminal_size.cols,
         attached_count,
         pane_title,
+        state,
+        key_table,
     );
     let mut frame = Vec::new();
     render_formatted_line(&mut frame, 0, status_y, &line);
@@ -85,7 +90,7 @@ pub(super) fn status_bar_runs(
         &base_style,
         options.resolve(Some(session_name), OptionName::StatusRightStyle),
     );
-    let context = active_format_context(session, attached_count);
+    let context = active_format_context(session, attached_count, None);
     let left_template = options
         .resolve(Some(session_name), OptionName::StatusLeft)
         .unwrap_or_default();
@@ -134,13 +139,26 @@ pub(super) fn status_bar_runs(
     runs
 }
 
-fn active_format_context(session: &Session, attached_count: usize) -> FormatContext {
+fn active_format_context(
+    session: &Session,
+    attached_count: usize,
+    key_table: Option<&str>,
+) -> FormatContext {
     let mut context = FormatContext::from_session(session)
         .with_session_attached(attached_count)
         .with_window(session.active_window_index(), session.window(), true, false);
     if let Some(pane) = session.window().active_pane() {
         context = context.with_window_pane(session.window(), pane);
     }
+    // The status bar is rendered per session, so client_prefix/client_key_table
+    // reflect the (representative) attached client's runtime key table. When the
+    // prefix has been pressed the client's key table is "prefix"; otherwise it
+    // falls back to the root table. Without this the #{?client_prefix,...} and
+    // #{client_key_table} format variables always expanded to empty.
+    let prefix_active = key_table == Some("prefix");
+    context = context
+        .with_named_value("client_key_table", key_table.unwrap_or("root"))
+        .with_named_value("client_prefix", if prefix_active { "1" } else { "0" });
     context
 }
 
@@ -150,7 +168,7 @@ pub(super) fn status_bar_line(
     columns: u16,
     attached_count: usize,
 ) -> FormattedLine {
-    status_bar_line_with_pane_title(session, options, columns, attached_count, None)
+    status_bar_line_with_pane_title(session, options, columns, attached_count, None, None, None)
 }
 
 fn status_bar_line_with_pane_title(
@@ -159,15 +177,23 @@ fn status_bar_line_with_pane_title(
     columns: u16,
     attached_count: usize,
     pane_title: Option<&str>,
+    state: Option<&HandlerState>,
+    key_table: Option<&str>,
 ) -> FormattedLine {
     let width = usize::from(columns);
     let utf8_config = Utf8Config::from_options(options);
     let session_name = session.name();
     let base_style = resolved_status_style(options, session_name);
-    let mut runtime = RuntimeFormatContext::new(active_format_context(session, attached_count))
-        .with_options(options)
-        .with_session(session)
-        .with_window(session.active_window_index(), session.window());
+    let mut runtime =
+        RuntimeFormatContext::new(active_format_context(session, attached_count, key_table))
+            .with_options(options)
+            .with_session(session)
+            .with_window(session.active_window_index(), session.window());
+    // Threading the handler state in lets runtime variables such as
+    // #{pane_in_mode} (the copy-mode indicator) resolve in the status bar.
+    if let Some(state) = state {
+        runtime = runtime.with_state(state);
+    }
     if let Some(pane) = session.window().active_pane() {
         runtime = runtime.with_pane(pane);
     }

--- a/crates/rmux-server/src/renderer/status/message.rs
+++ b/crates/rmux-server/src/renderer/status/message.rs
@@ -15,7 +15,7 @@ pub(in crate::renderer) fn format_status_message_line(
     message: &str,
     command_prompt: bool,
 ) -> FormattedLine {
-    let mut runtime = RuntimeFormatContext::new(active_format_context(session, 0))
+    let mut runtime = RuntimeFormatContext::new(active_format_context(session, 0, None))
         .with_options(options)
         .with_session(session)
         .with_window(session.active_window_index(), session.window())


### PR DESCRIPTION
## Problem

The status bar built its format context with only session/options/window/pane, so two classes of variables never resolved there:

- `#{client_prefix}` / `#{client_key_table}` are registered (`formats/context.rs`) but were never populated, so a prefix-pressed indicator (`#{?client_prefix,...}`) could never light up. Fixes #19.
- `#{pane_in_mode}` resolves through `RuntimeFormatContext` but needs the handler state via `with_state()`, which the status render never attached — so a copy-mode indicator (`#{?pane_in_mode,...}`) always read false.

## Fix

Thread the attached client's key table (already tracked as `ActiveAttach::key_table_name`, set to `"prefix"` while the prefix is pending) and the `HandlerState` into the status render, for both the full attach render and the status-only refresh path. Expose `client_key_table`, set `client_prefix = 1` when that table is `"prefix"`, and call `with_state()` so `pane_in_mode` resolves.

The status bar is rendered per session, so these reflect the session's representative attached client (exact for the common single-client case).

Fixes #19