### PR TITLE
fix(server): parse compact if-shell target flags

### DIFF
--- a/crates/rmux-server/src/handler_scripting/queue_parse.rs
+++ b/crates/rmux-server/src/handler_scripting/queue_parse.rs
@@ -186,6 +186,55 @@ fn signed_window_index_target(value: &str) -> bool {
     rest.is_empty() || rest.bytes().all(|byte| byte.is_ascii_digit())
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum IfShellTargetFlag {
+    NextArgument,
+    Attached(String),
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct IfShellFlagCluster {
+    background: bool,
+    format_mode: bool,
+    target: Option<IfShellTargetFlag>,
+}
+
+fn parse_if_shell_flag_cluster(token: &str) -> Option<IfShellFlagCluster> {
+    if !token.starts_with('-') || token == "-" || token == "--" || token.len() <= 2 {
+        return None;
+    }
+
+    let flags = token.strip_prefix('-')?;
+    let mut cluster = IfShellFlagCluster::default();
+    for (index, flag) in flags.char_indices() {
+        match flag {
+            'b' => cluster.background = true,
+            'F' => cluster.format_mode = true,
+            't' => {
+                let value_start = index + flag.len_utf8();
+                cluster.target = Some(if value_start == flags.len() {
+                    IfShellTargetFlag::NextArgument
+                } else {
+                    IfShellTargetFlag::Attached(flags[value_start..].to_owned())
+                });
+                return Some(cluster);
+            }
+            _ => return None,
+        }
+    }
+
+    Some(cluster)
+}
+
+fn parse_queued_if_shell_target(
+    raw_target: String,
+    sessions: &SessionStore,
+    find_context: &TargetFindContext,
+) -> Result<Target, RmuxError> {
+    let value = resolve_queue_target_argument("if-shell", 't', raw_target, sessions, find_context)?;
+    parse_target_arg("if-shell", value)
+}
+
 pub(super) fn parse_queued_if_shell(
     command: ParsedCommand,
     caller_cwd: Option<&Path>,
@@ -213,16 +262,33 @@ pub(super) fn parse_queued_if_shell(
             }
             "-t" => {
                 let _ = args.pop_front();
-                let value = resolve_queue_target_argument(
-                    "if-shell",
-                    't',
+                target = Some(parse_queued_if_shell_target(
                     pop_string_argument(&mut args, "-t target")?,
                     sessions,
                     find_context,
-                )?;
-                target = Some(parse_target_arg("if-shell", value)?);
+                )?);
             }
-            _ => break,
+            token => {
+                let Some(cluster) = parse_if_shell_flag_cluster(token) else {
+                    break;
+                };
+                let _ = args.pop_front();
+                background |= cluster.background;
+                format_mode |= cluster.format_mode;
+                if let Some(target_flag) = cluster.target {
+                    let raw_target = match target_flag {
+                        IfShellTargetFlag::NextArgument => {
+                            pop_string_argument(&mut args, "-t target")?
+                        }
+                        IfShellTargetFlag::Attached(value) => value,
+                    };
+                    target = Some(parse_queued_if_shell_target(
+                        raw_target,
+                        sessions,
+                        find_context,
+                    )?);
+                }
+            }
         }
     }
 

--- a/crates/rmux-server/src/handler_scripting_tests/if_shell.rs
+++ b/crates/rmux-server/src/handler_scripting_tests/if_shell.rs
@@ -291,6 +291,100 @@ async fn queued_if_shell_target_becomes_branch_current_target() {
 }
 
 #[tokio::test]
+async fn queued_if_shell_accepts_compact_format_target_with_attached_value() {
+    let handler = RequestHandler::new();
+    let alpha = session_name("alpha");
+    let beta = session_name("beta");
+    for session in [&alpha, &beta] {
+        assert!(matches!(
+            handler
+                .handle(Request::NewSession(NewSessionRequest {
+                    session_name: session.clone(),
+                    detached: true,
+                    size: Some(TerminalSize { cols: 80, rows: 24 }),
+                    environment: None,
+                }))
+                .await,
+            Response::NewSession(_)
+        ));
+    }
+
+    let parsed = CommandParser::new()
+        .parse("if-shell -Ft= 1 { display-message -p '#{session_name}' }")
+        .expect("if-shell compact target parses");
+    let output = handler
+        .execute_parsed_commands(
+            std::process::id(),
+            parsed,
+            QueueExecutionContext::without_caller_cwd()
+                .with_current_target(Some(Target::Session(beta)))
+                .with_mouse_target(Some(Target::Window(rmux_proto::WindowTarget::with_window(
+                    alpha, 0,
+                )))),
+        )
+        .await
+        .expect("compact if-shell branch should execute");
+    assert_eq!(output.stdout(), b"alpha\n");
+}
+
+#[tokio::test]
+async fn queued_if_shell_accepts_compact_format_target_with_next_argument() {
+    let handler = RequestHandler::new();
+    let alpha = session_name("alpha");
+    let beta = session_name("beta");
+    for session in [&alpha, &beta] {
+        assert!(matches!(
+            handler
+                .handle(Request::NewSession(NewSessionRequest {
+                    session_name: session.clone(),
+                    detached: true,
+                    size: Some(TerminalSize { cols: 80, rows: 24 }),
+                    environment: None,
+                }))
+                .await,
+            Response::NewSession(_)
+        ));
+    }
+
+    let parsed = CommandParser::new()
+        .parse("if-shell -Ft beta:0.0 1 { new-window -d -n compact }")
+        .expect("if-shell compact target parses");
+    handler
+        .execute_parsed_commands(
+            std::process::id(),
+            parsed,
+            QueueExecutionContext::without_caller_cwd().with_current_target(Some(Target::Pane(
+                PaneTarget::with_window(alpha.clone(), 0, 0),
+            ))),
+        )
+        .await
+        .expect("compact if-shell branch should execute");
+
+    let state = handler.state.lock().await;
+    let alpha_windows = state
+        .sessions
+        .session(&alpha)
+        .expect("alpha exists")
+        .windows()
+        .keys()
+        .copied()
+        .collect::<Vec<_>>();
+    let beta_session = state.sessions.session(&beta).expect("beta exists");
+    assert_eq!(alpha_windows, vec![0]);
+    assert_eq!(
+        beta_session.windows().keys().copied().collect::<Vec<_>>(),
+        vec![0, 1]
+    );
+    assert_eq!(
+        beta_session
+            .window_at(1)
+            .expect("compact window exists")
+            .name(),
+        Some("compact")
+    );
+}
+
+#[tokio::test]
 async fn if_shell_false_without_else_is_a_successful_noop() {
     let handler = RequestHandler::new();
 


### PR DESCRIPTION
## Summary
- Parse queued if-shell compact short-option clusters such as `-Ft=` and `-Ft beta:0.0`.
- Reuse the existing queued target resolver so `-t=` still resolves through the mouse target context.
- Add regression coverage for both mouse-target attached syntax and next-argument target syntax.

Fixes #58.

## Testing
- `cargo build --workspace`
- `cargo test -p rmux-server queued_if_shell -- --nocapture`
- `cargo test -p rmux-server if_shell -- --nocapture`
- `cargo test -p rmux-core brace -- --nocapture`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `TMPDIR=/tmp/rmux-codex-tmp cargo test -p rmux --test cli_surface -- --test-threads=1`

I also ran `cargo test --workspace --all-targets` on macOS. It progressed through the workspace but the parallel `cli_surface::alias_fallback_incompatible_wire_error_keeps_socket_context` test failed with `Invalid argument (os error 22)`; that same test passes when run alone and when the `cli_surface` suite is run serially with a short TMPDIR, so this appears to be existing socket-path/concurrency sensitivity rather than this parser change.

## Platform tested
- macOS