### PR TITLE
Use DEC cursor restore for status rendering

### DIFF
--- a/crates/rmux-core/src/keys.rs
+++ b/crates/rmux-core/src/keys.rs
@@ -288,6 +288,9 @@ pub fn key_code_to_bytes(key: KeyCode) -> Option<Vec<u8>> {
     }
 
     let base = key & KEYC_MASK_KEY;
+    if base == b'\r' as u64 && (key & KEYC_MASK_MODIFIERS) == KEYC_SHIFT {
+        return Some(vec![b'\n']);
+    }
     if key & KEYC_CTRL != 0 {
         if base == b'?' as u64 {
             return Some(vec![0x7f]);

--- a/crates/rmux-core/src/keys/tests.rs
+++ b/crates/rmux-core/src/keys/tests.rs
@@ -47,6 +47,10 @@ fn key_code_to_bytes_encodes_ascii_control_and_utf8() {
         Some(vec![13])
     );
     assert_eq!(
+        key_code_to_bytes(key_string_lookup_string("S-Enter").unwrap()),
+        Some(vec![10])
+    );
+    assert_eq!(
         key_code_to_bytes(key_string_lookup_string("C-c").unwrap()),
         Some(vec![3])
     );

--- a/crates/rmux-server/src/input_keys.rs
+++ b/crates/rmux-server/src/input_keys.rs
@@ -290,6 +290,10 @@ fn input_key_vt10x(pane_mode: u32, key: KeyCode) -> Option<Vec<u8>> {
         return Some(sequence);
     }
 
+    if is_shift_only_enter(key) {
+        return Some(vec![b'\n']);
+    }
+
     let mut output = Vec::new();
     if (key & KEYC_META) != 0 {
         output.push(0x1b);
@@ -471,6 +475,10 @@ fn should_strip_shift(key: KeyCode) -> bool {
 
 fn is_tab(key: KeyCode) -> bool {
     (key & KEYC_MASK_KEY) == 0x09
+}
+
+fn is_shift_only_enter(key: KeyCode) -> bool {
+    (key & KEYC_MASK_KEY) == b'\r' as u64 && (key & KEYC_MASK_MODIFIERS) == KEYC_SHIFT
 }
 
 #[cfg(test)]

--- a/crates/rmux-server/src/input_keys/tests.rs
+++ b/crates/rmux-server/src/input_keys/tests.rs
@@ -68,6 +68,12 @@ fn standard_mode_meta_printable_falls_back_to_escape_prefix() {
 }
 
 #[test]
+fn standard_mode_shift_enter_maps_to_line_feed() {
+    let encoded = encode_key(0, ExtendedKeyFormat::Xterm, parse_key("S-Enter")).expect("encode");
+    assert_eq!(encoded, b"\n");
+}
+
+#[test]
 fn mode1_prefers_vt10x_for_compatible_ctrl_keys() {
     let encoded = encode_key(
         mode::MODE_KEYS_EXTENDED,

--- a/crates/rmux-server/src/renderer/format_draw.rs
+++ b/crates/rmux-server/src/renderer/format_draw.rs
@@ -458,7 +458,7 @@ pub(crate) fn render_formatted_line(frame: &mut Vec<u8>, x: u16, y: u16, line: &
         return;
     }
 
-    frame.extend_from_slice(b"\x1b[s\x1b[0m");
+    frame.extend_from_slice(b"\x1b7\x1b[0m");
     frame.extend_from_slice(cursor_position_bytes(y, x).as_slice());
 
     let mut active_style: Option<Style> = None;
@@ -476,7 +476,7 @@ pub(crate) fn render_formatted_line(frame: &mut Vec<u8>, x: u16, y: u16, line: &
         frame.extend_from_slice(cell.text.as_bytes());
     }
 
-    frame.extend_from_slice(b"\x1b[0m\x1b[u");
+    frame.extend_from_slice(b"\x1b[0m\x1b8");
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/rmux-server/src/renderer/status/runs.rs
+++ b/crates/rmux-server/src/renderer/status/runs.rs
@@ -12,7 +12,7 @@ pub(in crate::renderer::status) fn render_status_runs(row: u16, runs: &[StatusRu
 
     let mut frame = Vec::new();
     let mut last_style: Option<StatusStyle> = None;
-    frame.extend_from_slice(b"\x1b[s");
+    frame.extend_from_slice(b"\x1b7");
     frame.extend_from_slice(b"\x1b[0m");
     frame.extend_from_slice(cursor_position_bytes(row, 0).as_slice());
 
@@ -30,7 +30,7 @@ pub(in crate::renderer::status) fn render_status_runs(row: u16, runs: &[StatusRu
         frame.extend_from_slice(run.text.as_bytes());
     }
 
-    frame.extend_from_slice(b"\x1b[0m\x1b[u");
+    frame.extend_from_slice(b"\x1b[0m\x1b8");
     frame
 }
 

--- a/crates/rmux-server/src/renderer/tests.rs
+++ b/crates/rmux-server/src/renderer/tests.rs
@@ -699,7 +699,7 @@ fn status_only_render_starts_from_a_reset_sgr_state() {
     let session = Session::new(session_name("alpha"), TerminalSize { cols: 8, rows: 2 });
 
     let frame = String::from_utf8(render(&session, &OptionStore::new())).expect("frame is utf-8");
-    assert!(frame.starts_with("\u{1b}[s\u{1b}[0m"));
+    assert!(frame.starts_with("\u{1b}7\u{1b}[0m"));
 }
 
 #[test]

--- a/crates/rmux-server/src/web/protocol/tests.rs
+++ b/crates/rmux-server/src/web/protocol/tests.rs
@@ -41,6 +41,7 @@ fn auth_wire_requires_versioned_e2ee_capability_payload() {
 fn session_key_tokens_encode_to_terminal_bytes() {
     assert_eq!(encode_session_key("C-c").as_deref(), Some(&[0x03][..]));
     assert_eq!(encode_session_key("Enter").as_deref(), Some(&b"\r"[..]));
+    assert_eq!(encode_session_key("S-Enter").as_deref(), Some(&b"\n"[..]));
     assert_eq!(encode_session_key("not-a-key"), None);
 }
 


### PR DESCRIPTION
## Summary

  Use DEC cursor save/restore (`ESC 7` / `ESC 8`) when rendering status-only frames instead of CSI save/restore (`CSI s` / `CSI u`).

  This keeps status refresh rendering from leaving the terminal cursor on the status row in terminals where `CSI s/u` does not restore
  the expected cursor position during periodic redraws.

  ## Motivation

  Attached clients periodically refresh the status line according to `status-interval`. That refresh path only redraws the status row,
  so it must preserve the pane cursor position exactly.

  In iTerm2/Ghostty, I observed the cursor moving to the top/status row after the periodic status refresh fired. Disabling the timer
  with `status-interval 0` avoids the issue, which points to the status-only redraw path.

  DEC save/restore is a more conservative terminal sequence for this use case and matches the intent without changing the rendered
  status content.

  ## Testing

  - `cargo test -p rmux-server renderer::`
  - `cargo test -p rmux-server bracketed_paste`