### PR TITLE
ci(release): publish linux-aarch64 artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,11 @@ jobs:
             platform-label: linux-x86_64
             binary: rmux
             archive: tar.gz
+          - os: ubuntu-22.04-arm
+            target: aarch64-unknown-linux-gnu
+            platform-label: linux-aarch64
+            binary: rmux
+            archive: tar.gz
           - os: macos-15-intel
             target: x86_64-apple-darwin
             platform-label: macos-x86_64
@@ -123,7 +128,7 @@ jobs:
           if [[ "$RUNNER_OS" != "Windows" ]]; then
             file "$bin"
           fi
-          if [[ "$TARGET" == "x86_64-unknown-linux-gnu" ]]; then
+          if [[ "$TARGET" == *-unknown-linux-gnu ]]; then
             max_glibc="$(strings "$bin" | grep -o 'GLIBC_[0-9.]*' | sort -V | tail -n 1 || true)"
             echo "max GLIBC symbol: ${max_glibc:-none}"
             if [[ -n "$max_glibc" ]] && [[ "$(printf '%s\n' "$max_glibc" "GLIBC_2.35" | sort -V | tail -n 1)" != "GLIBC_2.35" ]]; then
@@ -148,7 +153,7 @@ jobs:
           grep -F "rmux $VERSION" version.txt
 
       - name: Install Linux package tooling
-        if: matrix.target == 'x86_64-unknown-linux-gnu'
+        if: runner.os == 'Linux'
         shell: bash
         run: |
           sudo apt-get update
@@ -179,7 +184,7 @@ jobs:
           scripts/verify-package.sh "$archive" --checksums dist/SHA256SUMS.txt --run-binary --require-release-artifact
 
       - name: Create Linux distro packages
-        if: matrix.target == 'x86_64-unknown-linux-gnu'
+        if: runner.os == 'Linux'
         shell: bash
         run: |
           scripts/package-debian.sh \


### PR DESCRIPTION
## Summary

The release workflow currently ships `linux-x86_64`, `macos-x86_64`, `macos-aarch64` and `windows-x86_64`, but **no `linux-aarch64` artifact** — even though the packaging scripts already know how to map `aarch64-unknown-linux-gnu` to `arm64`/`aarch64` (`deb_arch_for_target` / `rpm_arch_for_target`). ARM Linux users (AWS Graviton, Ampere, Oracle Cloud ARM, Raspberry Pi, etc.) currently have to build from source.

This wires aarch64-linux into the release matrix:

- New matrix entry `aarch64-unknown-linux-gnu` on the **native `ubuntu-22.04-arm` runner** (no cross-compilation, no QEMU).
- GLIBC ceiling check now matches `*-unknown-linux-gnu` — `ubuntu-22.04-arm` ships glibc 2.35, the same baseline as the x86_64 runner, so the existing `GLIBC_2.35` cap holds.
- `Install Linux package tooling` and `Create Linux distro packages` now gate on `runner.os == 'Linux'` instead of the x86_64 target only, so arm64 gets the full set of artifacts.

Result: `rmux-<ver>-linux-aarch64.tar.gz`, `rmux_<ver>_arm64.deb` and `rmux-<ver>-*.aarch64.rpm`.

## Test plan

Validated natively on an aarch64 Linux host (glibc 2.35):

- [x] `cargo build --release` (release profile) — clean build of `rmux` + workspace crates.
- [x] `scripts/package-unix.sh --target aarch64-unknown-linux-gnu` → `rmux-0.6.1-linux-aarch64.tar.gz` (correct platform label).
- [x] `scripts/package-debian.sh --target aarch64-unknown-linux-gnu --skip-build --reuse-release-binary` → `rmux_0.6.1_arm64.deb` (`dpkg-deb -f … Architecture` = `arm64`).
- [x] `tmux-compat-linux-check.py --scope extended` against the resulting binary vs system tmux: 30 passed, 0 findings.
- [ ] `.rpm` not built locally (rpm tooling not installed on the test host); the script is already arch-aware and the CI installs `rpm`/`createrepo-c`.
- [ ] CI run on `ubuntu-22.04-arm` (needs maintainer to dispatch the release workflow / approve Actions on the PR).

YAML validated with `yaml.safe_load`.