### PR TITLE
fix(sdk): snapshot index pane handles via resolved stable id

### DIFF
--- a/crates/rmux-sdk/src/handles/pane/snapshot.rs
+++ b/crates/rmux-sdk/src/handles/pane/snapshot.rs
@@ -1,32 +1,35 @@
 use crate::handles::session::unexpected_response;
 use crate::{
-    Pane, PaneAttributes, PaneCell, PaneColor, PaneCursor, PaneGlyph, PaneSnapshot, Result,
+    Pane, PaneAttributes, PaneCell, PaneColor, PaneCursor, PaneGlyph, PaneId, PaneSnapshot, Result,
 };
 use rmux_proto::{
     PaneSnapshotCell, PaneSnapshotCursor, PaneSnapshotRefRequest, PaneSnapshotRequest,
-    PaneSnapshotResponse, Request, Response, CAPABILITY_SDK_PANE_BY_ID,
+    PaneSnapshotResponse, PaneTargetRef, Request, Response, CAPABILITY_SDK_PANE_BY_ID,
 };
 
 use super::target::{is_already_closed_error, parse_error};
 
 pub(super) async fn pane_snapshot(pane: &Pane) -> Result<PaneSnapshot> {
-    if pane.id().await?.is_none() {
+    // Resolve the handle to a concrete daemon pane identity first. A genuinely
+    // absent slot (stale or never-existed) resolves to `None` and keeps the
+    // documented default (revision 0) snapshot contract.
+    let Some(pane_id) = pane.id().await? else {
         return Ok(PaneSnapshot::default());
-    }
+    };
 
     // The pane was listed at the start of this call, but the daemon can still
     // close it between the existence check and the snapshot endpoint round
     // trip. Treat the already-closed protocol errors emitted in that window as
     // a "vanished mid-snapshot" signal and degrade to a default snapshot,
     // while genuine transport or protocol errors still propagate.
-    match request_pane_snapshot(pane).await {
+    match request_pane_snapshot(pane, pane_id).await {
         Ok(response) => snapshot_from_response(response),
         Err(error) if is_already_closed_error(&error, pane.target()) => Ok(PaneSnapshot::default()),
         Err(error) => Err(error),
     }
 }
 
-async fn request_pane_snapshot(pane: &Pane) -> Result<PaneSnapshotResponse> {
+async fn request_pane_snapshot(pane: &Pane, pane_id: PaneId) -> Result<PaneSnapshotResponse> {
     let response = if pane.stable_id.is_some() {
         crate::capabilities::require(pane.transport(), &[CAPABILITY_SDK_PANE_BY_ID]).await?;
         pane.transport()
@@ -35,16 +38,41 @@ async fn request_pane_snapshot(pane: &Pane) -> Result<PaneSnapshotResponse> {
             }))
             .await?
     } else {
-        pane.transport()
-            .request(Request::PaneSnapshot(PaneSnapshotRequest {
-                target: pane.target().into(),
-            }))
-            .await?
+        request_slot_pane_snapshot(pane, pane_id).await?
     };
 
     match response {
         Response::PaneSnapshot(response) => Ok(response),
         response => Err(unexpected_response("pane-snapshot", response)),
+    }
+}
+
+// A slot (index) handle reads through the stable pane id its listing resolved to,
+// whenever the daemon advertises by-id addressing. The by-slot snapshot endpoint
+// resolves `PaneTarget.pane_index` as a raw pane index, so a live pane whose
+// visible index differs from its raw index (any non-zero pane-base-index) would
+// resolve to the blank stale-slot default instead of real content.
+// The by-id endpoint maps the pane id back to its raw index inside the daemon, so
+// the index handle observes the same live pane as the discovery/by-id path.
+// Daemons that predate by-id snapshotting keep the legacy slot endpoint, so their
+// behavior is unchanged.
+async fn request_slot_pane_snapshot(pane: &Pane, pane_id: PaneId) -> Result<Response> {
+    match crate::capabilities::require(pane.transport(), &[CAPABILITY_SDK_PANE_BY_ID]).await {
+        Ok(()) => Ok(pane
+            .transport()
+            .request(Request::PaneSnapshotRef(PaneSnapshotRefRequest {
+                target: PaneTargetRef::by_id(pane.target().session_name.clone(), pane_id),
+            }))
+            .await?),
+        Err(error) if crate::capabilities::is_unavailable(&error, CAPABILITY_SDK_PANE_BY_ID) => {
+            Ok(pane
+                .transport()
+                .request(Request::PaneSnapshot(PaneSnapshotRequest {
+                    target: pane.target().into(),
+                }))
+                .await?)
+        }
+        Err(error) => Err(error),
     }
 }
 

--- a/crates/rmux-sdk/tests/pane_queries.rs
+++ b/crates/rmux-sdk/tests/pane_queries.rs
@@ -11,8 +11,9 @@ use std::time::Duration;
 
 use rmux_proto::{
     encode_frame, ClearHistoryRequest, FrameDecoder, HasSessionRequest, KillPaneRequest,
-    LinkWindowRequest, ListPanesRequest, NewWindowRequest, PaneTarget, Request,
-    ResizeWindowRequest, Response, SendKeysRequest, WindowTarget,
+    LinkWindowRequest, ListPanesRequest, NewWindowRequest, OptionName, PaneTarget, Request,
+    ResizeWindowRequest, Response, ScopeSelector, SendKeysRequest, SetOptionMode, SetOptionRequest,
+    WindowTarget,
 };
 use rmux_sdk::{EnsureSession, PaneProcessState, PaneRef, PaneSnapshot, RmuxBuilder, SessionName};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -101,6 +102,94 @@ async fn pane_id_info_and_snapshot_resolve_through_daemon_for_live_and_stale_slo
         unknown_session_pane.snapshot().await?,
         PaneSnapshot::default()
     );
+
+    harness.finish().await
+}
+
+// Regression guard for the by-slot index mismatch under a non-zero base-index: an
+// index/slot handle (`session.pane(w, p)`) must resolve the real live pane even
+// when the daemon runs with a non-zero `base-index`/`pane-base-index`, instead of
+// silently degrading to a blank `PaneSnapshot::default()` (revision 0). Before the
+// fix, a slot handle snapshot went to the by-slot endpoint, which resolves
+// `PaneTarget.pane_index` as a *raw* pane index. Under pane-base-index 1 the live
+// pane's visible index (1) differs from its raw index (0), so the by-slot lookup
+// missed and the snapshot degraded to the blank stale default, while the by-id
+// discovery path (which maps the stable pane id back to the raw index inside the
+// daemon) returned real content.
+#[tokio::test]
+async fn index_pane_handle_resolves_live_pane_under_nonzero_base_index() -> TestResult {
+    let _lock = LIVE_DAEMON_LOCK.lock().await;
+    let harness = Harness::start("pane-base-index").await?;
+    let rmux = harness.rmux();
+
+    // Set base-index/pane-base-index globally *before* creating the session so the
+    // session's sole window is keyed at daemon index 1 and its pane is reported at
+    // pane index 1 (base-adjusted), exactly the environment that triggered the bug.
+    raw_set_global_option(harness.socket_path(), OptionName::BaseIndex, "1").await?;
+    raw_set_global_option(harness.socket_path(), OptionName::PaneBaseIndex, "1").await?;
+
+    let alpha = session_name("sdkpanebaseidx");
+    let session = EnsureSession::named(alpha.clone())
+        .create_only()
+        .ensure(&rmux)
+        .await?;
+
+    // The by-id discovery path has always resolved correctly (it matches on the
+    // base-index-independent stable pane id). Use it as the source of truth for the
+    // live pane's identity and content.
+    let by_id = rmux.find_panes().session(alpha.as_str()).one().await?;
+    let by_id_id = by_id.id().await?.expect("discovered pane is listed");
+    let by_id_snapshot = by_id.snapshot().await?;
+    assert_ne!(
+        by_id_snapshot.revision, 0,
+        "by-id handle must observe the live pane"
+    );
+
+    // The literal daemon-reported indices under base-index 1 / pane-base-index 1.
+    let by_slot = session.pane(1, 1);
+    assert_eq!(by_slot.target(), &PaneRef::new(alpha.clone(), 1, 1));
+
+    let by_slot_id = by_slot
+        .id()
+        .await?
+        .expect("index handle must resolve the live pane under non-zero base-index");
+    assert_eq!(
+        by_slot_id, by_id_id,
+        "the index/slot handle must resolve to the same live pane as the by-id path"
+    );
+
+    let by_slot_snapshot = by_slot.snapshot().await?;
+    assert_ne!(
+        by_slot_snapshot.revision, 0,
+        "index handle snapshot must not be the blank stale-slot default"
+    );
+    assert_eq!(
+        (by_slot_snapshot.cols, by_slot_snapshot.rows),
+        (by_id_snapshot.cols, by_id_snapshot.rows),
+        "index and by-id snapshots must describe the same live pane grid"
+    );
+    assert_eq!(
+        by_slot_snapshot.visible_text(),
+        by_id_snapshot.visible_text(),
+        "the index/slot snapshot content must match the by-id snapshot for the same pane"
+    );
+
+    // *Literal* index semantics are preserved (tmux-like): under base-index 1 no
+    // window is keyed at literal index 0, so `pane(0, 0)` genuinely addresses an
+    // absent slot and must still yield the documented stale default. The fix
+    // resolves real panes at their base-adjusted indices; it does not reinterpret
+    // `(0, 0)` as "first window / first pane".
+    let literal_absent = session.pane(0, 0);
+    assert_eq!(literal_absent.id().await?, None);
+    assert_eq!(literal_absent.snapshot().await?, PaneSnapshot::default());
+    assert_eq!(literal_absent.snapshot().await?.revision, 0);
+
+    // A genuinely-absent slot must still yield the documented stale default,
+    // protecting the contract exercised by the stale-slot assertions above.
+    let genuinely_absent = session.pane(9, 9);
+    assert_eq!(genuinely_absent.id().await?, None);
+    assert_eq!(genuinely_absent.snapshot().await?, PaneSnapshot::default());
+    assert_eq!(genuinely_absent.snapshot().await?.revision, 0);
 
     harness.finish().await
 }
@@ -400,6 +489,23 @@ async fn raw_first_pane_id(
                 .ok_or_else(|| "list-panes returned no rows".into())
         }
         response => Err(format!("unexpected list-panes response: {response:?}").into()),
+    }
+}
+
+async fn raw_set_global_option(socket_path: &Path, option: OptionName, value: &str) -> TestResult {
+    match framed_request(
+        socket_path,
+        Request::SetOption(SetOptionRequest {
+            scope: ScopeSelector::Global,
+            option,
+            value: value.to_owned(),
+            mode: SetOptionMode::Replace,
+        }),
+    )
+    .await?
+    {
+        Response::SetOption(_) => Ok(()),
+        response => Err(format!("unexpected set-option response: {response:?}").into()),
     }
 }
 


### PR DESCRIPTION
Fixes #94

## Problem

Slot handles from `Session::pane(w, p)` snapshot through the by-slot endpoint, which sends the visible (base-adjusted) pane index. The daemon resolver (`pane_id_for_target` -> `window.pane(idx)`) matches the raw index. When `pane-base-index != 0` the lookup misses, the daemon returns `InvalidTarget`, and the SDK swallows it into a blank `PaneSnapshot::default()` with `revision: 0`. The by-id path is unaffected because the daemon maps the stable pane id back to the raw index internally.

## Fix

Slot-handle snapshots now resolve the stable pane id and use the by-id endpoint, falling back to the legacy slot endpoint for daemons without by-id support. The documented stale-slot contract is unchanged: genuinely absent slots still return the default snapshot.

## Scope note

The defect fires only when `pane-base-index != 0`. Revisiting the report with that understanding: under default config (`base-index 1` / `pane-base-index 1`), the `(0, 0)` blank was a genuinely absent slot under literal indexing (correctly blank by contract), while `(1, 1)` was the live pane hitting this bug; it is repaired by this change.

## Testing

- New regression test `index_pane_handle_resolves_live_pane_under_nonzero_base_index`: fails on unmodified main, passes with the fix, and fails again if the fix is reverted.
- Full `pane_queries` and `list_panes` suites pass; existing stale-slot and multi-window literal-index tests unchanged and green.
- `cargo fmt --check` and `cargo clippy -- -D warnings` on the changed targets are clean; the workspace build succeeds. One pre-existing lint in `tests/armed_wait.rs` reproduces on unmodified main with a newer local toolchain and is unrelated to this change.
- Independently verified end-to-end with the probe binary from the original report against a freshly built daemon in all three base-index configurations.

## Possible follow-ups (maintainer call, out of scope here)

- The daemon-side by-slot resolver interprets `PaneTarget.pane_index` as raw while `list-panes` renders visible indices; making target resolution visible-index-aware would also fix other by-slot commands (send-keys, kill-pane, select-pane, resize).
- `snapshot()` on a handle that never resolves still returns `Ok` with the default grid; an explicit error variant (option 2 in #94) may be worth considering.
