### PR TITLE
fix: respect pane-base-index in display-panes and other pane index rendering methods 

### DIFF
--- a/crates/rmux-server/src/format_runtime.rs
+++ b/crates/rmux-server/src/format_runtime.rs
@@ -112,6 +112,20 @@ impl<'a> RuntimeFormatContext<'a> {
         self
     }
 
+    fn pane_index_with_base(&self) -> Option<String>{
+        let raw = self
+            .base
+            .format_value(FormatVariable::PaneIndex)?
+            .parse::<u32>()
+            .ok()?;
+        let base = self
+            .option_store()
+            .and_then(|store| store.resolve(self.session_name(), OptionName::PaneBaseIndex))
+            .and_then(|value| value.parse::<u32>().ok())
+            .unwrap_or(0);
+        Some(raw.saturating_add(base).to_string())
+    }
+
     fn option_store(&self) -> Option<&OptionStore> {
         self.options
     }

--- a/crates/rmux-server/src/format_runtime/variables.rs
+++ b/crates/rmux-server/src/format_runtime/variables.rs
@@ -86,6 +86,7 @@ impl FormatVariables for RuntimeFormatContext<'_> {
             "pane_width" => self
                 .visible_pane_snapshot()
                 .map(|pane| pane.geometry().cols().to_string()),
+            "pane_index" => self.pane_index_with_base(),
             "session_activity_flag" => self.session_flag(WINLINK_ACTIVITY),
             "session_alert" => self.session_alert(),
             "session_alerts" => self.session_alerts(),

--- a/crates/rmux-server/src/handler_pane_command_tests.rs
+++ b/crates/rmux-server/src/handler_pane_command_tests.rs
@@ -1860,3 +1860,55 @@ async fn pane_snapshot_revision_changes_after_clear_history() {
         "clearing scrollback must change the snapshot revision",
     );
 }
+
+#[tokio::test]
+async fn list_panes_pane_index_respects_pane_base_index() {
+    let handler = RequestHandler::new();
+    let alpha = session_name("alpha");
+    create_session(&handler, &alpha).await;
+
+    assert!(matches!(
+        handler
+            .handle(Request::SplitWindow(SplitWindowRequest {
+                target: SplitWindowTarget::Session(alpha.clone()),
+                direction: SplitDirection::Vertical,
+                before: false,
+                environment: None,
+            }))
+            .await,
+        rmux_proto::Response::SplitWindow(_)
+    ));
+
+    assert!(matches!(
+        handler
+            .handle(Request::SetOption(SetOptionRequest {
+                scope: ScopeSelector::Global,
+                option: OptionName::PaneBaseIndex,
+                value: "1".to_owned(),
+                mode: SetOptionMode::Replace,
+            }))
+            .await,
+        rmux_proto::Response::SetOption(_)
+    ));
+
+    let listed = handler
+        .handle(Request::ListPanes(ListPanesRequest {
+            target: alpha.clone(),
+            target_window_index: None,
+            format: Some("#{pane_index}".to_owned()),
+        }))
+        .await;
+    let stdout = match listed {
+        rmux_proto::Response::ListPanes(response) => {
+            String::from_utf8(response.output.stdout).expect("list-panes utf8")
+        }
+        response => panic!("expected list-panes success, got {response:?}"),
+    };
+
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert_eq!(
+        lines,
+        vec!["1", "2"],
+        "pane_index should honor pane-base-index"
+    );
+}

--- a/crates/rmux-server/src/renderer/display_panes.rs
+++ b/crates/rmux-server/src/renderer/display_panes.rs
@@ -147,12 +147,17 @@ fn display_pane_specs(session: &Session, options: &OptionStore) -> Vec<DisplayPa
     let active_colour = display_panes_colour(
         options.resolve(Some(session.name()), OptionName::DisplayPanesActiveColour),
     );
+    let base_index = options
+        .resolve(Some(session.name()), 
+            OptionName::PaneBaseIndex)
+        .and_then(|v| v.parse::<u32>().ok())
+        .unwrap_or(0);
 
     display_panes(window)
         .into_iter()
         .filter_map(|pane| {
             let geometry = visible_pane_geometry(session, options, pane)?;
-            let label = pane.index().to_string();
+            let label = pane.index().saturating_add(base_index).to_string();
             let label_width = u16::try_from(label.len()).ok()?;
             if geometry.cols() < label_width || geometry.rows() == 0 {
                 return None;
@@ -413,7 +418,7 @@ pub(crate) struct DisplayPaneTarget {
 mod tests {
     use super::*;
     use rmux_core::{OptionStore, Session};
-    use rmux_proto::{ResizePaneAdjustment, SessionName, TerminalSize};
+    use rmux_proto::{ResizePaneAdjustment, SessionName, TerminalSize, ScopeSelector, SetOptionMode};
 
     fn session_name(value: &str) -> SessionName {
         SessionName::new(value).expect("valid session name")
@@ -483,5 +488,24 @@ mod tests {
         let options = OptionStore::new();
         assert!(render_display_panes_overlay(&session, &options).is_empty());
         assert_eq!(display_panes_label_count(&session, &options), 0);
+    }
+
+    #[test]
+    fn display_panes_overlay_respects_pane_base_index() {
+        let mut session = Session::new(session_name("alpha"), TerminalSize { cols: 8, rows: 4 }); 
+        session.split_active_pane().expect("split succeeds");
+        let mut options = OptionStore::new();
+        options.set(
+                ScopeSelector::Global,
+                OptionName::PaneBaseIndex,
+                "1".to_owned(),
+                SetOptionMode::Replace,
+            )
+            .expect("set succeeds");
+
+        let frame = String::from_utf8(render_display_panes_overlay(&session, &options)).expect("overlay is utf-8");
+
+        assert!(frame.contains("\u{1b}[2;3H\u{1b}[0m\u{1b}[44m1"));
+        assert!(frame.contains("\u{1b}[2;7H\u{1b}[0m\u{1b}[41m2"));
     }
 }


### PR DESCRIPTION
# Problem: 
rmux allows the ability to change the pane-base-index, but the new base index had no visible effect on the labels. So, if a user wanted the panes to start at index 1, rmux would continue using the 0 based indexing system, ignoring the setting.

The fix also needed to apply to other functions like display panes,  status-line #P formatting, and list-panes output.

# Solution:
@mohitt proposed a simple solution, adding a base variable which contains the pane-base-index value, and adding it to the current pane index. This fixes the functionality for display-panes.

The solution for the #{pane_index} / #P differences was to add a function which used the PaneBaseIndex option, and adding it to the raw index. This covers all cases mentioned in the second problem to my knowledge. A function was implemented to match the visual style of format_runtime/variables.rs.

# Testing: 
list_panes_pane_index_respects_pane_base_index tests whether listing panes respects the base index by the ListPanes response.

display_panes_overlay_respects_pane_base_index tests whether display-panes renders '1' and '2'.

Closes #18 