### PR TITLE
fix: opencode (and kitty-probing TUIs) lose Backspace inside rmux

### DIFF
--- a/crates/rmux-core/src/input/dispatch.rs
+++ b/crates/rmux-core/src/input/dispatch.rs
@@ -413,14 +413,7 @@ pub(crate) fn dispatch_csi<W: ScreenWriter + ?Sized>(parser: &mut InputParser, w
         CsiCommand::KittyKeyboardPop => {
             writer.mode_clear(mode::MODE_KEYS_KITTY | mode::MODE_KEYS_EXTENDED_2);
         }
-        CsiCommand::KittyKeyboardQuery => {
-            let flags = if (writer.current_mode() & mode::MODE_KEYS_KITTY) != 0 {
-                1
-            } else {
-                0
-            };
-            parser.reply(&format!("\x1b[?{flags}u"));
-        }
+        CsiCommand::KittyKeyboardQuery => {}
         CsiCommand::Modoff => {
             let n = parser.param_list.get(0, 0, 0);
             if n != 4 {

--- a/crates/rmux-core/src/input/tests/extended_timers_utf8.rs
+++ b/crates/rmux-core/src/input/tests/extended_timers_utf8.rs
@@ -28,10 +28,9 @@ fn kitty_keyboard_set_and_pop_update_csi_u_extended_keys() {
 }
 
 #[test]
-fn kitty_keyboard_query_reports_current_flag_state() {
+fn kitty_keyboard_query_does_not_reply() {
     let (p, _w) = parse(b"\x1b[>1u\x1b[?u");
-    let replies = String::from_utf8_lossy(&p.reply_buf);
-    assert_eq!(replies.as_ref(), "\x1b[?1u");
+    assert!(p.reply_buf.is_empty());
 }
 
 // ─── Hardening: ground timer ───────────────────────────────────────


### PR DESCRIPTION
## Problem

Backspace does not work for opencode when run inside an rmux pane (Ctrl+Backspace works; plain Backspace is dead). ESC and other keys are fine. Backspace works for opencode in plain xterm and in real tmux.

## Root cause

rmux's terminal emulator **answered** the kitty-keyboard capability query `CSI ? u` with `CSI ? {flags} u`, advertising support for the kitty-keyboard protocol. Real tmux 3.x does **not** answer it.

Probing applications (opencode / Bubble Tea) see the reply, conclude the terminal supports kitty keyboard, and switch into kitty/CSI-u input mode. rmux's kitty key encoding is only partial — trivial keys such as Backspace are always emitted as legacy bytes (`0x7f`) regardless of mode (`input_keys.rs:58`). The app therefore expects `CSI 127 u` and never recognises the bare `0x7f`, so Backspace is dropped. `Ctrl+Backspace` (`0x08` → Ctrl-H) survives because most parsers map it to delete independently.

Captured side-by-side from detached panes:

| query | rmux | real tmux 3.6b |
| --- | --- | --- |
| `CSI ? u` (kitty kb query) | `CSI ? 0 u` (answers) | _no response_ |

A live-attach byte capture confirmed rmux delivers the correct `0x7f` for plain Backspace and `0x08` for Ctrl+Backspace, with no stray bytes — so this is not an input-forwarding bug.

## Fix

Stop replying to the kitty-keyboard query (`CsiCommand::KittyKeyboardQuery` → no-op), matching tmux. Probing applications stay in legacy input mode and Backspace works.

Intentionally minimal: the kitty push/set/pop handlers and `MODE_KEYS_KITTY` tracking are left in place as scaffolding for a future complete kitty-keyboard implementation. A full implementation would also need: per-flag tracking (report-all etc.), a push/pop stack, event-type fields, and CSI-u encoding for trivial keys.

## Verification

- `cargo test -p rmux-core --lib` → **907 passed, 0 failed** (incl. the updated kitty query test).
- `cargo fmt --all --check` → clean.
- `cargo clippy -p rmux-core --all-targets --locked -- -D warnings` → clean.
- Confirmed opencode Backspace works after the fix.