### PR TITLE
fix(release): preserve Windows installer layout

### DIFF
--- a/scripts/install-windows.ps1
+++ b/scripts/install-windows.ps1
@@ -1,0 +1,219 @@
+param(
+    [string]$Version = "latest",
+    [string]$Repository = "Helvesec/rmux",
+    [string]$InstallDir = "$env:LOCALAPPDATA\rmux\bin",
+    [switch]$NoVerify
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Fail([string]$Message) {
+    Write-Error "rmux install: $Message"
+    exit 1
+}
+
+function Invoke-NativeCapture([string]$Program, [string[]]$Arguments) {
+    $previousErrorActionPreference = $ErrorActionPreference
+    try {
+        $ErrorActionPreference = "Continue"
+        $output = & $Program @Arguments 2>&1
+        $status = $LASTEXITCODE
+    } finally {
+        $ErrorActionPreference = $previousErrorActionPreference
+    }
+
+    [pscustomobject]@{
+        Output = $output
+        Status = $status
+    }
+}
+
+function Sha256File([string]$Path) {
+    $getFileHash = Get-Command Get-FileHash -ErrorAction SilentlyContinue
+    if ($getFileHash) {
+        return (Get-FileHash -Algorithm SHA256 -LiteralPath $Path).Hash.ToLowerInvariant()
+    }
+
+    $stream = [System.IO.File]::OpenRead([System.IO.Path]::GetFullPath($Path))
+    try {
+        $sha256 = [System.Security.Cryptography.SHA256]::Create()
+        try {
+            $hashBytes = $sha256.ComputeHash($stream)
+            return ([System.BitConverter]::ToString($hashBytes) -replace "-", "").ToLowerInvariant()
+        } finally {
+            $sha256.Dispose()
+        }
+    } finally {
+        $stream.Dispose()
+    }
+}
+
+function Copy-Tree([string]$Source, [string]$Destination) {
+    if (-not (Test-Path -LiteralPath $Source -PathType Container)) {
+        return
+    }
+
+    New-Item -ItemType Directory -Force -Path $Destination | Out-Null
+    Get-ChildItem -LiteralPath $Source -Force | ForEach-Object {
+        Copy-Item -Recurse -Force -LiteralPath $_.FullName -Destination $Destination
+    }
+}
+
+function Test-PackageRoot([string]$Root) {
+    foreach ($required in @("rmux.exe", "libexec\rmux\rmux.exe", "rmux-daemon.exe")) {
+        if (-not (Test-Path -LiteralPath (Join-Path $Root $required) -PathType Leaf)) {
+            return $false
+        }
+    }
+    return $true
+}
+
+function Resolve-LatestVersion([string]$RepositoryName) {
+    $response = Invoke-WebRequest `
+        -UseBasicParsing `
+        -Headers @{ "User-Agent" = "rmux-installer" } `
+        -Uri "https://api.github.com/repos/$RepositoryName/releases/latest"
+    $release = $response.Content | ConvertFrom-Json
+    if ([string]::IsNullOrWhiteSpace($release.tag_name)) {
+        Fail "latest release response did not include tag_name"
+    }
+    $release.tag_name
+}
+
+function Get-LocalPackageRoot {
+    $scriptPath = $MyInvocation.ScriptName
+    if ([string]::IsNullOrWhiteSpace($scriptPath)) {
+        $scriptPath = $PSCommandPath
+    }
+    if ([string]::IsNullOrWhiteSpace($scriptPath)) {
+        return $null
+    }
+
+    $root = Split-Path -Parent ([System.IO.Path]::GetFullPath($scriptPath))
+    if (Test-PackageRoot $root) {
+        return $root
+    }
+    $null
+}
+
+function Verify-InstalledLayout([string]$RmuxBinary) {
+    $result = Invoke-NativeCapture $RmuxBinary @("--help")
+    $output = $result.Output -join "`n"
+    if (($result.Status -ne 0 -and $result.Status -ne 1) -or
+        $output -notmatch 'usage: rmux') {
+        Fail "installed rmux could not reach its full CLI helper`n$output"
+    }
+}
+
+function Install-PackageRoot([string]$PackageRoot, [string]$DestinationBin, [bool]$Verify) {
+    $installBin = [System.IO.Path]::GetFullPath($DestinationBin)
+    $installRoot = Split-Path -Parent $installBin
+
+    foreach ($required in @("rmux.exe", "libexec\rmux\rmux.exe", "rmux-daemon.exe")) {
+        $requiredPath = Join-Path $PackageRoot $required
+        if (-not (Test-Path -LiteralPath $requiredPath -PathType Leaf)) {
+            Fail "archive is missing $required"
+        }
+    }
+
+    New-Item -ItemType Directory -Force -Path $installBin | Out-Null
+    New-Item -ItemType Directory -Force -Path (Join-Path $installRoot "libexec\rmux") | Out-Null
+
+    # Install private targets first so upgrades never expose a dispatcher that
+    # cannot reach its matching full helper.
+    Copy-Item `
+        -Force `
+        -LiteralPath (Join-Path $PackageRoot "libexec\rmux\rmux.exe") `
+        -Destination (Join-Path $installRoot "libexec\rmux\rmux.exe")
+    Copy-Item `
+        -Force `
+        -LiteralPath (Join-Path $PackageRoot "rmux-daemon.exe") `
+        -Destination (Join-Path $installRoot "rmux-daemon.exe")
+    Copy-Tree (Join-Path $PackageRoot "share") (Join-Path $installRoot "share")
+
+    foreach ($optional in @("README.md", "LICENSE-APACHE", "LICENSE-MIT", "rmux.1", "SHA256SUMS.txt")) {
+        $source = Join-Path $PackageRoot $optional
+        if (Test-Path -LiteralPath $source -PathType Leaf) {
+            Copy-Item -Force -LiteralPath $source -Destination (Join-Path $installRoot $optional)
+        }
+    }
+
+    $destination = Join-Path $installBin "rmux.exe"
+    Copy-Item `
+        -Force `
+        -LiteralPath (Join-Path $PackageRoot "rmux.exe") `
+        -Destination $destination
+
+    if ($Verify) {
+        Verify-InstalledLayout $destination
+    }
+
+    Write-Host "Installed rmux to $destination"
+
+    $pathParts = $env:Path -split [System.IO.Path]::PathSeparator
+    if ($pathParts -notcontains $installBin) {
+        Write-Host "Add $installBin to PATH if rmux is not found by PowerShell."
+    }
+}
+
+if ([string]::IsNullOrWhiteSpace($InstallDir)) {
+    Fail "InstallDir must not be empty"
+}
+
+$arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
+if ($arch -ne [System.Runtime.InteropServices.Architecture]::X64) {
+    Fail "Windows prebuilt binary is only available for x64. Use: cargo install rmux --locked"
+}
+
+$localPackageRoot = Get-LocalPackageRoot
+if ($localPackageRoot) {
+    Install-PackageRoot $localPackageRoot $InstallDir (-not $NoVerify)
+    exit 0
+}
+
+if ($Version -eq "latest") {
+    $Version = Resolve-LatestVersion $Repository
+}
+if ($Version -notmatch '^v[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$') {
+    Fail "invalid version: $Version"
+}
+
+$semver = $Version -replace '^v', ''
+$platform = "windows-x86_64"
+$archive = "rmux-$semver-$platform.zip"
+$baseUrl = "https://github.com/$Repository/releases/download/$Version"
+$tmp = Join-Path ([System.IO.Path]::GetTempPath()) ("rmux-install-" + [System.Guid]::NewGuid().ToString("N"))
+
+New-Item -ItemType Directory -Path $tmp | Out-Null
+
+try {
+    $zipPath = Join-Path $tmp $archive
+    $sumsPath = Join-Path $tmp "SHA256SUMS"
+
+    Invoke-WebRequest -UseBasicParsing -Uri "$baseUrl/SHA256SUMS" -OutFile $sumsPath
+    Invoke-WebRequest -UseBasicParsing -Uri "$baseUrl/$archive" -OutFile $zipPath
+
+    $line = Get-Content -LiteralPath $sumsPath |
+        Where-Object { $_ -match "\s+$([regex]::Escape($archive))$" } |
+        Select-Object -First 1
+    if (-not $line) {
+        Fail "checksum entry not found for $archive"
+    }
+
+    $expected = (($line -split "\s+")[0]).ToLowerInvariant()
+    $actual = Sha256File $zipPath
+    if ($actual -ne $expected) {
+        Fail "checksum mismatch for $archive"
+    }
+
+    Expand-Archive -Force -LiteralPath $zipPath -DestinationPath $tmp
+    $packageRoot = Join-Path $tmp "rmux-$semver-$platform"
+    if (-not (Test-PackageRoot $packageRoot)) {
+        Fail "required rmux package layout not found in archive"
+    }
+
+    Install-PackageRoot $packageRoot $InstallDir (-not $NoVerify)
+} finally {
+    Remove-Item -Recurse -Force -LiteralPath $tmp -ErrorAction SilentlyContinue
+}

--- a/scripts/package-windows.ps1
+++ b/scripts/package-windows.ps1
@@ -214,6 +214,7 @@ New-Item -ItemType Directory -Force -Path (Join-Path $stageDir "libexec/rmux") |
 Copy-Item -LiteralPath $binary -Destination (Join-Path $stageDir "rmux.exe")
 Copy-Item -LiteralPath $helperBinary -Destination (Join-Path $stageDir "libexec/rmux/rmux.exe")
 Copy-Item -LiteralPath $daemonBinary -Destination (Join-Path $stageDir "rmux-daemon.exe")
+Copy-Item -LiteralPath "scripts/install-windows.ps1" -Destination (Join-Path $stageDir "install.ps1")
 Copy-Item -LiteralPath "README.md", "LICENSE-APACHE", "LICENSE-MIT", "docs/man/rmux.1" -Destination $stageDir
 $completionDir = Join-Path ([System.IO.Path]::GetTempPath()) "rmux-completions-$([System.Guid]::NewGuid().ToString('N'))"
 New-Item -ItemType Directory -Force -Path $completionDir | Out-Null

--- a/scripts/verify-package-windows.ps1
+++ b/scripts/verify-package-windows.ps1
@@ -209,6 +209,26 @@ function InvokeMouseBorderSmoke([string]$Binary) {
     }
 }
 
+function AssertArchiveInstaller([string]$InstallScript, [string]$Root) {
+    $installRoot = Join-Path $Root "installed-rmux"
+    $installBin = Join-Path $installRoot "bin"
+
+    & $InstallScript -InstallDir $installBin
+    if (-not $?) {
+        Fail "archive install.ps1 failed"
+    }
+
+    foreach ($required in @("bin\rmux.exe", "libexec\rmux\rmux.exe", "rmux-daemon.exe", "share\rmux\artifact-metadata.json")) {
+        if (-not (Test-Path -LiteralPath (Join-Path $installRoot $required) -PathType Leaf)) {
+            Fail "install.ps1 did not install required file: $required"
+        }
+    }
+
+    $installedBinary = Join-Path $installBin "rmux.exe"
+    AssertSuccess $installedBinary @("-V") | Out-Null
+    AssertHelperFallback $installedBinary
+}
+
 function VerifyChecksumManifest([string]$Root, [string]$Manifest) {
     $rootFull = [System.IO.Path]::GetFullPath($Root)
     foreach ($line in Get-Content -LiteralPath $Manifest) {
@@ -277,7 +297,7 @@ try {
         Fail "archive root directory is missing: $([System.IO.Path]::GetFileNameWithoutExtension($archiveName))"
     }
 
-    foreach ($required in @("rmux.exe", "libexec/rmux/rmux.exe", "rmux-daemon.exe", "SHA256SUMS.txt", "share/rmux/artifact-metadata.json", "README.md", "LICENSE-APACHE", "LICENSE-MIT", "rmux.1")) {
+    foreach ($required in @("rmux.exe", "libexec/rmux/rmux.exe", "rmux-daemon.exe", "install.ps1", "SHA256SUMS.txt", "share/rmux/artifact-metadata.json", "README.md", "LICENSE-APACHE", "LICENSE-MIT", "rmux.1")) {
         if (-not (Test-Path -LiteralPath (Join-Path $packageRoot $required))) {
             Fail "missing package file: $required"
         }
@@ -321,6 +341,7 @@ try {
     }
 
     if ($RunBinary) {
+        AssertArchiveInstaller (Join-Path $packageRoot "install.ps1") $tmpRoot
         AssertSuccess $binary @("-V") | Out-Null
         AssertHelperFallback $binary
         AssertSuccess $helperBinary @("-V") | Out-Null


### PR DESCRIPTION
Fixes #86.

Supersedes #87 after renaming the head branch to match the project branch naming pattern.

## Summary

The documented Windows install path currently downloads the v0.8.0 zip but installs only the public rmux.exe tiny dispatcher into %LOCALAPPDATA%\rmux\bin. A clean install or upgrade from the old layout can then fail immediately with:

    private rmux helper not found under libexec/rmux; rebuild or reinstall rmux

The release archive already contains the required Windows package layout: rmux.exe, libexec/rmux/rmux.exe, rmux-daemon.exe, and share/.... This PR makes that layout installable and testable from the repository.

## Fix

- Add a versioned scripts/install-windows.ps1 that downloads the Windows zip, verifies the release checksum, and installs the full package layout.
- Install private targets first, then the public tiny dispatcher, so upgrades never expose a dispatcher that cannot reach its matching helper.
- Package the script into Windows archives as install.ps1.
- Extend scripts/verify-package-windows.ps1 to require install.ps1 and run it into a temporary prefix, catching missing libexec helper regressions.

## Testing

- cargo fmt --all -- --check
- cargo build --workspace
- scripts/install-windows.ps1 -InstallDir <temp>, then <temp>/bin/rmux.exe -V and list-commands
- Repacked the v0.8.0 Windows zip with this install.ps1 and ran scripts/verify-package-windows.ps1 <zip> -Checksums <checksums> -RunBinary

I also ran:

- cargo test --workspace --all-targets
- cargo test -p rmux --test acceptance_cli_matrix -- --test-threads=1

Both hit the existing Windows failure cannot find window: 0 in cli_acceptance_matrix_exercises_real_daemon_state; the same isolated test fails on unmodified upstream/main (3b254fe).

I also ran cargo clippy --workspace --all-targets -- -D warnings; it currently fails on unmodified code with the new stable toolchain lint clippy::byte-char-slices at crates/rmux-server/src/pane_io/types.rs:1117.

## Platform tested

- Windows 11
- PowerShell 7
