### PR TITLE
emulator: answer OSC 10/11/12 colour queries for detached sessions

### DIFF
--- a/crates/rmux-core/src/input/dispatch.rs
+++ b/crates/rmux-core/src/input/dispatch.rs
@@ -9,7 +9,7 @@ use super::csi_helpers::{
 use super::mode;
 use super::sgr;
 use super::tables;
-use super::{InputParser, INPUT_LAST};
+use super::{InputEndType, InputParser, OscColourSlot, INPUT_LAST};
 
 // ─── C0 dispatch ───────────────────────────────────────────────────
 
@@ -494,7 +494,9 @@ pub(crate) fn dispatch_osc<W: ScreenWriter + ?Sized>(parser: &mut InputParser, w
         i += 1;
     }
 
-    let data = String::from_utf8_lossy(&buf[i..]);
+    // Owned: the OSC 10/11/12 arms below mutate parser state (stored colours
+    // and the reply buffer) while the payload is still in use.
+    let data = String::from_utf8_lossy(&buf[i..]).into_owned();
     let end = parser.input_end;
 
     match option {
@@ -506,14 +508,32 @@ pub(crate) fn dispatch_osc<W: ScreenWriter + ?Sized>(parser: &mut InputParser, w
             parser.cell.cell.link = writer.current_hyperlink_id();
         }
         9 => writer.osc_notification(&data),
-        10 => writer.osc_fg_colour(&data, end),
-        11 => writer.osc_bg_colour(&data, end),
-        12 => writer.osc_cursor_colour(&data, end),
+        10 if !answer_osc_colour_query(parser, OscColourSlot::Foreground, &data, end) => {
+            parser.set_osc_colour(OscColourSlot::Foreground, &data);
+            writer.osc_fg_colour(&data, end);
+        }
+        11 if !answer_osc_colour_query(parser, OscColourSlot::Background, &data, end) => {
+            parser.set_osc_colour(OscColourSlot::Background, &data);
+            writer.osc_bg_colour(&data, end);
+        }
+        12 if !answer_osc_colour_query(parser, OscColourSlot::Cursor, &data, end) => {
+            parser.set_osc_colour(OscColourSlot::Cursor, &data);
+            writer.osc_cursor_colour(&data, end);
+        }
         52 => writer.osc_clipboard(&data, end),
         104 => writer.osc_reset_palette(&data),
-        110 => writer.osc_reset_fg(),
-        111 => writer.osc_reset_bg(),
-        112 => writer.osc_reset_cursor(),
+        110 => {
+            parser.reset_osc_colour(OscColourSlot::Foreground);
+            writer.osc_reset_fg();
+        }
+        111 => {
+            parser.reset_osc_colour(OscColourSlot::Background);
+            writer.osc_reset_bg();
+        }
+        112 => {
+            parser.reset_osc_colour(OscColourSlot::Cursor);
+            writer.osc_reset_cursor();
+        }
         133 => writer.osc_shell_integration(&data),
         _ => {}
     }
@@ -545,4 +565,32 @@ pub(crate) fn dispatch_dcs<W: ScreenWriter + ?Sized>(parser: &mut InputParser, w
         payload.extend_from_slice(buf);
         writer.sixel_passthrough(&payload);
     }
+}
+
+/// Answers an OSC 10/11/12 colour QUERY (`?` payload) from the emulator, the
+/// way an attached terminal would (`OSC <n>;rgb:RRRR/GGGG/BBBB`, terminated
+/// like the query). Detached sessions have no terminal to forward the query
+/// to, and theme-detecting TUIs otherwise mis-render. Returns false for
+/// set-colour payloads, which callers handle as before.
+fn answer_osc_colour_query(
+    parser: &mut InputParser,
+    slot: OscColourSlot,
+    data: &str,
+    end: InputEndType,
+) -> bool {
+    if data != "?" {
+        return false;
+    }
+
+    let reply = format!(
+        "\x1b]{};{}{}",
+        slot.osc_number(),
+        parser.osc_colour(slot),
+        match end {
+            InputEndType::Bel => "\x07",
+            InputEndType::St => "\x1b\\",
+        }
+    );
+    parser.reply(&reply);
+    true
 }

--- a/crates/rmux-core/src/input/mod.rs
+++ b/crates/rmux-core/src/input/mod.rs
@@ -63,6 +63,58 @@ pub enum InputEndType {
     Bel,
 }
 
+/// Colour slots reported to OSC 10/11/12 queries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OscColourSlot {
+    /// OSC 10 — default foreground.
+    Foreground,
+    /// OSC 11 — default background.
+    Background,
+    /// OSC 12 — cursor colour.
+    Cursor,
+}
+
+impl OscColourSlot {
+    pub(crate) const fn osc_number(self) -> u32 {
+        match self {
+            Self::Foreground => 10,
+            Self::Background => 11,
+            Self::Cursor => 12,
+        }
+    }
+
+    const fn index(self) -> usize {
+        match self {
+            Self::Foreground => 0,
+            Self::Background => 1,
+            Self::Cursor => 2,
+        }
+    }
+}
+
+/// Default colours reported to OSC 10/11/12 queries when the application has
+/// not set one. Detached sessions have no attached terminal to answer, so the
+/// daemon impersonates a conventional dark terminal; override per daemon with
+/// `RMUX_DEFAULT_FOREGROUND` / `RMUX_DEFAULT_BACKGROUND` /
+/// `RMUX_DEFAULT_CURSOR_COLOUR` (X11 `rgb:RRRR/GGGG/BBBB` format expected by
+/// query consumers).
+fn default_osc_colours() -> &'static [String; 3] {
+    static DEFAULTS: std::sync::OnceLock<[String; 3]> = std::sync::OnceLock::new();
+    DEFAULTS.get_or_init(|| {
+        let var = |name: &str, fallback: &str| {
+            std::env::var(name)
+                .ok()
+                .filter(|value| !value.is_empty())
+                .unwrap_or_else(|| fallback.to_owned())
+        };
+        [
+            var("RMUX_DEFAULT_FOREGROUND", "rgb:cccc/cccc/cccc"),
+            var("RMUX_DEFAULT_BACKGROUND", "rgb:0000/0000/0000"),
+            var("RMUX_DEFAULT_CURSOR_COLOUR", "rgb:cccc/cccc/cccc"),
+        ]
+    })
+}
+
 /// Per-pane VT input parser, matching tmux `input_ctx`.
 pub struct InputParser {
     /// Current parser state.
@@ -115,6 +167,10 @@ pub struct InputParser {
     reply_buf: Vec<u8>,
     /// Dropped terminal passthrough events caused by parser string limits.
     terminal_passthrough_dropped_count: u64,
+
+    /// Application-set OSC 10/11/12 colours (fg, bg, cursor); `None` falls
+    /// back to the daemon defaults when a query is answered.
+    osc_colours: [Option<String>; 3],
 }
 
 impl InputParser {
@@ -144,7 +200,26 @@ impl InputParser {
             ground_timer_active: false,
             reply_buf: Vec::new(),
             terminal_passthrough_dropped_count: 0,
+            osc_colours: [None, None, None],
         }
+    }
+
+    /// Returns the colour reported for an OSC 10/11/12 query.
+    pub(crate) fn osc_colour(&self, slot: OscColourSlot) -> &str {
+        self.osc_colours[slot.index()]
+            .as_deref()
+            .unwrap_or_else(|| default_osc_colours()[slot.index()].as_str())
+    }
+
+    /// Records an application-set OSC 10/11/12 colour so later queries
+    /// round-trip the value.
+    pub(crate) fn set_osc_colour(&mut self, slot: OscColourSlot, value: &str) {
+        self.osc_colours[slot.index()] = Some(value.to_owned());
+    }
+
+    /// Resets an OSC colour back to the daemon default (OSC 110/111/112).
+    pub(crate) fn reset_osc_colour(&mut self, slot: OscColourSlot) {
+        self.osc_colours[slot.index()] = None;
     }
 
     /// Updates the maximum regular string buffer size used for OSC/DCS input.

--- a/crates/rmux-core/src/input/tests.rs
+++ b/crates/rmux-core/src/input/tests.rs
@@ -200,6 +200,16 @@ impl ScreenWriter for RecordingWriter {
     fn osc_hyperlink(&mut self, data: &str) {
         self.calls.push(format!("osc_hyperlink({data:?})"));
     }
+    fn osc_fg_colour(&mut self, data: &str, end: InputEndType) {
+        self.calls.push(format!("osc_fg_colour({data:?}, {end:?})"));
+    }
+    fn osc_bg_colour(&mut self, data: &str, end: InputEndType) {
+        self.calls.push(format!("osc_bg_colour({data:?}, {end:?})"));
+    }
+    fn osc_cursor_colour(&mut self, data: &str, end: InputEndType) {
+        self.calls
+            .push(format!("osc_cursor_colour({data:?}, {end:?})"));
+    }
     fn osc_clipboard(&mut self, data: &str, end: InputEndType) {
         self.calls.push(format!("osc_clipboard({data:?}, {end:?})"));
     }

--- a/crates/rmux-core/src/input/tests/osc_dcs_misc.rs
+++ b/crates/rmux-core/src/input/tests/osc_dcs_misc.rs
@@ -172,3 +172,51 @@ fn all_17_states_exist() {
 }
 
 // ─── MODSET/MODOFF tests ──────────────────────────────────────────
+
+// ─── OSC 10/11/12 colour queries ────────────────────────────────────
+//
+// Detached sessions have no attached terminal to answer colour queries, so
+// the emulator replies itself (theme-detecting TUIs mis-render otherwise).
+// NOTE: these assert the compiled-in defaults; the RMUX_DEFAULT_* env
+// overrides are read once per process, so they are not exercised here.
+
+#[test]
+fn osc_10_fg_query_replies_with_default_st() {
+    let (p, _w) = parse(b"\x1b]10;?\x1b\\");
+    let replies = String::from_utf8_lossy(&p.reply_buf);
+    assert_eq!(replies.as_ref(), "\x1b]10;rgb:cccc/cccc/cccc\x1b\\");
+}
+
+#[test]
+fn osc_11_bg_query_replies_with_default_bel() {
+    let (p, _w) = parse(b"\x1b]11;?\x07");
+    let replies = String::from_utf8_lossy(&p.reply_buf);
+    assert_eq!(replies.as_ref(), "\x1b]11;rgb:0000/0000/0000\x07");
+}
+
+#[test]
+fn osc_12_cursor_query_replies_with_default() {
+    let (p, _w) = parse(b"\x1b]12;?\x1b\\");
+    let replies = String::from_utf8_lossy(&p.reply_buf);
+    assert_eq!(replies.as_ref(), "\x1b]12;rgb:cccc/cccc/cccc\x1b\\");
+}
+
+#[test]
+fn osc_11_set_then_query_round_trips() {
+    let (p, _w) = parse(b"\x1b]11;rgb:1111/2222/3333\x1b\\\x1b]11;?\x1b\\");
+    let replies = String::from_utf8_lossy(&p.reply_buf);
+    assert_eq!(replies.as_ref(), "\x1b]11;rgb:1111/2222/3333\x1b\\");
+}
+
+#[test]
+fn osc_111_reset_restores_default_bg() {
+    let (p, _w) = parse(b"\x1b]11;rgb:1111/2222/3333\x1b\\\x1b]111\x1b\\\x1b]11;?\x1b\\");
+    let replies = String::from_utf8_lossy(&p.reply_buf);
+    assert_eq!(replies.as_ref(), "\x1b]11;rgb:0000/0000/0000\x1b\\");
+}
+
+#[test]
+fn osc_10_set_still_reaches_writer() {
+    let (_p, w) = parse(b"\x1b]10;rgb:eeee/eeee/eeee\x1b\\");
+    assert!(w.has_call("osc_fg_colour("));
+}


### PR DESCRIPTION
## Problem

A program inside a detached rmux pane gets no answer when it queries the terminal's colours (`OSC 10/11/12` with a `?` payload). The emulator already impersonates the attached terminal for DA1/DA2/DSR/DECRQM/XTVERSION (`input/dispatch.rs`), but the OSC colour commands were parsed and dropped (`screen/writer.rs` no-op stubs), so there was no reply at all.

Theme-detecting TUIs mis-render as a result: e.g. Claude Code with `theme: "auto"` queries `ESC ]11;?` at startup and, receiving nothing, silently falls back to the wrong palette variant (we hit this driving Claude Code inside detached rmux sessions — 256-color salmon instead of its truecolor brand orange).

## Change

Answer the queries from the emulator, riding the existing parser reply-buffer → pane reader → pty master write-back path (the same machinery as DA1):

- `?` payload → reply `OSC <n>;rgb:RRRR/GGGG/BBBB`, terminated like the query (BEL vs ST) — the exact format rmux's own client-side theme parser (`src/cli/terminal_theme.rs`) produces and consumes.
- Set payloads are recorded on the parser so later queries round-trip the value, and still reach the `ScreenWriter` unchanged.
- `OSC 110/111/112` resets restore defaults.
- Defaults impersonate a conventional dark terminal (`rgb:cccc/cccc/cccc` on `rgb:0000/0000/0000`), overridable per daemon via `RMUX_DEFAULT_FOREGROUND` / `RMUX_DEFAULT_BACKGROUND` / `RMUX_DEFAULT_CURSOR_COLOUR`.

## Tests

New unit tests beside the existing DA1/XTVERSION reply tests: query replies for all three slots with both terminators, set-then-query round-trip, reset behavior, and writer passthrough for set payloads (`RecordingWriter` now records the colour calls). `cargo test -p rmux-core`: 913 passed; `cargo test -p rmux-server pane_transcript`: 18 passed; clippy/fmt clean.