### PR TITLE
add Nix flake with single-source version

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,44 @@ cargo add ratatui-rmux
 
 </details>
 
+<a id="install-nix"></a>
+<details>
+<summary><strong>Nix / NixOS install</strong></summary>
+
+RMUX provides a flake (`x86_64`/`aarch64`, Linux and macOS).
+
+#### Run without installing
+
+```sh
+nix run github:helvesec/rmux
+```
+
+#### Install into your profile
+
+```sh
+nix profile install github:helvesec/rmux
+```
+
+#### Add to a flake-based system / Home Manager
+
+```nix
+{
+  inputs.rmux.url = "github:helvesec/rmux";
+  # then add inputs.rmux.packages.${system}.default to your packages
+}
+```
+
+#### Development shell
+
+```sh
+nix develop          # cargo, rustc, clippy, rustfmt, rust-analyzer
+```
+
+The flake derives its version from `Cargo.toml`. Packaging details and the
+maintainer release notes live in [docs/nix-packaging.md](docs/nix-packaging.md).
+
+</details>
+
 SHA256 checksums are published with every GitHub Release. APT, DNF, Homebrew, Scoop, Chocolatey, and WinGet metadata are generated from the same release assets.
 
 ## Documentation

--- a/docs/nix-packaging.md
+++ b/docs/nix-packaging.md
@@ -1,0 +1,83 @@
+# Nix Packaging
+
+RMUX ships a [Nix flake](../flake.nix) that builds the `rmux` and `rmux-daemon`
+binaries from source, exposes a `nix run` app, and provides a development shell.
+It targets `x86_64-linux`, `aarch64-linux`, `x86_64-darwin`, and
+`aarch64-darwin`.
+
+## Single source of truth for the version
+
+The flake does **not** hardcode a version. At evaluation time it parses the
+`version` field from the `[workspace.package]` table in [`Cargo.toml`](../Cargo.toml)
+— the same number used by every workspace crate and by the README badge.
+
+```nix
+cargoToml = builtins.readFile ./Cargo.toml;
+version = ...; # parsed from [workspace.package] version = "x.y.z"
+```
+
+Verify what the flake will use at any time:
+
+```sh
+nix eval --raw .#packages.x86_64-linux.default.version
+```
+
+This means the version lives in exactly one place. Bumping `Cargo.toml`
+automatically updates the Nix package version — there is nothing version-shaped
+to keep in sync inside `flake.nix`.
+
+Dependency hashes are pinned via the committed [`Cargo.lock`](../Cargo.lock)
+(`cargoLock.lockFile`), so there is **no `cargoHash` to recompute** when
+dependencies change. Updating `Cargo.lock` is enough.
+
+## Maintainer release checklist
+
+When cutting a new release, the Nix flake needs **no manual edits** for the
+common case. The release flow is:
+
+1. **Bump the version in `Cargo.toml`** (the `[workspace.package]` `version`
+   field) as you already do for a release. The flake picks this up
+   automatically.
+2. If dependencies changed, make sure **`Cargo.lock` is committed and current**
+   (`cargo update` / `cargo build` then commit `Cargo.lock`). The flake reads
+   hashes from it; no `cargoHash` edit is required.
+3. Run the verification sequence below.
+4. Refresh the pinned `nixpkgs` input only when you intend to
+   (`nix flake update`), then commit `flake.lock`. This is optional per release;
+   pin updates are a deliberate change, not a per-version chore.
+5. Commit `flake.nix` / `flake.lock` changes together with the release.
+
+> Action required only if you ever **rename the binary, change the license, move
+> the repository, or restructure `[workspace.package]`** — those are reflected in
+> `flake.nix` (`pname`, `meta`, the version-parsing match) and would need a
+> matching edit. A plain version bump never requires touching `flake.nix`.
+
+## Verification
+
+```sh
+nix build --no-link
+nix run . -- -V                 # should print "rmux <version>" from Cargo.toml
+nix flake check
+nix develop -c cargo --version
+```
+
+`nix run . -- -V` (rmux uses tmux-style flags; `-V` is the version flag) is the
+end-to-end check that the single-source-of-truth version flows from `Cargo.toml`
+through the flake into the built binary.
+
+> The build sets `doCheck = false`, so tests do not run during `nix build`. The
+> `tests/` integration suites spawn the daemon over real PTYs/sockets, shell out
+> to host tools like `ps`, and some are timing-sensitive (e.g. an interactive
+> choose-tree redraw race) — unreliable in the hermetic, CPU-saturated sandbox
+> even though they pass under `cargo test`. Run the full suite in the project's
+> CI and locally with `cargo test`.
+
+## Updating the pinned nixpkgs
+
+```sh
+nix flake update      # refresh flake.lock to latest nixpkgs-unstable
+git add flake.lock
+```
+
+Treat this as an intentional change (it can shift the toolchain and transitive
+build inputs); re-run the verification sequence afterward.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,94 @@
+{
+  description = "RMUX — a local terminal multiplexer with a tmux-style CLI, daemon runtime, Rust SDK, and ratatui integration.";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+
+      # Single source of truth for the version: parse it out of the workspace
+      # manifest's [workspace.package] table so the number is only ever edited in
+      # Cargo.toml. On release, bump the version there and the flake follows.
+      cargoToml = builtins.readFile ./Cargo.toml;
+      version =
+        let
+          # Match the first `version = "x.y.z"` after the [workspace.package] header.
+          after = nixpkgs.lib.last (nixpkgs.lib.splitString "[workspace.package]" cargoToml);
+          m = builtins.match ".*[\n\r]+version[[:space:]]*=[[:space:]]*\"([^\"]+)\".*" after;
+        in
+        if m == null
+        then throw "flake.nix: could not parse version from [workspace.package] in Cargo.toml"
+        else builtins.head m;
+    in
+    {
+      packages = forAllSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          default = pkgs.rustPlatform.buildRustPackage {
+            pname = "rmux";
+            inherit version;
+
+            src = ./.;
+
+            # Use the committed Cargo.lock as the source of dependency hashes.
+            # This keeps builds reproducible without a manually maintained
+            # cargoHash that would need recomputing on every dependency change.
+            cargoLock = {
+              lockFile = ./Cargo.lock;
+            };
+
+            # Tests are not run during the Nix build. The tests/ integration
+            # suites spawn the daemon over real PTYs/sockets, shell out to host
+            # tools like `ps`, and some are timing-sensitive (e.g. interactive
+            # choose-tree redraw races) — unreliable in the hermetic,
+            # CPU-saturated build sandbox even though they pass under
+            # `cargo test`. The full suite runs in the project's CI and locally.
+            # See docs/nix-packaging.md.
+            doCheck = false;
+
+            # The workspace defaults to publish = false for library crates and
+            # builds both the `rmux` and `rmux-daemon` binaries from the root crate.
+
+            meta = with pkgs.lib; {
+              description = "A local terminal multiplexer with a tmux-style CLI, daemon runtime, Rust SDK, and ratatui integration.";
+              homepage = "https://github.com/helvesec/rmux";
+              license = with licenses; [ mit asl20 ]; # MIT OR Apache-2.0
+              mainProgram = "rmux";
+            };
+          };
+        }
+      );
+
+      apps = forAllSystems (system: {
+        default = {
+          type = "app";
+          program = "${self.packages.${system}.default}/bin/rmux";
+        };
+      });
+
+      devShells = forAllSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          default = pkgs.mkShell {
+            buildInputs = with pkgs; [
+              cargo
+              rustc
+              rust-analyzer
+              rustfmt
+              clippy
+            ];
+
+            RUST_SRC_PATH = "${pkgs.rust.packages.stable.rustPlatform.rustLibSrc}";
+          };
+        }
+      );
+    };
+}


### PR DESCRIPTION
For a wider exposure and adoption of this project I've added flake so Nix/NixOS user can run and develop rmux. I'm using the forked version myself for a fun interessing project. 

Thanks for this great project!

Add a multi-system flake (x86_64/aarch64, Linux and macOS) that builds the rmux and rmux-daemon binaries, exposes a nix run app, and provides a dev shell.

The package version is parsed from the [workspace.package] table in Cargo.toml at evaluation time rather than hardcoded, so the version stays single-sourced. Dependency hashes come from the committed Cargo.lock, so no cargoHash needs recomputing on dependency changes.

Tests are not run during the build (doCheck = false): the integration suites need real PTYs/sockets and host tools and include timing-sensitive cases that are unreliable in the hermetic sandbox; the full suite runs in CI and locally.

Add docs/nix-packaging.md with the maintainer release notes and a README install section.