### PR TITLE
ci: build canonical release assets

### DIFF
--- a/.github/actions/canonical-build/action.yml
+++ b/.github/actions/canonical-build/action.yml
@@ -1,0 +1,303 @@
+name: Build one canonical RMUX platform
+description: Build, attest, and persist one native release bundle without publication authority
+
+inputs:
+  expected-source-sha:
+    description: Exact protected main commit to build
+    required: true
+  fast-run-id:
+    description: Numeric Actions run ID containing the accepted fast proof
+    required: true
+  release-intent-id:
+    description: Unique allowlisted identifier for this release intent
+    required: true
+  planned-release-ref:
+    description: Planned stable or release-candidate tag name
+    required: true
+  release-kind:
+    description: Shadow, release-candidate, or stable intent kind
+    required: true
+  platform-key:
+    description: Contracted canonical platform key
+    required: true
+  runner-image:
+    description: Literal GitHub-hosted runner image contracted for the platform
+    required: true
+  target-triple:
+    description: Native Rust target triple contracted for the platform
+    required: true
+
+outputs:
+  assets-artifact-id:
+    description: Numeric ID of the canonical asset artifact
+    value: ${{ steps.assets-api.outputs.artifact_id }}
+  assets-artifact-digest:
+    description: Canonical API digest of the canonical asset artifact
+    value: ${{ steps.assets-api.outputs.artifact_digest }}
+  assets-artifact-name:
+    description: SHA-scoped canonical asset artifact name
+    value: ${{ steps.identity.outputs.assets_name }}
+  provenance-artifact-id:
+    description: Numeric ID of the post-upload provenance artifact
+    value: ${{ steps.provenance-api.outputs.artifact_id }}
+  provenance-artifact-digest:
+    description: Canonical API digest of the provenance artifact
+    value: ${{ steps.provenance-api.outputs.artifact_digest }}
+  attestation-id:
+    description: Opaque GitHub build-provenance attestation identifier
+    value: ${{ steps.attest.outputs.attestation-id }}
+  build-record-sha256:
+    description: SHA-256 of the canonical build record
+    value: ${{ steps.record.outputs.build_record_sha256 }}
+
+runs:
+  using: composite
+  steps:
+    - id: identity
+      name: Validate source, runner, target, and cold object policy
+      shell: bash
+      env:
+        RMUX_EXPECTED_SOURCE_SHA: ${{ inputs.expected-source-sha }}
+        RMUX_PLATFORM_KEY: ${{ inputs.platform-key }}
+        RMUX_RUNNER_IMAGE: ${{ inputs.runner-image }}
+        RMUX_TARGET_TRIPLE: ${{ inputs.target-triple }}
+      run: |
+        set -euo pipefail
+        test "$GITHUB_EVENT_NAME" = workflow_dispatch
+        test "$GITHUB_REF" = refs/heads/main
+        test "$GITHUB_RUN_ATTEMPT" = 1
+        test "$GITHUB_SHA" = "$RMUX_EXPECTED_SOURCE_SHA"
+        test "$(git rev-parse HEAD)" = "$RMUX_EXPECTED_SOURCE_SHA"
+        test -z "$(git status --porcelain --untracked-files=no)"
+        test "$RUNNER_ENVIRONMENT" = github-hosted
+        test -z "${RUSTC_WRAPPER:-}"
+        test -z "${RUSTC_WORKSPACE_WRAPPER:-}"
+        test "$CARGO_INCREMENTAL" = 0
+        canonical_target="$RUNNER_TEMP/rmux-canonical-target"
+        canonical_bundle="$RUNNER_TEMP/rmux-canonical-bundle"
+        canonical_assets="$canonical_bundle/assets"
+        canonical_completions="$RUNNER_TEMP/rmux-canonical-completions"
+        test ! -e "$canonical_target"
+        test ! -e "$canonical_bundle"
+        python3 - "$RMUX_PLATFORM_KEY" "$RMUX_RUNNER_IMAGE" "$RMUX_TARGET_TRIPLE" "$RUNNER_OS" "$RUNNER_ARCH" <<'PY'
+        import json
+        import pathlib
+        import sys
+
+        contract = json.loads(pathlib.Path(".github/release/canonical-build-contract.json").read_text())
+        matches = [entry for entry in contract["platforms"] if entry["key"] == sys.argv[1]]
+        if len(matches) != 1:
+            raise SystemExit("canonical platform key is not unique")
+        entry = matches[0]
+        observed = (sys.argv[2], sys.argv[3], sys.argv[4], sys.argv[5])
+        expected = (entry["runner_image"], entry["target_triple"], entry["runner_os"], entry["runner_arch"])
+        if observed != expected:
+            raise SystemExit(f"canonical platform mapping differs: {observed!r} != {expected!r}")
+        PY
+        mkdir -p "$canonical_target" "$canonical_assets"
+        {
+          echo "CARGO_TARGET_DIR=$canonical_target"
+          echo "CANONICAL_BUNDLE=$canonical_bundle"
+          echo "CANONICAL_ASSETS=$canonical_assets"
+          echo "RMUX_COMPLETIONS_DIR=$canonical_completions"
+        } >> "$GITHUB_ENV"
+        echo "assets_name=rmux-canonical-$RMUX_PLATFORM_KEY-$RMUX_EXPECTED_SOURCE_SHA" >> "$GITHUB_OUTPUT"
+
+    - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+      with:
+        toolchain: "1.96.1"
+        targets: ${{ inputs.target-triple }}
+
+    - name: Capture toolchain and fetch locked dependencies
+      shell: bash
+      run: |
+        set -euo pipefail
+        rustc -vV > "$CANONICAL_BUNDLE/rustc-vV.txt"
+        cargo fetch --locked
+
+    - name: Install Linux packaging tools
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y binutils cpio rpm createrepo-c
+
+    - name: Build and package Unix assets once
+      if: runner.os != 'Windows'
+      shell: bash
+      env:
+        RMUX_PACKAGE_CODESIGN_ADHOC: ${{ runner.os == 'macOS' && '1' || '0' }}
+        RMUX_PLATFORM_KEY: ${{ inputs.platform-key }}
+        RMUX_TARGET_TRIPLE: ${{ inputs.target-triple }}
+      run: |
+        set -euo pipefail
+        scripts/package-unix.sh \
+          --configuration release \
+          --target "$RMUX_TARGET_TRIPLE" \
+          --platform-label "$RMUX_PLATFORM_KEY" \
+          --output-dir "$CANONICAL_ASSETS"
+        if [[ "$RUNNER_OS" == Linux ]]; then
+          scripts/package-debian.sh \
+            --configuration release \
+            --target "$RMUX_TARGET_TRIPLE" \
+            --output-dir "$CANONICAL_ASSETS" \
+            --skip-build \
+            --reuse-release-binary
+          scripts/package-rpm.sh \
+            --configuration release \
+            --target "$RMUX_TARGET_TRIPLE" \
+            --output-dir "$CANONICAL_ASSETS" \
+            --skip-build \
+            --reuse-release-binary
+        fi
+
+    - name: Build and package Windows assets once
+      if: runner.os == 'Windows'
+      shell: pwsh
+      env:
+        RMUX_PLATFORM_KEY: ${{ inputs.platform-key }}
+        RMUX_TARGET_TRIPLE: ${{ inputs.target-triple }}
+      run: |
+        ./scripts/package-windows.ps1 `
+          -Configuration release `
+          -Target $env:RMUX_TARGET_TRIPLE `
+          -PlatformLabel $env:RMUX_PLATFORM_KEY `
+          -OutputDir $env:CANONICAL_ASSETS
+
+    - id: record
+      name: Record and enumerate every subject
+      shell: bash
+      env:
+        RMUX_EXPECTED_SOURCE_SHA: ${{ inputs.expected-source-sha }}
+        RMUX_FAST_RUN_ID: ${{ inputs.fast-run-id }}
+        RMUX_RELEASE_INTENT_ID: ${{ inputs.release-intent-id }}
+        RMUX_PLANNED_RELEASE_REF: ${{ inputs.planned-release-ref }}
+        RMUX_RELEASE_KIND: ${{ inputs.release-kind }}
+        RMUX_PLATFORM_KEY: ${{ inputs.platform-key }}
+        RMUX_RUNNER_IMAGE: ${{ inputs.runner-image }}
+      run: |
+        set -euo pipefail
+        test -z "$(git status --porcelain --untracked-files=no)"
+        record_sha=$(scripts/release/canonical-build-record.py create \
+          --source-sha "$RMUX_EXPECTED_SOURCE_SHA" \
+          --fast-run-id "$RMUX_FAST_RUN_ID" \
+          --candidate-run-id "$GITHUB_RUN_ID" \
+          --candidate-run-attempt "$GITHUB_RUN_ATTEMPT" \
+          --release-intent-id "$RMUX_RELEASE_INTENT_ID" \
+          --planned-release-ref "$RMUX_PLANNED_RELEASE_REF" \
+          --release-kind "$RMUX_RELEASE_KIND" \
+          --platform-key "$RMUX_PLATFORM_KEY" \
+          --assets-dir "$CANONICAL_ASSETS" \
+          --runner-image "$RMUX_RUNNER_IMAGE" \
+          --runner-os "$RUNNER_OS" \
+          --runner-arch "$RUNNER_ARCH" \
+          --runner-environment "$RUNNER_ENVIRONMENT" \
+          --rustc-verbose "$CANONICAL_BUNDLE/rustc-vV.txt" \
+          --output "$CANONICAL_BUNDLE/canonical-build-record.json")
+        scripts/release/canonical-build-record.py subjects \
+          --record "$CANONICAL_BUNDLE/canonical-build-record.json" \
+          --assets-dir "$CANONICAL_ASSETS" \
+          --output "$CANONICAL_BUNDLE/canonical-subjects.sha256"
+        echo "build_record_sha256=$record_sha" >> "$GITHUB_OUTPUT"
+
+    - id: attest
+      name: Attest the canonical checksum subjects
+      uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32
+      with:
+        subject-checksums: ${{ env.CANONICAL_BUNDLE }}/canonical-subjects.sha256
+        create-storage-record: false
+        show-summary: false
+
+    - id: assets-upload
+      name: Persist the canonical assets and record
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+      with:
+        name: ${{ steps.identity.outputs.assets_name }}
+        path: |
+          ${{ env.CANONICAL_ASSETS }}
+          ${{ env.CANONICAL_BUNDLE }}/canonical-build-record.json
+        if-no-files-found: error
+        retention-days: 7
+        compression-level: 0
+
+    - id: assets-api
+      name: Resolve the persisted asset by numeric ID
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        RMUX_ASSETS_ARTIFACT_ID: ${{ steps.assets-upload.outputs.artifact-id }}
+        RMUX_ASSETS_ARTIFACT_NAME: ${{ steps.identity.outputs.assets_name }}
+        RMUX_EXPECTED_SOURCE_SHA: ${{ inputs.expected-source-sha }}
+      run: |
+        set -euo pipefail
+        scripts/release/actions-artifact.py resolve-id \
+          --repository "$GITHUB_REPOSITORY" \
+          --run-id "$GITHUB_RUN_ID" \
+          --artifact-id "$RMUX_ASSETS_ARTIFACT_ID" \
+          --name "$RMUX_ASSETS_ARTIFACT_NAME" \
+          --expected-source-sha "$RMUX_EXPECTED_SOURCE_SHA" \
+          --max-attempts 6 \
+          --retry-delay-seconds 2 \
+          --github-output "$GITHUB_OUTPUT"
+
+    - name: Bind post-upload IDs without self-reference
+      shell: bash
+      env:
+        RMUX_ASSETS_ARTIFACT_DIGEST: ${{ steps.assets-api.outputs.artifact_digest }}
+        RMUX_ASSETS_ARTIFACT_ID: ${{ steps.assets-api.outputs.artifact_id }}
+        RMUX_ASSETS_ARTIFACT_NAME: ${{ steps.assets-api.outputs.artifact_name }}
+        RMUX_ATTESTATION_BUNDLE: ${{ steps.attest.outputs.bundle-path }}
+        RMUX_ATTESTATION_ID: ${{ steps.attest.outputs.attestation-id }}
+        RMUX_BUILD_RECORD_SHA256: ${{ steps.record.outputs.build_record_sha256 }}
+        RMUX_EXPECTED_SOURCE_SHA: ${{ inputs.expected-source-sha }}
+        RMUX_PLATFORM_KEY: ${{ inputs.platform-key }}
+      run: |
+        set -euo pipefail
+        provenance="$RUNNER_TEMP/rmux-canonical-provenance"
+        test ! -e "$provenance"
+        mkdir -p "$provenance"
+        cp "$CANONICAL_BUNDLE/canonical-build-record.json" "$provenance/"
+        cp "$CANONICAL_BUNDLE/rustc-vV.txt" "$provenance/"
+        cp "$RMUX_ATTESTATION_BUNDLE" "$provenance/build-provenance.sigstore.json"
+        scripts/release/canonical-artifact-binding.py create \
+          --source-sha "$RMUX_EXPECTED_SOURCE_SHA" \
+          --candidate-run-id "$GITHUB_RUN_ID" \
+          --platform-key "$RMUX_PLATFORM_KEY" \
+          --assets-artifact-id "$RMUX_ASSETS_ARTIFACT_ID" \
+          --assets-artifact-name "$RMUX_ASSETS_ARTIFACT_NAME" \
+          --assets-artifact-digest "$RMUX_ASSETS_ARTIFACT_DIGEST" \
+          --build-record "$provenance/canonical-build-record.json" \
+          --build-record-sha256 "$RMUX_BUILD_RECORD_SHA256" \
+          --attestation-id "$RMUX_ATTESTATION_ID" \
+          --attestation-bundle "$provenance/build-provenance.sigstore.json" \
+          --output "$provenance/canonical-artifact-binding.json"
+
+    - id: provenance-upload
+      name: Persist provenance separately from public assets
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+      with:
+        name: rmux-canonical-provenance-${{ inputs.platform-key }}-${{ inputs.expected-source-sha }}
+        path: ${{ runner.temp }}/rmux-canonical-provenance
+        if-no-files-found: error
+        retention-days: 7
+        compression-level: 0
+
+    - id: provenance-api
+      name: Resolve the persisted provenance by numeric ID
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        RMUX_EXPECTED_SOURCE_SHA: ${{ inputs.expected-source-sha }}
+        RMUX_PROVENANCE_ARTIFACT_ID: ${{ steps.provenance-upload.outputs.artifact-id }}
+        RMUX_PROVENANCE_ARTIFACT_NAME: rmux-canonical-provenance-${{ inputs.platform-key }}-${{ inputs.expected-source-sha }}
+      run: |
+        set -euo pipefail
+        scripts/release/actions-artifact.py resolve-id \
+          --repository "$GITHUB_REPOSITORY" \
+          --run-id "$GITHUB_RUN_ID" \
+          --artifact-id "$RMUX_PROVENANCE_ARTIFACT_ID" \
+          --name "$RMUX_PROVENANCE_ARTIFACT_NAME" \
+          --expected-source-sha "$RMUX_EXPECTED_SOURCE_SHA" \
+          --max-attempts 6 \
+          --retry-delay-seconds 2 \
+          --github-output "$GITHUB_OUTPUT"

--- a/.github/actions/canonical-smoke/action.yml
+++ b/.github/actions/canonical-smoke/action.yml
@@ -1,0 +1,244 @@
+name: Smoke one persisted canonical RMUX bundle
+description: Download by numeric artifact ID, verify every byte, then run a native smoke
+
+inputs:
+  expected-source-sha:
+    description: Exact protected main commit represented by the artifacts
+    required: true
+  fast-run-id:
+    description: Numeric Actions run ID containing the accepted fast archive
+    required: true
+  fast-nextest-artifact-id:
+    description: Numeric artifact ID of the exact Windows Nextest archive
+    required: true
+  fast-nextest-artifact-digest:
+    description: Actions archive digest of the Windows Nextest artifact
+    required: true
+  release-intent-id:
+    description: Unique allowlisted identifier for this release intent
+    required: true
+  planned-release-ref:
+    description: Planned stable or release-candidate tag name
+    required: true
+  release-kind:
+    description: Shadow, release-candidate, or stable intent kind
+    required: true
+  platform-key:
+    description: Contracted canonical platform key
+    required: true
+  assets-artifact-id:
+    description: Numeric ID of the persisted canonical asset artifact
+    required: true
+  assets-artifact-name:
+    description: SHA-scoped name of the persisted canonical asset artifact
+    required: true
+  assets-artifact-digest:
+    description: Actions archive digest of the canonical asset artifact
+    required: true
+  expected-build-record-sha256:
+    description: SHA-256 emitted by the canonical build job for its build record
+    required: true
+  smoke-kind:
+    description: Contracted package, runtime, SDK, or mouse smoke kind
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Verify the literal GitHub-hosted smoke allocation
+      shell: bash
+      env:
+        RMUX_PLATFORM_KEY: ${{ inputs.platform-key }}
+      run: |
+        set -euo pipefail
+        test "$RUNNER_ENVIRONMENT" = github-hosted
+        python3 - "$RMUX_PLATFORM_KEY" "$RUNNER_OS" "$RUNNER_ARCH" <<'PY'
+        import json
+        import pathlib
+        import sys
+
+        contract = json.loads(pathlib.Path(".github/release/canonical-build-contract.json").read_text())
+        matches = [entry for entry in contract["platforms"] if entry["key"] == sys.argv[1]]
+        if len(matches) != 1:
+            raise SystemExit("canonical smoke platform key is not unique")
+        observed = (sys.argv[2], sys.argv[3])
+        expected = (matches[0]["runner_os"], matches[0]["runner_arch"])
+        if observed != expected:
+            raise SystemExit(f"canonical smoke runner differs: {observed!r} != {expected!r}")
+        PY
+
+    - name: Verify the current-run artifact identity
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        RMUX_ASSETS_ARTIFACT_DIGEST: ${{ inputs.assets-artifact-digest }}
+        RMUX_ASSETS_ARTIFACT_ID: ${{ inputs.assets-artifact-id }}
+        RMUX_ASSETS_ARTIFACT_NAME: ${{ inputs.assets-artifact-name }}
+        RMUX_EXPECTED_SOURCE_SHA: ${{ inputs.expected-source-sha }}
+      run: |
+        set -euo pipefail
+        scripts/release/actions-artifact.py verify \
+          --repository "$GITHUB_REPOSITORY" \
+          --run-id "$GITHUB_RUN_ID" \
+          --artifact-id "$RMUX_ASSETS_ARTIFACT_ID" \
+          --name "$RMUX_ASSETS_ARTIFACT_NAME" \
+          --expected-digest "$RMUX_ASSETS_ARTIFACT_DIGEST" \
+          --expected-source-sha "$RMUX_EXPECTED_SOURCE_SHA"
+
+    - name: Download only the persisted asset artifact ID
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+      with:
+        artifact-ids: ${{ inputs.assets-artifact-id }}
+        path: ${{ runner.temp }}/rmux-canonical-download
+
+    - name: Verify the build record and all downloaded bytes
+      shell: bash
+      env:
+        RMUX_EXPECTED_BUILD_RECORD_SHA256: ${{ inputs.expected-build-record-sha256 }}
+        RMUX_EXPECTED_SOURCE_SHA: ${{ inputs.expected-source-sha }}
+        RMUX_FAST_RUN_ID: ${{ inputs.fast-run-id }}
+        RMUX_RELEASE_INTENT_ID: ${{ inputs.release-intent-id }}
+        RMUX_PLANNED_RELEASE_REF: ${{ inputs.planned-release-ref }}
+        RMUX_RELEASE_KIND: ${{ inputs.release-kind }}
+        RMUX_PLATFORM_KEY: ${{ inputs.platform-key }}
+      run: |
+        set -euo pipefail
+        scripts/release/canonical-build-record.py verify \
+          --source-sha "$RMUX_EXPECTED_SOURCE_SHA" \
+          --fast-run-id "$RMUX_FAST_RUN_ID" \
+          --candidate-run-id "$GITHUB_RUN_ID" \
+          --release-intent-id "$RMUX_RELEASE_INTENT_ID" \
+          --planned-release-ref "$RMUX_PLANNED_RELEASE_REF" \
+          --release-kind "$RMUX_RELEASE_KIND" \
+          --platform-key "$RMUX_PLATFORM_KEY" \
+          --assets-dir "$RUNNER_TEMP/rmux-canonical-download/assets" \
+          --record "$RUNNER_TEMP/rmux-canonical-download/canonical-build-record.json" \
+          --expected-record-sha256 "$RMUX_EXPECTED_BUILD_RECORD_SHA256"
+
+    - name: Install Linux verification tools
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y rpm
+
+    - name: Smoke persisted Unix packages
+      if: runner.os != 'Windows'
+      shell: bash
+      run: |
+        set -euo pipefail
+        assets="$RUNNER_TEMP/rmux-canonical-download/assets"
+        set -- "$assets"/rmux-*.tar.gz
+        test "$#" = 1
+        test -f "$1"
+        scripts/verify-package.sh "$1" \
+          --checksums "$assets/SHA256SUMS.txt" \
+          --run-binary \
+          --require-release-artifact
+        if [[ "$RUNNER_OS" == Linux ]]; then
+          set -- "$assets"/rmux_*.deb
+          test "$#" = 1
+          test -f "$1"
+          scripts/verify-debian-package.sh "$1" \
+            --checksums "$assets/SHA256SUMS.txt" \
+            --run-binary \
+            --require-release-artifact
+          set -- "$assets"/rmux-*.rpm
+          test "$#" = 1
+          test -f "$1"
+          scripts/verify-rpm-package.sh "$1" \
+            --checksums "$assets/SHA256SUMS.txt" \
+            --run-binary \
+            --require-release-artifact
+        fi
+
+    - name: Verify the exact fast Windows driver artifact
+      if: runner.os == 'Windows' && inputs.smoke-kind != 'runtime'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        RMUX_EXPECTED_SOURCE_SHA: ${{ inputs.expected-source-sha }}
+        RMUX_FAST_NEXTEST_DIGEST: ${{ inputs.fast-nextest-artifact-digest }}
+        RMUX_FAST_NEXTEST_ID: ${{ inputs.fast-nextest-artifact-id }}
+        RMUX_FAST_RUN_ID: ${{ inputs.fast-run-id }}
+      run: |
+        set -euo pipefail
+        scripts/release/actions-artifact.py verify \
+          --repository "$GITHUB_REPOSITORY" \
+          --run-id "$RMUX_FAST_RUN_ID" \
+          --artifact-id "$RMUX_FAST_NEXTEST_ID" \
+          --name "rmux-windows-nextest-$RMUX_EXPECTED_SOURCE_SHA" \
+          --expected-digest "$RMUX_FAST_NEXTEST_DIGEST" \
+          --expected-source-sha "$RMUX_EXPECTED_SOURCE_SHA"
+
+    - name: Download exact fast Windows test drivers
+      if: runner.os == 'Windows' && inputs.smoke-kind != 'runtime'
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+      with:
+        artifact-ids: ${{ inputs.fast-nextest-artifact-id }}
+        path: ${{ runner.temp }}/rmux-fast-nextest
+        github-token: ${{ github.token }}
+        repository: ${{ github.repository }}
+        run-id: ${{ inputs.fast-run-id }}
+
+    - name: Verify exact fast Windows test driver bytes
+      if: runner.os == 'Windows' && inputs.smoke-kind != 'runtime'
+      shell: bash
+      run: |
+        set -euo pipefail
+        cd "$RUNNER_TEMP/rmux-fast-nextest"
+        test -f windows-nextest.tar.zst
+        test -f windows-nextest.tar.zst.sha256
+        sha256sum --check windows-nextest.tar.zst.sha256
+
+    - name: Smoke persisted Windows runtime bytes
+      if: runner.os == 'Windows' && inputs.smoke-kind == 'runtime'
+      shell: pwsh
+      env:
+        RMUX_EXPECTED_GIT_SHA: ${{ inputs.expected-source-sha }}
+      run: |
+        $assets = "$env:RUNNER_TEMP/rmux-canonical-download/assets"
+        $archives = @(Get-ChildItem -LiteralPath $assets -Filter "rmux-*.zip")
+        if ($archives.Count -ne 1) { throw "expected one canonical Windows ZIP" }
+        ./scripts/verify-package-windows.ps1 `
+          -Archive $archives[0].FullName `
+          -Checksums "$assets/SHA256SUMS.txt" `
+          -RunBinary `
+          -RunDaemonSmoke `
+          -RunCtrlMatrixSmoke `
+          -RequireReleaseArtifact `
+          -ExpectedGitSha $env:RMUX_EXPECTED_GIT_SHA
+
+    - name: Smoke persisted Windows SDK bytes
+      if: runner.os == 'Windows' && inputs.smoke-kind == 'sdk'
+      shell: pwsh
+      env:
+        RMUX_EXPECTED_GIT_SHA: ${{ inputs.expected-source-sha }}
+      run: |
+        $assets = "$env:RUNNER_TEMP/rmux-canonical-download/assets"
+        $archives = @(Get-ChildItem -LiteralPath $assets -Filter "rmux-*.zip")
+        if ($archives.Count -ne 1) { throw "expected one canonical Windows ZIP" }
+        ./scripts/verify-package-windows.ps1 `
+          -Archive $archives[0].FullName `
+          -Checksums "$assets/SHA256SUMS.txt" `
+          -RunSdkSmoke `
+          -RequireReleaseArtifact `
+          -ExpectedGitSha $env:RMUX_EXPECTED_GIT_SHA `
+          -NextestArchive "$env:RUNNER_TEMP/rmux-fast-nextest/windows-nextest.tar.zst"
+
+    - name: Smoke persisted Windows mouse bytes
+      if: runner.os == 'Windows' && inputs.smoke-kind == 'mouse'
+      shell: pwsh
+      env:
+        RMUX_EXPECTED_GIT_SHA: ${{ inputs.expected-source-sha }}
+      run: |
+        $assets = "$env:RUNNER_TEMP/rmux-canonical-download/assets"
+        $archives = @(Get-ChildItem -LiteralPath $assets -Filter "rmux-*.zip")
+        if ($archives.Count -ne 1) { throw "expected one canonical Windows ZIP" }
+        ./scripts/verify-package-windows.ps1 `
+          -Archive $archives[0].FullName `
+          -Checksums "$assets/SHA256SUMS.txt" `
+          -RunMouseBorderSmoke `
+          -RequireReleaseArtifact `
+          -ExpectedGitSha $env:RMUX_EXPECTED_GIT_SHA `
+          -NextestArchive "$env:RUNNER_TEMP/rmux-fast-nextest/windows-nextest.tar.zst"

--- a/.github/release/candidate-contract.json
+++ b/.github/release/candidate-contract.json
@@ -11,6 +11,7 @@
     "runner_group_id": 0,
     "runner_group_name": "GitHub Actions",
     "non_runner_jobs": [
+      "Build canonical native artifacts",
       "Run release-only candidate delta"
     ],
     "jobs_by_label": {
@@ -36,6 +37,7 @@
         "Nix flake gate",
         "Platform build and smoke on windows-latest",
         "Release candidate delta gate",
+        "Release candidate gate",
         "Release review (${{ matrix.section }})",
         "Release review (cli)",
         "Release review (lint)",
@@ -129,9 +131,11 @@
       "Windows workspace tests (18/18)"
     ],
     "skipped_jobs": [
+      "Build canonical native artifacts",
       "Native Windows runtime smoke",
       "Nix flake gate",
       "Release candidate delta gate",
+      "Release candidate gate",
       "Release review (${{ matrix.section }})",
       "Release review (perf)",
       "Release review gate (no package)",
@@ -216,14 +220,20 @@
   "policy_paths": [
     ".config/nextest.toml",
     ".github/CODEOWNERS",
+    ".github/actions/canonical-build/action.yml",
+    ".github/actions/canonical-smoke/action.yml",
     ".github/release/candidate-contract.json",
     ".github/release/candidate-workflow-contract.json",
+    ".github/release/canonical-build-contract.json",
     ".github/release/channel-policy.json",
     ".github/release/measurement-budget.json",
     ".github/release/schemas/candidate-manifest.schema.json",
+    ".github/release/schemas/canonical-artifact-binding.schema.json",
+    ".github/release/schemas/canonical-build-record.schema.json",
     ".github/release/schemas/promotion-authorization.schema.json",
     ".github/release/schemas/publication-receipt.schema.json",
     ".github/release/windows-coverage-contract.json",
+    ".github/workflows/canonical-native-build.yml",
     ".github/workflows/ci.yml",
     ".github/workflows/publish-chocolatey.yml",
     ".github/workflows/release-candidate-delta.yml",
@@ -293,6 +303,10 @@
     "scripts/release-local.sh",
     "scripts/release-review-gate-windows.ps1",
     "scripts/release-review-gate.sh",
+    "scripts/release/actions-artifact.py",
+    "scripts/release/canonical-artifact-binding.py",
+    "scripts/release/canonical-build-record.py",
+    "scripts/release/canonical_contract.py",
     "scripts/release/dispatch-release-candidate.sh",
     "scripts/release/dispatch-shadow-candidate.sh",
     "scripts/release/github_actions.py",
@@ -335,6 +349,7 @@
     "tests/reference/tmux_compat/frozen_reference.yaml",
     "tests/release_automation_spec.rs",
     "tests/release_candidate_spec.rs",
+    "tests/release_canonical_build_spec.rs",
     "tests/release_proof_adversarial_spec.rs",
     "tests/release_shadow_spec.rs"
   ]

--- a/.github/release/candidate-workflow-contract.json
+++ b/.github/release/candidate-workflow-contract.json
@@ -37,6 +37,15 @@
       "windows-ctrl-matrix"
     ]
   },
+  "canonical_builds": {
+    "contract": ".github/release/canonical-build-contract.json",
+    "workflow": ".github/workflows/canonical-native-build.yml",
+    "native_platforms": 5,
+    "windows_smokes": ["mouse", "runtime", "sdk"],
+    "artifact_retention_days": 7,
+    "download_by_artifact_id": true,
+    "object_cache_restored": false
+  },
   "publication": {
     "enabled": false,
     "public_triggers": false,

--- a/.github/release/canonical-build-contract.json
+++ b/.github/release/canonical-build-contract.json
@@ -1,0 +1,69 @@
+{
+  "schema_version": 1,
+  "status": "review-only-non-publishing",
+  "repository_id": 1239918790,
+  "workflow": {
+    "id": 277622540,
+    "path": ".github/workflows/ci.yml",
+    "event": "workflow_dispatch",
+    "branch": "main",
+    "required_attempt": 1
+  },
+  "reusable_workflow": ".github/workflows/canonical-native-build.yml",
+  "rust_toolchain": "1.96.1",
+  "artifact_retention_days": 7,
+  "build_policy": {
+    "cargo_incremental": false,
+    "cargo_locked": true,
+    "fresh_target": true,
+    "object_cache_restored": false,
+    "publication_authority": false
+  },
+  "platforms": [
+    {
+      "key": "linux-x86_64",
+      "runner_image": "ubuntu-22.04",
+      "runner_os": "Linux",
+      "runner_arch": "X64",
+      "target_triple": "x86_64-unknown-linux-gnu",
+      "archive_format": "tar.gz",
+      "linux_packages": true
+    },
+    {
+      "key": "linux-aarch64",
+      "runner_image": "ubuntu-22.04-arm",
+      "runner_os": "Linux",
+      "runner_arch": "ARM64",
+      "target_triple": "aarch64-unknown-linux-gnu",
+      "archive_format": "tar.gz",
+      "linux_packages": true
+    },
+    {
+      "key": "macos-x86_64",
+      "runner_image": "macos-15-intel",
+      "runner_os": "macOS",
+      "runner_arch": "X64",
+      "target_triple": "x86_64-apple-darwin",
+      "archive_format": "tar.gz",
+      "linux_packages": false
+    },
+    {
+      "key": "macos-aarch64",
+      "runner_image": "macos-15",
+      "runner_os": "macOS",
+      "runner_arch": "ARM64",
+      "target_triple": "aarch64-apple-darwin",
+      "archive_format": "tar.gz",
+      "linux_packages": false
+    },
+    {
+      "key": "windows-x86_64",
+      "runner_image": "windows-latest",
+      "runner_os": "Windows",
+      "runner_arch": "X64",
+      "target_triple": "x86_64-pc-windows-msvc",
+      "archive_format": "zip",
+      "linux_packages": false
+    }
+  ]
+}

--- a/.github/release/schemas/candidate-manifest.schema.json
+++ b/.github/release/schemas/candidate-manifest.schema.json
@@ -95,9 +95,17 @@
           "artifact_id": {"type": "integer", "minimum": 1},
           "name": {"type": "string", "minLength": 1},
           "archive_digest": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
-          "target_triple": {"type": "string", "pattern": "^[A-Za-z0-9_][A-Za-z0-9_.-]{2,63}$"},
+          "target_triple": {
+            "enum": [
+              "aarch64-apple-darwin",
+              "aarch64-unknown-linux-gnu",
+              "x86_64-apple-darwin",
+              "x86_64-pc-windows-msvc",
+              "x86_64-unknown-linux-gnu"
+            ]
+          },
           "runner_image": {
-            "enum": ["macos-15", "macos-15-intel", "ubuntu-latest", "windows-latest"]
+            "enum": ["macos-15", "macos-15-intel", "ubuntu-22.04", "ubuntu-22.04-arm", "windows-latest"]
           },
           "rust_toolchain": {"type": "string", "minLength": 1, "maxLength": 128},
           "rustc_vv_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
@@ -116,7 +124,29 @@
               }
             }
           }
-        }
+        },
+        "allOf": [
+          {
+            "if": {"properties": {"target_triple": {"const": "x86_64-unknown-linux-gnu"}}, "required": ["target_triple"]},
+            "then": {"properties": {"runner_image": {"const": "ubuntu-22.04"}}}
+          },
+          {
+            "if": {"properties": {"target_triple": {"const": "aarch64-unknown-linux-gnu"}}, "required": ["target_triple"]},
+            "then": {"properties": {"runner_image": {"const": "ubuntu-22.04-arm"}}}
+          },
+          {
+            "if": {"properties": {"target_triple": {"const": "x86_64-apple-darwin"}}, "required": ["target_triple"]},
+            "then": {"properties": {"runner_image": {"const": "macos-15-intel"}}}
+          },
+          {
+            "if": {"properties": {"target_triple": {"const": "aarch64-apple-darwin"}}, "required": ["target_triple"]},
+            "then": {"properties": {"runner_image": {"const": "macos-15"}}}
+          },
+          {
+            "if": {"properties": {"target_triple": {"const": "x86_64-pc-windows-msvc"}}, "required": ["target_triple"]},
+            "then": {"properties": {"runner_image": {"const": "windows-latest"}}}
+          }
+        ]
       }
     }
   },

--- a/.github/release/schemas/canonical-artifact-binding.schema.json
+++ b/.github/release/schemas/canonical-artifact-binding.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rmux.io/schemas/canonical-artifact-binding-v1.json",
+  "title": "RMUX post-upload canonical artifact binding",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "repository_id",
+    "source_git_sha",
+    "candidate_run_id",
+    "platform_key",
+    "assets",
+    "build_record_sha256",
+    "attestation"
+  ],
+  "properties": {
+    "schema_version": {"const": 1},
+    "repository_id": {"const": 1239918790},
+    "source_git_sha": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+    "candidate_run_id": {"type": "integer", "minimum": 1},
+    "platform_key": {"enum": ["linux-x86_64", "linux-aarch64", "macos-x86_64", "macos-aarch64", "windows-x86_64"]},
+    "assets": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["artifact_id", "artifact_name", "artifact_digest"],
+      "properties": {
+        "artifact_id": {"type": "integer", "minimum": 1},
+        "artifact_name": {"type": "string", "pattern": "^rmux-canonical-[A-Za-z0-9._-]+-[0-9a-f]{40}$"},
+        "artifact_digest": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"}
+      }
+    },
+    "build_record_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "attestation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["attestation_id", "bundle_file", "bundle_sha256"],
+      "properties": {
+        "attestation_id": {"type": "string", "minLength": 1, "maxLength": 256},
+        "bundle_file": {"const": "build-provenance.sigstore.json"},
+        "bundle_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+      }
+    }
+  }
+}

--- a/.github/release/schemas/canonical-build-record.schema.json
+++ b/.github/release/schemas/canonical-build-record.schema.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rmux.io/schemas/canonical-build-record-v1.json",
+  "title": "RMUX canonical native build record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "repository_id",
+    "source_git_sha",
+    "fast_run_id",
+    "candidate_run_id",
+    "candidate_run_attempt",
+    "release_intent_id",
+    "planned_release_ref",
+    "release_kind",
+    "platform",
+    "runner",
+    "toolchain",
+    "build_policy",
+    "created_at",
+    "files"
+  ],
+  "properties": {
+    "schema_version": {"const": 1},
+    "repository_id": {"const": 1239918790},
+    "source_git_sha": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+    "fast_run_id": {"type": "integer", "minimum": 1},
+    "candidate_run_id": {"type": "integer", "minimum": 1},
+    "candidate_run_attempt": {"const": 1},
+    "release_intent_id": {"type": "string", "pattern": "^[A-Za-z0-9._:-]{8,128}$"},
+    "planned_release_ref": {"type": "string", "pattern": "^v[0-9]+\\.[0-9]+\\.[0-9]+(?:-rc\\.[0-9]+)?$"},
+    "release_kind": {"enum": ["shadow", "rc", "stable"]},
+    "platform": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["key", "target_triple", "archive_format"],
+      "properties": {
+        "key": {"enum": ["linux-x86_64", "linux-aarch64", "macos-x86_64", "macos-aarch64", "windows-x86_64"]},
+        "target_triple": {"enum": ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "aarch64-apple-darwin", "x86_64-pc-windows-msvc"]},
+        "archive_format": {"enum": ["tar.gz", "zip"]}
+      }
+    },
+    "runner": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["image", "os", "arch", "environment"],
+      "properties": {
+        "image": {"enum": ["ubuntu-22.04", "ubuntu-22.04-arm", "macos-15-intel", "macos-15", "windows-latest"]},
+        "os": {"enum": ["Linux", "macOS", "Windows"]},
+        "arch": {"enum": ["X64", "ARM64"]},
+        "environment": {"const": "github-hosted"}
+      }
+    },
+    "toolchain": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["requested", "release", "host", "commit_hash", "rustc_verbose_sha256"],
+      "properties": {
+        "requested": {"const": "1.96.1"},
+        "release": {"const": "1.96.1"},
+        "host": {"enum": ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "aarch64-apple-darwin", "x86_64-pc-windows-msvc"]},
+        "commit_hash": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+        "rustc_verbose_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+      }
+    },
+    "build_policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["fresh_target", "cargo_incremental", "cargo_locked", "object_cache_restored", "publication_authority"],
+      "properties": {
+        "fresh_target": {"const": true},
+        "cargo_incremental": {"const": false},
+        "cargo_locked": {"const": true},
+        "object_cache_restored": {"const": false},
+        "publication_authority": {"const": false}
+      }
+    },
+    "created_at": {"type": "string", "format": "date-time"},
+    "files": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["path", "role", "size", "sha256"],
+        "properties": {
+          "path": {"type": "string", "pattern": "^(?!/)(?!.*(?:^|/)\\.\\.(?:/|$))[A-Za-z0-9._+@=-]+(?:/[A-Za-z0-9._+@=-]+)*$"},
+          "role": {"enum": ["archive", "checksums", "debian", "rpm"]},
+          "size": {"type": "integer", "minimum": 1},
+          "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+        }
+      }
+    }
+  }
+}

--- a/.github/workflows/canonical-native-build.yml
+++ b/.github/workflows/canonical-native-build.yml
@@ -1,0 +1,403 @@
+name: Canonical native builds
+
+on:
+  workflow_call:
+    inputs:
+      expected_source_sha:
+        required: true
+        type: string
+      fast_run_id:
+        required: true
+        type: string
+      fast_nextest_artifact_id:
+        required: true
+        type: string
+      fast_nextest_artifact_digest:
+        required: true
+        type: string
+      release_intent_id:
+        required: true
+        type: string
+      planned_release_ref:
+        required: true
+        type: string
+      release_kind:
+        required: true
+        type: string
+
+permissions: {}
+
+jobs:
+  build-linux-x86-64:
+    name: Canonical build linux-x86_64
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
+    permissions:
+      actions: read
+      attestations: write
+      contents: read
+      id-token: write
+    env:
+      CARGO_INCREMENTAL: "0"
+      CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_RUSTFLAGS: "-C target-feature=+crt-static"
+    outputs:
+      assets_id: ${{ steps.build.outputs.assets-artifact-id }}
+      assets_digest: ${{ steps.build.outputs.assets-artifact-digest }}
+      assets_name: ${{ steps.build.outputs.assets-artifact-name }}
+      provenance_id: ${{ steps.build.outputs.provenance-artifact-id }}
+      provenance_digest: ${{ steps.build.outputs.provenance-artifact-digest }}
+      attestation_id: ${{ steps.build.outputs.attestation-id }}
+      record_sha256: ${{ steps.build.outputs.build-record-sha256 }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+      - id: build
+        uses: ./.github/actions/canonical-build
+        with:
+          expected-source-sha: ${{ inputs.expected_source_sha }}
+          fast-run-id: ${{ inputs.fast_run_id }}
+          release-intent-id: ${{ inputs.release_intent_id }}
+          planned-release-ref: ${{ inputs.planned_release_ref }}
+          release-kind: ${{ inputs.release_kind }}
+          platform-key: linux-x86_64
+          runner-image: ubuntu-22.04
+          target-triple: x86_64-unknown-linux-gnu
+
+  build-linux-aarch64:
+    name: Canonical build linux-aarch64
+    runs-on: ubuntu-22.04-arm
+    timeout-minutes: 60
+    permissions:
+      actions: read
+      attestations: write
+      contents: read
+      id-token: write
+    env:
+      CARGO_INCREMENTAL: "0"
+      CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_RUSTFLAGS: "-C target-feature=+crt-static"
+    outputs:
+      assets_id: ${{ steps.build.outputs.assets-artifact-id }}
+      assets_digest: ${{ steps.build.outputs.assets-artifact-digest }}
+      assets_name: ${{ steps.build.outputs.assets-artifact-name }}
+      provenance_id: ${{ steps.build.outputs.provenance-artifact-id }}
+      provenance_digest: ${{ steps.build.outputs.provenance-artifact-digest }}
+      attestation_id: ${{ steps.build.outputs.attestation-id }}
+      record_sha256: ${{ steps.build.outputs.build-record-sha256 }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+      - id: build
+        uses: ./.github/actions/canonical-build
+        with:
+          expected-source-sha: ${{ inputs.expected_source_sha }}
+          fast-run-id: ${{ inputs.fast_run_id }}
+          release-intent-id: ${{ inputs.release_intent_id }}
+          planned-release-ref: ${{ inputs.planned_release_ref }}
+          release-kind: ${{ inputs.release_kind }}
+          platform-key: linux-aarch64
+          runner-image: ubuntu-22.04-arm
+          target-triple: aarch64-unknown-linux-gnu
+
+  build-macos-x86-64:
+    name: Canonical build macos-x86_64
+    runs-on: macos-15-intel
+    timeout-minutes: 60
+    permissions:
+      actions: read
+      attestations: write
+      contents: read
+      id-token: write
+    env:
+      CARGO_INCREMENTAL: "0"
+      CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_RUSTFLAGS: "-C target-feature=+crt-static"
+    outputs:
+      assets_id: ${{ steps.build.outputs.assets-artifact-id }}
+      assets_digest: ${{ steps.build.outputs.assets-artifact-digest }}
+      assets_name: ${{ steps.build.outputs.assets-artifact-name }}
+      provenance_id: ${{ steps.build.outputs.provenance-artifact-id }}
+      provenance_digest: ${{ steps.build.outputs.provenance-artifact-digest }}
+      attestation_id: ${{ steps.build.outputs.attestation-id }}
+      record_sha256: ${{ steps.build.outputs.build-record-sha256 }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+      - id: build
+        uses: ./.github/actions/canonical-build
+        with:
+          expected-source-sha: ${{ inputs.expected_source_sha }}
+          fast-run-id: ${{ inputs.fast_run_id }}
+          release-intent-id: ${{ inputs.release_intent_id }}
+          planned-release-ref: ${{ inputs.planned_release_ref }}
+          release-kind: ${{ inputs.release_kind }}
+          platform-key: macos-x86_64
+          runner-image: macos-15-intel
+          target-triple: x86_64-apple-darwin
+
+  build-macos-aarch64:
+    name: Canonical build macos-aarch64
+    runs-on: macos-15
+    timeout-minutes: 60
+    permissions:
+      actions: read
+      attestations: write
+      contents: read
+      id-token: write
+    env:
+      CARGO_INCREMENTAL: "0"
+      CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_RUSTFLAGS: "-C target-feature=+crt-static"
+    outputs:
+      assets_id: ${{ steps.build.outputs.assets-artifact-id }}
+      assets_digest: ${{ steps.build.outputs.assets-artifact-digest }}
+      assets_name: ${{ steps.build.outputs.assets-artifact-name }}
+      provenance_id: ${{ steps.build.outputs.provenance-artifact-id }}
+      provenance_digest: ${{ steps.build.outputs.provenance-artifact-digest }}
+      attestation_id: ${{ steps.build.outputs.attestation-id }}
+      record_sha256: ${{ steps.build.outputs.build-record-sha256 }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+      - id: build
+        uses: ./.github/actions/canonical-build
+        with:
+          expected-source-sha: ${{ inputs.expected_source_sha }}
+          fast-run-id: ${{ inputs.fast_run_id }}
+          release-intent-id: ${{ inputs.release_intent_id }}
+          planned-release-ref: ${{ inputs.planned_release_ref }}
+          release-kind: ${{ inputs.release_kind }}
+          platform-key: macos-aarch64
+          runner-image: macos-15
+          target-triple: aarch64-apple-darwin
+
+  build-windows-x86-64:
+    name: Canonical build windows-x86_64
+    runs-on: windows-latest
+    timeout-minutes: 60
+    permissions:
+      actions: read
+      attestations: write
+      contents: read
+      id-token: write
+    env:
+      CARGO_INCREMENTAL: "0"
+      CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_RUSTFLAGS: "-C target-feature=+crt-static"
+    outputs:
+      assets_id: ${{ steps.build.outputs.assets-artifact-id }}
+      assets_digest: ${{ steps.build.outputs.assets-artifact-digest }}
+      assets_name: ${{ steps.build.outputs.assets-artifact-name }}
+      provenance_id: ${{ steps.build.outputs.provenance-artifact-id }}
+      provenance_digest: ${{ steps.build.outputs.provenance-artifact-digest }}
+      attestation_id: ${{ steps.build.outputs.attestation-id }}
+      record_sha256: ${{ steps.build.outputs.build-record-sha256 }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+      - id: build
+        uses: ./.github/actions/canonical-build
+        with:
+          expected-source-sha: ${{ inputs.expected_source_sha }}
+          fast-run-id: ${{ inputs.fast_run_id }}
+          release-intent-id: ${{ inputs.release_intent_id }}
+          planned-release-ref: ${{ inputs.planned_release_ref }}
+          release-kind: ${{ inputs.release_kind }}
+          platform-key: windows-x86_64
+          runner-image: windows-latest
+          target-triple: x86_64-pc-windows-msvc
+
+  smoke-linux-x86-64:
+    name: Canonical smoke linux-x86_64
+    needs: build-linux-x86-64
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+      - uses: ./.github/actions/canonical-smoke
+        with:
+          expected-source-sha: ${{ inputs.expected_source_sha }}
+          fast-run-id: ${{ inputs.fast_run_id }}
+          fast-nextest-artifact-id: ${{ inputs.fast_nextest_artifact_id }}
+          fast-nextest-artifact-digest: ${{ inputs.fast_nextest_artifact_digest }}
+          release-intent-id: ${{ inputs.release_intent_id }}
+          planned-release-ref: ${{ inputs.planned_release_ref }}
+          release-kind: ${{ inputs.release_kind }}
+          platform-key: linux-x86_64
+          assets-artifact-id: ${{ needs.build-linux-x86-64.outputs.assets_id }}
+          assets-artifact-name: ${{ needs.build-linux-x86-64.outputs.assets_name }}
+          assets-artifact-digest: ${{ needs.build-linux-x86-64.outputs.assets_digest }}
+          expected-build-record-sha256: ${{ needs.build-linux-x86-64.outputs.record_sha256 }}
+          smoke-kind: package
+
+  smoke-linux-aarch64:
+    name: Canonical smoke linux-aarch64
+    needs: build-linux-aarch64
+    runs-on: ubuntu-22.04-arm
+    timeout-minutes: 20
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+      - uses: ./.github/actions/canonical-smoke
+        with:
+          expected-source-sha: ${{ inputs.expected_source_sha }}
+          fast-run-id: ${{ inputs.fast_run_id }}
+          fast-nextest-artifact-id: ${{ inputs.fast_nextest_artifact_id }}
+          fast-nextest-artifact-digest: ${{ inputs.fast_nextest_artifact_digest }}
+          release-intent-id: ${{ inputs.release_intent_id }}
+          planned-release-ref: ${{ inputs.planned_release_ref }}
+          release-kind: ${{ inputs.release_kind }}
+          platform-key: linux-aarch64
+          assets-artifact-id: ${{ needs.build-linux-aarch64.outputs.assets_id }}
+          assets-artifact-name: ${{ needs.build-linux-aarch64.outputs.assets_name }}
+          assets-artifact-digest: ${{ needs.build-linux-aarch64.outputs.assets_digest }}
+          expected-build-record-sha256: ${{ needs.build-linux-aarch64.outputs.record_sha256 }}
+          smoke-kind: package
+
+  smoke-macos-x86-64:
+    name: Canonical smoke macos-x86_64
+    needs: build-macos-x86-64
+    runs-on: macos-15-intel
+    timeout-minutes: 20
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+      - uses: ./.github/actions/canonical-smoke
+        with:
+          expected-source-sha: ${{ inputs.expected_source_sha }}
+          fast-run-id: ${{ inputs.fast_run_id }}
+          fast-nextest-artifact-id: ${{ inputs.fast_nextest_artifact_id }}
+          fast-nextest-artifact-digest: ${{ inputs.fast_nextest_artifact_digest }}
+          release-intent-id: ${{ inputs.release_intent_id }}
+          planned-release-ref: ${{ inputs.planned_release_ref }}
+          release-kind: ${{ inputs.release_kind }}
+          platform-key: macos-x86_64
+          assets-artifact-id: ${{ needs.build-macos-x86-64.outputs.assets_id }}
+          assets-artifact-name: ${{ needs.build-macos-x86-64.outputs.assets_name }}
+          assets-artifact-digest: ${{ needs.build-macos-x86-64.outputs.assets_digest }}
+          expected-build-record-sha256: ${{ needs.build-macos-x86-64.outputs.record_sha256 }}
+          smoke-kind: package
+
+  smoke-macos-aarch64:
+    name: Canonical smoke macos-aarch64
+    needs: build-macos-aarch64
+    runs-on: macos-15
+    timeout-minutes: 20
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+      - uses: ./.github/actions/canonical-smoke
+        with:
+          expected-source-sha: ${{ inputs.expected_source_sha }}
+          fast-run-id: ${{ inputs.fast_run_id }}
+          fast-nextest-artifact-id: ${{ inputs.fast_nextest_artifact_id }}
+          fast-nextest-artifact-digest: ${{ inputs.fast_nextest_artifact_digest }}
+          release-intent-id: ${{ inputs.release_intent_id }}
+          planned-release-ref: ${{ inputs.planned_release_ref }}
+          release-kind: ${{ inputs.release_kind }}
+          platform-key: macos-aarch64
+          assets-artifact-id: ${{ needs.build-macos-aarch64.outputs.assets_id }}
+          assets-artifact-name: ${{ needs.build-macos-aarch64.outputs.assets_name }}
+          assets-artifact-digest: ${{ needs.build-macos-aarch64.outputs.assets_digest }}
+          expected-build-record-sha256: ${{ needs.build-macos-aarch64.outputs.record_sha256 }}
+          smoke-kind: package
+
+  smoke-windows-x86-64:
+    name: Canonical smoke windows-x86_64 (${{ matrix.smoke }})
+    needs: build-windows-x86-64
+    runs-on: windows-latest
+    timeout-minutes: 20
+    permissions:
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix:
+        smoke: [runtime, sdk, mouse]
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+      - uses: ./.github/actions/canonical-smoke
+        with:
+          expected-source-sha: ${{ inputs.expected_source_sha }}
+          fast-run-id: ${{ inputs.fast_run_id }}
+          fast-nextest-artifact-id: ${{ inputs.fast_nextest_artifact_id }}
+          fast-nextest-artifact-digest: ${{ inputs.fast_nextest_artifact_digest }}
+          release-intent-id: ${{ inputs.release_intent_id }}
+          planned-release-ref: ${{ inputs.planned_release_ref }}
+          release-kind: ${{ inputs.release_kind }}
+          platform-key: windows-x86_64
+          assets-artifact-id: ${{ needs.build-windows-x86-64.outputs.assets_id }}
+          assets-artifact-name: ${{ needs.build-windows-x86-64.outputs.assets_name }}
+          assets-artifact-digest: ${{ needs.build-windows-x86-64.outputs.assets_digest }}
+          expected-build-record-sha256: ${{ needs.build-windows-x86-64.outputs.record_sha256 }}
+          smoke-kind: ${{ matrix.smoke }}
+
+  gate:
+    name: Canonical native build gate
+    if: always()
+    needs:
+      - build-linux-x86-64
+      - build-linux-aarch64
+      - build-macos-x86-64
+      - build-macos-aarch64
+      - build-windows-x86-64
+      - smoke-linux-x86-64
+      - smoke-linux-aarch64
+      - smoke-macos-x86-64
+      - smoke-macos-aarch64
+      - smoke-windows-x86-64
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - name: Require all canonical builds and exact-byte smokes
+        env:
+          BUILD_LINUX_X64: ${{ needs.build-linux-x86-64.result }}
+          BUILD_LINUX_ARM64: ${{ needs.build-linux-aarch64.result }}
+          BUILD_MACOS_X64: ${{ needs.build-macos-x86-64.result }}
+          BUILD_MACOS_ARM64: ${{ needs.build-macos-aarch64.result }}
+          BUILD_WINDOWS_X64: ${{ needs.build-windows-x86-64.result }}
+          SMOKE_LINUX_X64: ${{ needs.smoke-linux-x86-64.result }}
+          SMOKE_LINUX_ARM64: ${{ needs.smoke-linux-aarch64.result }}
+          SMOKE_MACOS_X64: ${{ needs.smoke-macos-x86-64.result }}
+          SMOKE_MACOS_ARM64: ${{ needs.smoke-macos-aarch64.result }}
+          SMOKE_WINDOWS_X64: ${{ needs.smoke-windows-x86-64.result }}
+        run: |
+          for result in \
+            "$BUILD_LINUX_X64" "$BUILD_LINUX_ARM64" \
+            "$BUILD_MACOS_X64" "$BUILD_MACOS_ARM64" "$BUILD_WINDOWS_X64" \
+            "$SMOKE_LINUX_X64" "$SMOKE_LINUX_ARM64" \
+            "$SMOKE_MACOS_X64" "$SMOKE_MACOS_ARM64" "$SMOKE_WINDOWS_X64"; do
+            test "$result" = success
+          done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,9 @@ jobs:
       CANDIDATE_RELEASE_INTENT_ID: ${{ inputs.release_intent_id }}
       CANDIDATE_PLANNED_RELEASE_REF: ${{ inputs.planned_release_ref }}
       CANDIDATE_RELEASE_KIND: ${{ inputs.release_kind }}
+    outputs:
+      fast_nextest_artifact_digest: ${{ steps.fast-nextest.outputs.artifact_digest }}
+      fast_nextest_artifact_id: ${{ steps.fast-nextest.outputs.artifact_id }}
     steps:
       - name: Reject untrusted candidate inputs before checkout
         shell: bash
@@ -128,12 +131,26 @@ jobs:
           --kind fast
           > fast-proof.json
 
+      - id: fast-nextest
+        name: Resolve the exact fast Windows test archive
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          scripts/release/actions-artifact.py resolve
+          --repository "$GITHUB_REPOSITORY"
+          --run-id "$CANDIDATE_FAST_RUN_ID"
+          --name "rmux-windows-nextest-$CANDIDATE_EXPECTED_SOURCE_SHA"
+          --expected-source-sha "$CANDIDATE_EXPECTED_SOURCE_SHA"
+          --github-output "$GITHUB_OUTPUT"
+          > fast-nextest-artifact.json
+
       - name: Upload immutable input proofs
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: rmux-fast-proof-${{ inputs.expected_source_sha }}
           path: |
             candidate-intent.json
+            fast-nextest-artifact.json
             fast-proof.json
           if-no-files-found: error
           retention-days: 7
@@ -166,6 +183,43 @@ jobs:
         run: |
           test "$FAST_PROOF_RESULT" = success
           test "$DELTA_RESULT" = success
+
+  release-canonical-native:
+    name: Build canonical native artifacts
+    if: github.event_name == 'workflow_dispatch' && inputs.release_qualification
+    needs: verify-fast-evidence
+    uses: ./.github/workflows/canonical-native-build.yml
+    with:
+      expected_source_sha: ${{ inputs.expected_source_sha }}
+      fast_run_id: ${{ inputs.fast_run_id }}
+      fast_nextest_artifact_id: ${{ needs.verify-fast-evidence.outputs.fast_nextest_artifact_id }}
+      fast_nextest_artifact_digest: ${{ needs.verify-fast-evidence.outputs.fast_nextest_artifact_digest }}
+      release_intent_id: ${{ inputs.release_intent_id }}
+      planned_release_ref: ${{ inputs.planned_release_ref }}
+      release_kind: ${{ inputs.release_kind }}
+    permissions:
+      actions: read
+      attestations: write
+      contents: read
+      id-token: write
+
+  release-candidate-gate:
+    name: Release candidate gate
+    if: >-
+      always() && github.event_name == 'workflow_dispatch' &&
+      inputs.release_qualification
+    needs: [release-candidate-delta-gate, release-canonical-native]
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - name: Require release delta and every canonical byte
+        env:
+          CANONICAL_RESULT: ${{ needs.release-canonical-native.result }}
+          DELTA_RESULT: ${{ needs.release-candidate-delta-gate.result }}
+        run: |
+          test "$DELTA_RESULT" = success
+          test "$CANONICAL_RESULT" = success
 
   linux-quality:
     name: Linux format, lint, and docs
@@ -878,11 +932,27 @@ jobs:
         if: steps.archive-cache.outputs.cache-hit != 'true'
         run: cargo nextest archive --workspace --locked --archive-file target/windows-nextest.tar.zst
 
+      - name: Bind the Windows test archive bytes
+        shell: pwsh
+        run: |
+          $archive = "target/windows-nextest.tar.zst"
+          if (-not (Test-Path -LiteralPath $archive -PathType Leaf)) {
+            throw "Windows Nextest archive is missing"
+          }
+          $digest = (Get-FileHash -Algorithm SHA256 -LiteralPath $archive).Hash.ToLowerInvariant()
+          [System.IO.File]::WriteAllText(
+            "$archive.sha256",
+            "$digest  windows-nextest.tar.zst`n",
+            [System.Text.Encoding]::ASCII
+          )
+
       - name: Upload Windows test archive
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: rmux-windows-nextest-${{ github.sha }}
-          path: target/windows-nextest.tar.zst
+          path: |
+            target/windows-nextest.tar.zst
+            target/windows-nextest.tar.zst.sha256
           if-no-files-found: error
           retention-days: 7
           compression-level: 0

--- a/scripts/release/actions-artifact.py
+++ b/scripts/release/actions-artifact.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Resolve or verify one immutable GitHub Actions artifact by numeric ID."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import time
+from pathlib import Path
+from typing import Any
+
+from github_actions import GitHubApiError, gh_api, read_json
+
+DIGEST = re.compile(r"sha256:[0-9a-f]{64}")
+SHA = re.compile(r"[0-9a-f]{40}")
+REPOSITORY = "Helvesec/rmux"
+REPOSITORY_ID = 1239918790
+
+
+def get_artifact_by_id(args: argparse.Namespace) -> dict[str, Any]:
+    if args.artifact_json:
+        value = read_json(args.artifact_json)
+        if isinstance(value, dict) and "artifacts" in value:
+            value = value["artifacts"]
+        if isinstance(value, list):
+            matches = [item for item in value if item.get("id") == args.artifact_id]
+            if len(matches) != 1:
+                raise ValueError(
+                    "artifact fixture must contain exactly one requested artifact ID"
+                )
+            value = matches[0]
+        if not isinstance(value, dict):
+            raise ValueError("artifact fixture must be an artifact object")
+        return value
+
+    for attempt in range(1, args.max_attempts + 1):
+        try:
+            value = gh_api(
+                f"repos/{args.repository}/actions/artifacts/{args.artifact_id}"
+            )
+        except GitHubApiError:
+            if attempt == args.max_attempts:
+                raise
+            time.sleep(args.retry_delay_seconds)
+            continue
+        if not isinstance(value, dict):
+            raise ValueError("artifact response must be an object")
+        return value
+    raise AssertionError("bounded artifact lookup exhausted without returning")
+
+
+def load_artifacts(args: argparse.Namespace) -> list[dict[str, Any]]:
+    if args.command in {"resolve-id", "verify"}:
+        return [get_artifact_by_id(args)]
+    if args.artifact_json:
+        value = read_json(args.artifact_json)
+        if isinstance(value, dict) and "artifacts" in value:
+            value = value["artifacts"]
+        if not isinstance(value, list) or not all(
+            isinstance(item, dict) for item in value
+        ):
+            raise ValueError("artifact fixture must be an artifact array")
+        return value
+    artifacts: list[dict[str, Any]] = []
+    page = 1
+    expected_total: int | None = None
+    while True:
+        value = gh_api(
+            f"repos/{args.repository}/actions/runs/{args.run_id}/artifacts"
+            f"?per_page=100&page={page}"
+        )
+        if not isinstance(value, dict) or not isinstance(value.get("artifacts"), list):
+            raise ValueError("run artifact response has no artifacts array")
+        total = value.get("total_count")
+        if type(total) is not int or total < 0:
+            raise ValueError("run artifact response has no valid total_count")
+        if expected_total is None:
+            expected_total = total
+        elif expected_total != total:
+            raise ValueError("artifact total changed during pagination")
+        current = value["artifacts"]
+        artifacts.extend(current)
+        if len(artifacts) >= expected_total:
+            break
+        if not current:
+            raise ValueError("artifact pagination ended early")
+        page += 1
+    if len(artifacts) != expected_total:
+        raise ValueError("artifact pagination returned the wrong cardinality")
+    return artifacts
+
+
+def verify_artifact(
+    artifact: dict[str, Any], args: argparse.Namespace
+) -> dict[str, Any]:
+    artifact_id = artifact.get("id")
+    if type(artifact_id) is not int or artifact_id <= 0:
+        raise ValueError("artifact ID must be a positive integer")
+    if args.command in {"resolve-id", "verify"} and artifact_id != args.artifact_id:
+        raise ValueError("artifact ID does not match the requested ID")
+    if artifact.get("name") != args.name:
+        raise ValueError("artifact name does not match the exact expected name")
+    digest = artifact.get("digest")
+    if not isinstance(digest, str) or DIGEST.fullmatch(digest) is None:
+        raise ValueError("artifact digest is not a SHA-256 digest")
+    if args.command == "verify" and digest != args.expected_digest:
+        raise ValueError("artifact digest changed")
+    if artifact.get("expired") is not False:
+        raise ValueError("artifact is expired")
+    size = artifact.get("size_in_bytes")
+    if type(size) is not int or size <= 0:
+        raise ValueError("artifact size must be a positive integer")
+    workflow = artifact.get("workflow_run")
+    if not isinstance(workflow, dict):
+        raise ValueError("artifact workflow identity is missing")
+    expected_workflow = {
+        "id": args.run_id,
+        "repository_id": REPOSITORY_ID,
+        "head_repository_id": REPOSITORY_ID,
+        "head_sha": args.expected_source_sha,
+    }
+    for field, expected in expected_workflow.items():
+        if workflow.get(field) != expected:
+            raise ValueError(f"artifact workflow {field} mismatch")
+    return {
+        "artifact_id": artifact_id,
+        "name": artifact["name"],
+        "digest": digest,
+        "size_in_bytes": size,
+        "run_id": args.run_id,
+        "source_git_sha": args.expected_source_sha,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    commands = parser.add_subparsers(dest="command", required=True)
+    for name in ("resolve", "resolve-id", "verify"):
+        command = commands.add_parser(name)
+        command.add_argument("--repository", default=REPOSITORY)
+        command.add_argument("--run-id", type=int, required=True)
+        command.add_argument("--name", required=True)
+        command.add_argument("--expected-source-sha", required=True)
+        command.add_argument("--artifact-json", type=Path)
+        command.add_argument("--github-output", type=Path)
+        if name in {"resolve-id", "verify"}:
+            command.add_argument("--artifact-id", type=int, required=True)
+            command.add_argument("--max-attempts", type=int, default=1)
+            command.add_argument("--retry-delay-seconds", type=int, default=0)
+        if name == "verify":
+            command.add_argument("--expected-digest", required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.repository != REPOSITORY:
+        raise ValueError(f"repository must be exactly {REPOSITORY}")
+    if args.run_id <= 0:
+        raise ValueError("run ID must be positive")
+    if SHA.fullmatch(args.expected_source_sha) is None:
+        raise ValueError("expected source SHA must be 40 lowercase hex characters")
+    if args.command == "verify" and (
+        not isinstance(args.expected_digest, str)
+        or DIGEST.fullmatch(args.expected_digest) is None
+    ):
+        raise ValueError("expected digest is not canonical")
+    if args.command in {"resolve-id", "verify"}:
+        if args.artifact_id <= 0:
+            raise ValueError("artifact ID must be positive")
+        if not 1 <= args.max_attempts <= 10:
+            raise ValueError("artifact lookup max attempts must be between 1 and 10")
+        if not 0 <= args.retry_delay_seconds <= 10:
+            raise ValueError("artifact retry delay must be between 0 and 10 seconds")
+    artifacts = load_artifacts(args)
+    if args.command == "resolve":
+        matches = [
+            artifact for artifact in artifacts if artifact.get("name") == args.name
+        ]
+        if len(matches) != 1:
+            raise ValueError(
+                f"expected exactly one artifact named {args.name!r}, got {len(matches)}"
+            )
+        artifact = matches[0]
+    elif args.command == "verify":
+        if len(artifacts) != 1:
+            raise ValueError("artifact verification requires exactly one artifact")
+        artifact = artifacts[0]
+    else:
+        if len(artifacts) != 1:
+            raise ValueError("direct artifact resolution requires exactly one artifact")
+        artifact = artifacts[0]
+    result = verify_artifact(artifact, args)
+    if args.github_output:
+        with args.github_output.open("a", encoding="utf-8") as output:
+            output.write(f"artifact_id={result['artifact_id']}\n")
+            output.write(f"artifact_digest={result['digest']}\n")
+            output.write(f"artifact_name={result['name']}\n")
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release/canonical-artifact-binding.py
+++ b/scripts/release/canonical-artifact-binding.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Create and verify the post-upload binding for a canonical asset artifact."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+SHA = re.compile(r"[0-9a-f]{40}")
+DIGEST = re.compile(r"sha256:[0-9a-f]{64}")
+PLATFORMS = {
+    "linux-x86_64",
+    "linux-aarch64",
+    "macos-x86_64",
+    "macos-aarch64",
+    "windows-x86_64",
+}
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def read_object(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ValueError(f"binding is not valid UTF-8 JSON: {path}") from error
+    if not isinstance(value, dict):
+        raise ValueError("binding must be a JSON object")
+    return value
+
+
+def validate_inputs(args: argparse.Namespace) -> None:
+    if SHA.fullmatch(args.source_sha) is None:
+        raise ValueError("source SHA is not canonical")
+    if args.candidate_run_id <= 0 or args.assets_artifact_id <= 0:
+        raise ValueError("run and artifact IDs must be positive")
+    if args.platform_key not in PLATFORMS:
+        raise ValueError("platform key is not canonical")
+    expected_name = f"rmux-canonical-{args.platform_key}-{args.source_sha}"
+    if args.assets_artifact_name != expected_name:
+        raise ValueError("asset artifact name does not match platform and source")
+    if DIGEST.fullmatch(args.assets_artifact_digest) is None:
+        raise ValueError("asset artifact digest is not canonical")
+    if re.fullmatch(r"[0-9a-f]{64}", args.build_record_sha256) is None:
+        raise ValueError("build record digest is not canonical")
+    if not args.attestation_id or len(args.attestation_id) > 256:
+        raise ValueError("attestation ID is invalid")
+    for path, label in (
+        (args.build_record, "build record"),
+        (args.attestation_bundle, "attestation bundle"),
+    ):
+        resolved = path.resolve(strict=True)
+        if not resolved.is_file() or resolved.is_symlink() or resolved.stat().st_size <= 0:
+            raise ValueError(f"{label} must be one non-empty regular file")
+    if sha256_file(args.build_record) != args.build_record_sha256:
+        raise ValueError("build record digest changed before binding")
+
+
+def expected_binding(args: argparse.Namespace) -> dict[str, Any]:
+    validate_inputs(args)
+    return {
+        "schema_version": 1,
+        "repository_id": 1239918790,
+        "source_git_sha": args.source_sha,
+        "candidate_run_id": args.candidate_run_id,
+        "platform_key": args.platform_key,
+        "assets": {
+            "artifact_id": args.assets_artifact_id,
+            "artifact_name": args.assets_artifact_name,
+            "artifact_digest": args.assets_artifact_digest,
+        },
+        "build_record_sha256": args.build_record_sha256,
+        "attestation": {
+            "attestation_id": args.attestation_id,
+            "bundle_file": "build-provenance.sigstore.json",
+            "bundle_sha256": sha256_file(args.attestation_bundle),
+        },
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("command", choices=("create", "verify"))
+    parser.add_argument("--source-sha", required=True)
+    parser.add_argument("--candidate-run-id", type=int, required=True)
+    parser.add_argument("--platform-key", required=True)
+    parser.add_argument("--assets-artifact-id", type=int, required=True)
+    parser.add_argument("--assets-artifact-name", required=True)
+    parser.add_argument("--assets-artifact-digest", required=True)
+    parser.add_argument("--build-record", type=Path, required=True)
+    parser.add_argument("--build-record-sha256", required=True)
+    parser.add_argument("--attestation-id", required=True)
+    parser.add_argument("--attestation-bundle", type=Path, required=True)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--binding", type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    expected = expected_binding(args)
+    if args.command == "create":
+        if args.output is None or args.binding is not None:
+            raise ValueError("create requires --output and forbids --binding")
+        args.output.write_text(
+            json.dumps(expected, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        print(sha256_file(args.output))
+    else:
+        if args.binding is None or args.output is not None:
+            raise ValueError("verify requires --binding and forbids --output")
+        if read_object(args.binding) != expected:
+            raise ValueError("canonical artifact binding changed")
+        print(sha256_file(args.binding))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release/canonical-build-record.py
+++ b/scripts/release/canonical-build-record.py
@@ -1,0 +1,480 @@
+#!/usr/bin/env python3
+"""Create or verify the immutable record for one canonical native bundle."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+CONTRACT = ROOT / ".github/release/canonical-build-contract.json"
+SAFE_PATH = re.compile(r"[A-Za-z0-9._+@=-]+(?:/[A-Za-z0-9._+@=-]+)*")
+SHA = re.compile(r"[0-9a-f]{40}")
+INTENT = re.compile(r"[A-Za-z0-9._:-]{8,128}")
+TAG = re.compile(r"v[0-9]+\.[0-9]+\.[0-9]+(?:-rc\.[0-9]+)?")
+RECORD_SHA = re.compile(r"[0-9a-f]{64}")
+
+
+def read_object(path: Path, label: str) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ValueError(f"{label} is not valid UTF-8 JSON: {path}") from error
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} must be a JSON object")
+    return value
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def exact_keys(value: dict[str, Any], expected: set[str], label: str) -> None:
+    actual = set(value)
+    if actual != expected:
+        raise ValueError(
+            f"{label} keys differ: missing={sorted(expected - actual)}, "
+            f"extra={sorted(actual - expected)}"
+        )
+
+
+def load_contract(path: Path) -> tuple[dict[str, Any], dict[str, dict[str, Any]]]:
+    contract = read_object(path, "canonical build contract")
+    exact_keys(
+        contract,
+        {
+            "schema_version",
+            "status",
+            "repository_id",
+            "workflow",
+            "reusable_workflow",
+            "rust_toolchain",
+            "artifact_retention_days",
+            "build_policy",
+            "platforms",
+        },
+        "canonical build contract",
+    )
+    if contract["schema_version"] != 1:
+        raise ValueError("unsupported canonical build contract schema")
+    if contract["status"] != "review-only-non-publishing":
+        raise ValueError("canonical build contract is not review-only")
+    if contract["repository_id"] != 1239918790:
+        raise ValueError("canonical build repository ID changed")
+    if contract["rust_toolchain"] != "1.96.1":
+        raise ValueError("canonical build toolchain changed")
+    if contract["artifact_retention_days"] != 7:
+        raise ValueError("canonical artifact retention must be seven days")
+    expected_policy = {
+        "cargo_incremental": False,
+        "cargo_locked": True,
+        "fresh_target": True,
+        "object_cache_restored": False,
+        "publication_authority": False,
+    }
+    if contract["build_policy"] != expected_policy:
+        raise ValueError("canonical build policy changed")
+    platforms = contract["platforms"]
+    if not isinstance(platforms, list) or len(platforms) != 5:
+        raise ValueError("canonical build contract must contain five platforms")
+    by_key: dict[str, dict[str, Any]] = {}
+    for platform in platforms:
+        if not isinstance(platform, dict):
+            raise ValueError("canonical platform must be an object")
+        exact_keys(
+            platform,
+            {
+                "key",
+                "runner_image",
+                "runner_os",
+                "runner_arch",
+                "target_triple",
+                "archive_format",
+                "linux_packages",
+            },
+            "canonical platform",
+        )
+        key = platform["key"]
+        if not isinstance(key, str) or key in by_key:
+            raise ValueError("canonical platform keys must be unique strings")
+        by_key[key] = platform
+    return contract, by_key
+
+
+def asset_role(relative: str, platform: dict[str, Any]) -> str:
+    if relative == "SHA256SUMS.txt":
+        return "checksums"
+    archive_suffix = f".{platform['archive_format']}"
+    if relative.endswith(archive_suffix):
+        return "archive"
+    if platform["linux_packages"] and relative.endswith(".deb"):
+        return "debian"
+    if platform["linux_packages"] and relative.endswith(".rpm"):
+        return "rpm"
+    raise ValueError(f"canonical asset has no contracted role: {relative}")
+
+
+def verify_asset_roles(files: list[dict[str, Any]], platform: dict[str, Any]) -> None:
+    expected = {"archive", "checksums"}
+    if platform["linux_packages"]:
+        expected.update({"debian", "rpm"})
+    roles = [item["role"] for item in files]
+    if set(roles) != expected or len(roles) != len(expected):
+        raise ValueError(
+            f"canonical asset roles differ: expected={sorted(expected)}, "
+            f"actual={sorted(roles)}"
+        )
+
+
+def verify_checksums(directory: Path, files: list[dict[str, Any]]) -> None:
+    checksums = directory / "SHA256SUMS.txt"
+    try:
+        lines = checksums.read_text(encoding="ascii").splitlines()
+    except (OSError, UnicodeDecodeError) as error:
+        raise ValueError("canonical checksum manifest is not ASCII") from error
+    expected = {
+        item["path"]: item["sha256"]
+        for item in files
+        if item["role"] != "checksums"
+    }
+    actual: dict[str, str] = {}
+    for line in lines:
+        match = re.fullmatch(r"([0-9a-f]{64})  (\S+)", line)
+        if match is None or SAFE_PATH.fullmatch(match.group(2)) is None:
+            raise ValueError("canonical checksum manifest line is invalid")
+        path = match.group(2)
+        if path in actual:
+            raise ValueError(f"duplicate canonical checksum entry: {path}")
+        actual[path] = match.group(1)
+    if actual != expected:
+        raise ValueError("canonical checksum manifest does not cover the exact asset set")
+
+
+def asset_files(directory: Path, platform: dict[str, Any]) -> list[dict[str, Any]]:
+    root = directory.resolve(strict=True)
+    if not root.is_dir():
+        raise ValueError("assets path must be a directory")
+    files: list[dict[str, Any]] = []
+    for path in sorted(root.rglob("*")):
+        if path.is_symlink():
+            raise ValueError(f"canonical assets cannot contain symlinks: {path}")
+        if path.is_dir():
+            continue
+        if not path.is_file():
+            raise ValueError(f"canonical asset is not a regular file: {path}")
+        relative = path.relative_to(root).as_posix()
+        if SAFE_PATH.fullmatch(relative) is None or ".." in relative.split("/"):
+            raise ValueError(f"canonical asset path is not portable: {relative}")
+        size = path.stat().st_size
+        if size <= 0:
+            raise ValueError(f"canonical asset is empty: {relative}")
+        files.append(
+            {
+                "path": relative,
+                "role": asset_role(relative, platform),
+                "size": size,
+                "sha256": sha256_file(path),
+            }
+        )
+    if not files:
+        raise ValueError("canonical bundle has no assets")
+    verify_asset_roles(files, platform)
+    verify_checksums(root, files)
+    return files
+
+
+def validate_identity(args: argparse.Namespace) -> None:
+    if SHA.fullmatch(args.source_sha) is None:
+        raise ValueError("source SHA must be 40 lowercase hexadecimal characters")
+    if args.fast_run_id <= 0 or args.candidate_run_id <= 0:
+        raise ValueError("run IDs must be positive integers")
+    if args.candidate_run_attempt != 1:
+        raise ValueError("canonical candidate must use Actions attempt 1")
+    if INTENT.fullmatch(args.release_intent_id) is None:
+        raise ValueError("release intent ID uses characters outside the allowlist")
+    if TAG.fullmatch(args.planned_release_ref) is None:
+        raise ValueError("planned release ref is not canonical")
+    is_rc = "-rc." in args.planned_release_ref
+    if args.release_kind == "stable" and is_rc:
+        raise ValueError("stable candidate cannot use an RC ref")
+    if args.release_kind == "rc" and not is_rc:
+        raise ValueError("RC candidate requires an RC ref")
+
+
+def rustc_identity(path: Path, expected_host: str, expected_release: str) -> dict[str, str]:
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeDecodeError) as error:
+        raise ValueError("rustc verbose evidence is not UTF-8") from error
+    fields: dict[str, str] = {}
+    for line in lines:
+        if ": " not in line:
+            continue
+        key, value = line.split(": ", 1)
+        if key in fields:
+            raise ValueError(f"duplicate rustc verbose field: {key}")
+        fields[key] = value
+    if fields.get("host") != expected_host:
+        raise ValueError("rustc host does not match the canonical target")
+    if fields.get("release") != expected_release:
+        raise ValueError("rustc release does not match the canonical toolchain")
+    commit = fields.get("commit-hash", "")
+    if re.fullmatch(r"[0-9a-f]{40}", commit) is None:
+        raise ValueError("rustc commit hash is missing or non-canonical")
+    return {"host": expected_host, "release": expected_release, "commit_hash": commit}
+
+
+def create(args: argparse.Namespace) -> str:
+    contract, platforms = load_contract(args.contract)
+    validate_identity(args)
+    platform = platforms.get(args.platform_key)
+    if platform is None:
+        raise ValueError(f"unknown canonical platform: {args.platform_key}")
+    actual_runner = {
+        "image": args.runner_image,
+        "os": args.runner_os,
+        "arch": args.runner_arch,
+        "environment": args.runner_environment,
+    }
+    expected_runner = {
+        "image": platform["runner_image"],
+        "os": platform["runner_os"],
+        "arch": platform["runner_arch"],
+        "environment": "github-hosted",
+    }
+    if actual_runner != expected_runner:
+        raise ValueError(
+            f"runner identity mismatch: expected {expected_runner}, got {actual_runner}"
+        )
+    rustc_path = args.rustc_verbose.resolve(strict=True)
+    if not rustc_path.is_file() or rustc_path.is_symlink():
+        raise ValueError("rustc verbose evidence must be one regular file")
+    rustc = rustc_identity(
+        rustc_path, platform["target_triple"], contract["rust_toolchain"]
+    )
+    created_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    record = {
+        "schema_version": 1,
+        "repository_id": contract["repository_id"],
+        "source_git_sha": args.source_sha,
+        "fast_run_id": args.fast_run_id,
+        "candidate_run_id": args.candidate_run_id,
+        "candidate_run_attempt": args.candidate_run_attempt,
+        "release_intent_id": args.release_intent_id,
+        "planned_release_ref": args.planned_release_ref,
+        "release_kind": args.release_kind,
+        "platform": {
+            "key": platform["key"],
+            "target_triple": platform["target_triple"],
+            "archive_format": platform["archive_format"],
+        },
+        "runner": actual_runner,
+        "toolchain": {
+            "requested": contract["rust_toolchain"],
+            **rustc,
+            "rustc_verbose_sha256": sha256_file(rustc_path),
+        },
+        "build_policy": contract["build_policy"],
+        "created_at": created_at,
+        "files": asset_files(args.assets_dir, platform),
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(record, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    digest = sha256_file(args.output)
+    print(digest)
+    return digest
+
+
+def verify_record_shape(
+    record: dict[str, Any], contract: dict[str, Any], platform: dict[str, Any]
+) -> None:
+    exact_keys(
+        record,
+        {
+            "schema_version",
+            "repository_id",
+            "source_git_sha",
+            "fast_run_id",
+            "candidate_run_id",
+            "candidate_run_attempt",
+            "release_intent_id",
+            "planned_release_ref",
+            "release_kind",
+            "platform",
+            "runner",
+            "toolchain",
+            "build_policy",
+            "created_at",
+            "files",
+        },
+        "canonical build record",
+    )
+    if record["schema_version"] != 1 or record["repository_id"] != 1239918790:
+        raise ValueError("canonical build record identity changed")
+    if record["candidate_run_attempt"] != 1:
+        raise ValueError("canonical build record is not attempt 1")
+    expected_platform = {
+        "key": platform["key"],
+        "target_triple": platform["target_triple"],
+        "archive_format": platform["archive_format"],
+    }
+    if record["platform"] != expected_platform:
+        raise ValueError("canonical platform record does not match its contract")
+    expected_runner = {
+        "image": platform["runner_image"],
+        "os": platform["runner_os"],
+        "arch": platform["runner_arch"],
+        "environment": "github-hosted",
+    }
+    if record["runner"] != expected_runner:
+        raise ValueError("canonical runner record does not match its contract")
+    if record["build_policy"] != contract["build_policy"]:
+        raise ValueError("canonical build policy record changed")
+    toolchain = record.get("toolchain")
+    if not isinstance(toolchain, dict):
+        raise ValueError("canonical toolchain record is missing")
+    exact_keys(
+        toolchain,
+        {"requested", "release", "host", "commit_hash", "rustc_verbose_sha256"},
+        "toolchain",
+    )
+    if toolchain["requested"] != contract["rust_toolchain"]:
+        raise ValueError("canonical toolchain request changed")
+    if toolchain["release"] != contract["rust_toolchain"]:
+        raise ValueError("canonical toolchain release changed")
+    if toolchain["host"] != platform["target_triple"]:
+        raise ValueError("canonical toolchain host changed")
+    if not isinstance(toolchain["commit_hash"], str) or not re.fullmatch(
+        r"[0-9a-f]{40}", toolchain["commit_hash"]
+    ):
+        raise ValueError("canonical toolchain commit hash is invalid")
+    if not isinstance(toolchain["rustc_verbose_sha256"], str) or not re.fullmatch(
+        r"[0-9a-f]{64}", toolchain["rustc_verbose_sha256"]
+    ):
+        raise ValueError("rustc verbose digest is invalid")
+    try:
+        parsed = datetime.fromisoformat(record["created_at"].replace("Z", "+00:00"))
+    except (AttributeError, ValueError) as error:
+        raise ValueError("canonical build timestamp is invalid") from error
+    if parsed.tzinfo is None:
+        raise ValueError("canonical build timestamp must include a timezone")
+
+
+def verify(args: argparse.Namespace) -> str:
+    if RECORD_SHA.fullmatch(args.expected_record_sha256) is None:
+        raise ValueError("expected canonical build record digest is invalid")
+    initial_digest = sha256_file(args.record)
+    if initial_digest != args.expected_record_sha256:
+        raise ValueError("canonical build record digest differs from build output")
+    contract, platforms = load_contract(args.contract)
+    platform = platforms.get(args.platform_key)
+    if platform is None:
+        raise ValueError(f"unknown canonical platform: {args.platform_key}")
+    record = read_object(args.record, "canonical build record")
+    verify_record_shape(record, contract, platform)
+    expected = {
+        "source_git_sha": args.source_sha,
+        "fast_run_id": args.fast_run_id,
+        "candidate_run_id": args.candidate_run_id,
+        "release_intent_id": args.release_intent_id,
+        "planned_release_ref": args.planned_release_ref,
+        "release_kind": args.release_kind,
+    }
+    for field, value in expected.items():
+        if record.get(field) != value:
+            raise ValueError(f"canonical build record {field} mismatch")
+    recorded_files = record.get("files")
+    if not isinstance(recorded_files, list):
+        raise ValueError("canonical build record files must be an array")
+    actual_files = asset_files(args.assets_dir, platform)
+    if recorded_files != actual_files:
+        raise ValueError("downloaded canonical asset set or digest changed")
+    digest = sha256_file(args.record)
+    if digest != args.expected_record_sha256:
+        raise ValueError("canonical build record changed during smoke verification")
+    print(digest)
+    return digest
+
+
+def write_subjects(args: argparse.Namespace) -> None:
+    record = read_object(args.record, "canonical build record")
+    recorded_files = record.get("files")
+    if not isinstance(recorded_files, list):
+        raise ValueError("canonical build record files must be an array")
+    _, platforms = load_contract(args.contract)
+    platform_record = record.get("platform")
+    if not isinstance(platform_record, dict):
+        raise ValueError("canonical build record platform is missing")
+    platform = platforms.get(platform_record.get("key"))
+    if platform is None:
+        raise ValueError("canonical build record platform is unknown")
+    actual_files = asset_files(args.assets_dir, platform)
+    if recorded_files != actual_files:
+        raise ValueError("canonical build subjects differ from the build record")
+    lines = [
+        f"{item['sha256']}  assets/{item['path']}" for item in actual_files
+    ]
+    lines.append(f"{sha256_file(args.record)}  canonical-build-record.json")
+    args.output.write_text("\n".join(sorted(lines)) + "\n", encoding="ascii")
+
+
+def common_identity(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--source-sha", required=True)
+    parser.add_argument("--fast-run-id", type=int, required=True)
+    parser.add_argument("--candidate-run-id", type=int, required=True)
+    parser.add_argument("--release-intent-id", required=True)
+    parser.add_argument("--planned-release-ref", required=True)
+    parser.add_argument("--release-kind", choices=("shadow", "rc", "stable"), required=True)
+    parser.add_argument("--platform-key", required=True)
+    parser.add_argument("--assets-dir", type=Path, required=True)
+    parser.add_argument("--contract", type=Path, default=CONTRACT)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    commands = parser.add_subparsers(dest="command", required=True)
+    create_parser = commands.add_parser("create")
+    common_identity(create_parser)
+    create_parser.add_argument("--candidate-run-attempt", type=int, required=True)
+    create_parser.add_argument("--runner-image", required=True)
+    create_parser.add_argument("--runner-os", required=True)
+    create_parser.add_argument("--runner-arch", required=True)
+    create_parser.add_argument("--runner-environment", required=True)
+    create_parser.add_argument("--rustc-verbose", type=Path, required=True)
+    create_parser.add_argument("--output", type=Path, required=True)
+    verify_parser = commands.add_parser("verify")
+    common_identity(verify_parser)
+    verify_parser.add_argument("--record", type=Path, required=True)
+    verify_parser.add_argument("--expected-record-sha256", required=True)
+    subjects_parser = commands.add_parser("subjects")
+    subjects_parser.add_argument("--record", type=Path, required=True)
+    subjects_parser.add_argument("--assets-dir", type=Path, required=True)
+    subjects_parser.add_argument("--output", type=Path, required=True)
+    subjects_parser.add_argument("--contract", type=Path, default=CONTRACT)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.command == "create":
+        create(args)
+    elif args.command == "verify":
+        verify(args)
+    else:
+        write_subjects(args)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release/canonical_contract.py
+++ b/scripts/release/canonical_contract.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Validate the canonical native-build contract and its schemas."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+CONTRACT_DIR = ROOT / ".github" / "release"
+
+CANONICAL_RUNNER_LABELS = {
+    "macos-15",
+    "macos-15-intel",
+    "ubuntu-22.04",
+    "ubuntu-22.04-arm",
+    "windows-latest",
+}
+
+PLATFORMS = {
+    "linux-x86_64": (
+        "ubuntu-22.04",
+        "Linux",
+        "X64",
+        "x86_64-unknown-linux-gnu",
+    ),
+    "linux-aarch64": (
+        "ubuntu-22.04-arm",
+        "Linux",
+        "ARM64",
+        "aarch64-unknown-linux-gnu",
+    ),
+    "macos-x86_64": (
+        "macos-15-intel",
+        "macOS",
+        "X64",
+        "x86_64-apple-darwin",
+    ),
+    "macos-aarch64": (
+        "macos-15",
+        "macOS",
+        "ARM64",
+        "aarch64-apple-darwin",
+    ),
+    "windows-x86_64": (
+        "windows-latest",
+        "Windows",
+        "X64",
+        "x86_64-pc-windows-msvc",
+    ),
+}
+
+
+def _unique_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    value: dict[str, Any] = {}
+    for key, item in pairs:
+        if key in value:
+            raise ValueError(f"duplicate JSON object key: {key!r}")
+        value[key] = item
+    return value
+
+
+def _load(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(
+            path.read_text(encoding="utf-8"), object_pairs_hook=_unique_object
+        )
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ValueError(f"cannot read {path.relative_to(ROOT)}: {error}") from error
+    if not isinstance(value, dict):
+        raise ValueError(f"{path.relative_to(ROOT)} must contain an object")
+    return value
+
+
+def validate_candidate_policy(value: Any) -> None:
+    strict_contract = _load(CONTRACT_DIR / "candidate-workflow-contract.json")
+    expected = {
+        "contract": ".github/release/canonical-build-contract.json",
+        "workflow": ".github/workflows/canonical-native-build.yml",
+        "native_platforms": 5,
+        "windows_smokes": ["mouse", "runtime", "sdk"],
+        "artifact_retention_days": 7,
+        "download_by_artifact_id": True,
+        "object_cache_restored": False,
+    }
+    if value != expected or strict_contract.get("canonical_builds") != expected:
+        raise ValueError("canonical candidate build policy drifted")
+
+
+def validate_build() -> None:
+    contract = _load(CONTRACT_DIR / "canonical-build-contract.json")
+    if (
+        contract.get("schema_version") != 1
+        or contract.get("status") != "review-only-non-publishing"
+        or contract.get("repository_id") != 1239918790
+        or contract.get("rust_toolchain") != "1.96.1"
+        or contract.get("artifact_retention_days") != 7
+    ):
+        raise ValueError("canonical build contract identity changed")
+    platforms = contract.get("platforms")
+    if not isinstance(platforms, list):
+        raise ValueError("canonical platforms must be an array")
+    actual = {
+        entry.get("key"): (
+            entry.get("runner_image"),
+            entry.get("runner_os"),
+            entry.get("runner_arch"),
+            entry.get("target_triple"),
+        )
+        for entry in platforms
+        if isinstance(entry, dict)
+    }
+    if actual != PLATFORMS or len(platforms) != len(PLATFORMS):
+        raise ValueError("canonical target-to-runner mapping changed")
+
+    workflow = (ROOT / ".github/workflows/canonical-native-build.yml").read_text(
+        encoding="utf-8"
+    )
+    actual_job_runners: dict[str, str] = {}
+    current_job: str | None = None
+    inside_jobs = False
+    for line in workflow.splitlines():
+        if line == "jobs:":
+            inside_jobs = True
+            continue
+        if not inside_jobs:
+            continue
+        job_match = re.fullmatch(r"  ([a-z0-9-]+):", line)
+        if job_match is not None:
+            current_job = job_match.group(1)
+            continue
+        runner_match = re.fullmatch(r"    runs-on: ([A-Za-z0-9.-]+)", line)
+        if current_job is not None and runner_match is not None:
+            actual_job_runners[current_job] = runner_match.group(1)
+    expected_job_runners = {
+        **{
+            f"build-{key.replace('_', '-')}": value[0]
+            for key, value in PLATFORMS.items()
+        },
+        **{
+            f"smoke-{key.replace('_', '-')}": value[0]
+            for key, value in PLATFORMS.items()
+        },
+        "gate": "ubuntu-22.04",
+    }
+    if actual_job_runners != expected_job_runners:
+        raise ValueError("canonical workflow job-to-runner mapping changed")
+    for forbidden in (
+        "runs-on: ${{",
+        "actions/cache@",
+        "sccache",
+        "contents: write",
+        "packages: write",
+        "secrets: inherit",
+        "environment:",
+    ):
+        if forbidden in workflow:
+            raise ValueError(f"canonical workflow contains forbidden value {forbidden}")
+    if workflow.count("uses: ./.github/actions/canonical-build") != 5:
+        raise ValueError("canonical workflow must contain five explicit native builds")
+    if workflow.count("expected-build-record-sha256: ${{ needs.build-") != 5:
+        raise ValueError("every canonical smoke must bind the producer record digest")
+    if "matrix:\n        smoke: [runtime, sdk, mouse]" not in workflow:
+        raise ValueError("canonical Windows smokes must be exhaustive and explicit")
+
+
+def validate_schemas(candidate: dict[str, Any], schema_dir: Path) -> None:
+    strict_candidate = _load(schema_dir / "candidate-manifest.schema.json")
+    if candidate != strict_candidate:
+        raise ValueError("candidate manifest schema changed during canonical validation")
+    candidate = strict_candidate
+    runner_images = candidate["properties"]["artifacts"]["items"]["properties"][
+        "runner_image"
+    ].get("enum")
+    if runner_images != sorted(CANONICAL_RUNNER_LABELS):
+        raise ValueError(
+            "candidate runner_image must use the canonical runner allowlist"
+        )
+    target_triples = candidate["properties"]["artifacts"]["items"]["properties"][
+        "target_triple"
+    ].get("enum")
+    if target_triples != sorted(entry[3] for entry in PLATFORMS.values()):
+        raise ValueError("candidate target_triple must use the canonical allowlist")
+    artifact_pairing = candidate["properties"]["artifacts"]["items"].get("allOf")
+    if not isinstance(artifact_pairing, list) or len(artifact_pairing) != 5:
+        raise ValueError("candidate schema must bind each target to one runner image")
+
+    canonical_record = _load(schema_dir / "canonical-build-record.schema.json")
+    canonical_binding = _load(schema_dir / "canonical-artifact-binding.schema.json")
+    for filename, schema in (
+        ("canonical-build-record.schema.json", canonical_record),
+        ("canonical-artifact-binding.schema.json", canonical_binding),
+    ):
+        if schema.get("additionalProperties") is not False:
+            raise ValueError(f"{filename} must fail closed on unknown fields")
+        if not isinstance(schema.get("required"), list):
+            raise ValueError(f"{filename} must define exhaustive required fields")
+    record_files = canonical_record["properties"]["files"]["items"]
+    if set(record_files.get("required", [])) != {"path", "role", "size", "sha256"}:
+        raise ValueError("canonical record must bind every asset role and byte")
+    binding_required = set(canonical_binding.get("required", []))
+    if not {"assets", "attestation", "build_record_sha256"} <= binding_required:
+        raise ValueError("canonical artifact binding is incomplete")

--- a/scripts/release/validate-contracts.py
+++ b/scripts/release/validate-contracts.py
@@ -9,6 +9,11 @@ import subprocess
 from pathlib import Path
 from typing import Any
 
+from canonical_contract import (
+    validate_build as validate_canonical_build,
+    validate_candidate_policy as validate_canonical_candidate_policy,
+    validate_schemas as validate_canonical_schemas,
+)
 from local_action_policy import validate_local_action_policy
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -180,8 +185,11 @@ def validate_candidate() -> None:
     non_runner_jobs = require_unique_strings(
         runner_policy.get("non_runner_jobs"), "runner_policy.non_runner_jobs"
     )
-    if non_runner_jobs != ["Run release-only candidate delta"]:
-        raise ValueError("runner policy must identify the reusable workflow call job")
+    if non_runner_jobs != [
+        "Build canonical native artifacts",
+        "Run release-only candidate delta",
+    ]:
+        raise ValueError("runner policy must identify both reusable workflow call jobs")
     contracted_jobs = (
         set(success)
         | set(skipped)
@@ -340,6 +348,7 @@ def validate_candidate_workflow() -> None:
         raise ValueError("candidate delta contains a fast-covered review section")
     if delta.get("tmux_oracle_builds") != 1:
         raise ValueError("the fast and candidate path must build tmux exactly once")
+    validate_canonical_candidate_policy(contract.get("canonical_builds"))
     publication = contract.get("publication")
     if not isinstance(publication, dict) or any(
         publication.get(field) is not False
@@ -480,13 +489,7 @@ def validate_schemas() -> None:
         raise ValueError(
             "candidate schema must bind stable/RC kind and prerelease state"
         )
-    runner_images = candidate["properties"]["artifacts"]["items"]["properties"][
-        "runner_image"
-    ].get("enum")
-    if runner_images != sorted(STANDARD_RUNNER_LABELS):
-        raise ValueError(
-            "candidate runner_image must use the standard runner allowlist"
-        )
+    validate_canonical_schemas(candidate, schema_dir)
 
 
 def validate_measurement_budget() -> None:
@@ -528,6 +531,7 @@ def validate_measurement_budget() -> None:
 def main() -> int:
     validate_candidate()
     validate_candidate_workflow()
+    validate_canonical_build()
     validate_windows_coverage()
     validate_channels()
     validate_schemas()

--- a/tests/release_canonical_build_spec.rs
+++ b/tests/release_canonical_build_spec.rs
@@ -1,0 +1,644 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn temp_dir(label: &str) -> PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock before epoch")
+        .as_nanos();
+    let path = std::env::temp_dir().join(format!(
+        "rmux-canonical-{label}-{}-{nonce}",
+        std::process::id()
+    ));
+    fs::create_dir_all(&path).expect("create canonical fixture directory");
+    path
+}
+
+fn python() -> &'static str {
+    if cfg!(windows) {
+        "python.exe"
+    } else {
+        "python3"
+    }
+}
+
+fn run(program: &Path, arguments: &[&str]) -> Output {
+    Command::new(python())
+        .arg(program)
+        .args(arguments)
+        .current_dir(repo_root())
+        .output()
+        .unwrap_or_else(|error| {
+            panic!(
+                "failed to run {} with {}: {error}",
+                program.display(),
+                python()
+            )
+        })
+}
+
+fn run_python(arguments: &[&str]) -> Output {
+    Command::new(python())
+        .args(arguments)
+        .current_dir(repo_root())
+        .output()
+        .unwrap_or_else(|error| panic!("failed to run {}: {error}", python()))
+}
+
+fn job_block<'a>(workflow: &'a str, job: &str, next: &str) -> &'a str {
+    workflow
+        .split(&format!("\n  {job}:\n"))
+        .nth(1)
+        .unwrap_or_else(|| panic!("missing canonical job {job}"))
+        .split(&format!("\n  {next}:\n"))
+        .next()
+        .unwrap_or_else(|| panic!("unbounded canonical job {job}"))
+}
+
+#[test]
+fn canonical_workflow_has_five_literal_native_allocations() {
+    let workflow = include_str!("../.github/workflows/canonical-native-build.yml");
+    let expected = [
+        (
+            "build-linux-x86-64",
+            "build-linux-aarch64",
+            "runs-on: ubuntu-22.04",
+            "platform-key: linux-x86_64",
+            "target-triple: x86_64-unknown-linux-gnu",
+        ),
+        (
+            "build-linux-aarch64",
+            "build-macos-x86-64",
+            "runs-on: ubuntu-22.04-arm",
+            "platform-key: linux-aarch64",
+            "target-triple: aarch64-unknown-linux-gnu",
+        ),
+        (
+            "build-macos-x86-64",
+            "build-macos-aarch64",
+            "runs-on: macos-15-intel",
+            "platform-key: macos-x86_64",
+            "target-triple: x86_64-apple-darwin",
+        ),
+        (
+            "build-macos-aarch64",
+            "build-windows-x86-64",
+            "runs-on: macos-15",
+            "platform-key: macos-aarch64",
+            "target-triple: aarch64-apple-darwin",
+        ),
+        (
+            "build-windows-x86-64",
+            "smoke-linux-x86-64",
+            "runs-on: windows-latest",
+            "platform-key: windows-x86_64",
+            "target-triple: x86_64-pc-windows-msvc",
+        ),
+    ];
+    for (job, next, runner, platform, target) in expected {
+        let block = job_block(workflow, job, next);
+        for required in [
+            runner,
+            platform,
+            target,
+            "uses: ./.github/actions/canonical-build",
+        ] {
+            assert!(block.contains(required), "{job} lost {required}");
+        }
+    }
+    assert_eq!(
+        workflow
+            .matches("uses: ./.github/actions/canonical-build")
+            .count(),
+        5
+    );
+    assert!(!workflow.contains("runs-on: ${{"));
+    assert!(!workflow.contains("self-hosted"));
+}
+
+#[test]
+fn canonical_producers_are_object_cold_and_non_publishing() {
+    let workflow = include_str!("../.github/workflows/canonical-native-build.yml");
+    let build = include_str!("../.github/actions/canonical-build/action.yml");
+    for forbidden in [
+        "actions/cache@",
+        "sccache",
+        "contents: write",
+        "packages: write",
+        "secrets: inherit",
+        "environment:",
+        "gh release",
+        "git push",
+    ] {
+        assert!(!workflow.contains(forbidden), "workflow gained {forbidden}");
+        assert!(
+            !build.contains(forbidden),
+            "build action gained {forbidden}"
+        );
+    }
+    for required in [
+        "test ! -e \"$canonical_target\"",
+        "test -z \"${RUSTC_WRAPPER:-}\"",
+        "test -z \"${RUSTC_WORKSPACE_WRAPPER:-}\"",
+        "cargo fetch --locked",
+        "scripts/package-unix.sh",
+        "scripts/package-windows.ps1",
+        "subject-checksums:",
+        "create-storage-record: false",
+        "retention-days: 7",
+        "compression-level: 0",
+    ] {
+        assert!(build.contains(required), "canonical build lost {required}");
+    }
+    assert_eq!(build.matches("scripts/package-windows.ps1").count(), 1);
+    for api_bound in [
+        "value: ${{ steps.assets-api.outputs.artifact_digest }}",
+        "value: ${{ steps.provenance-api.outputs.artifact_digest }}",
+        "RMUX_ASSETS_ARTIFACT_DIGEST: ${{ steps.assets-api.outputs.artifact_digest }}",
+        "scripts/release/actions-artifact.py resolve-id",
+        "--max-attempts 6",
+        "--retry-delay-seconds 2",
+    ] {
+        assert!(
+            build.contains(api_bound),
+            "canonical build lost {api_bound}"
+        );
+    }
+    assert!(!build.contains("steps.assets-upload.outputs.artifact-digest"));
+    assert!(!build.contains("steps.provenance-upload.outputs.artifact-digest"));
+    assert!(workflow.contains("attestations: write"));
+    assert!(workflow.contains("id-token: write"));
+    assert_eq!(workflow.matches("actions: read").count(), 10);
+    assert_eq!(build.matches("description:").count(), 16);
+    assert_eq!(build.matches("required: true").count(), 8);
+    let smoke = include_str!("../.github/actions/canonical-smoke/action.yml");
+    assert_eq!(smoke.matches("description:").count(), 14);
+    assert_eq!(smoke.matches("required: true").count(), 13);
+}
+
+#[test]
+fn canonical_smokes_consume_numeric_ids_and_exact_fast_drivers() {
+    let smoke = include_str!("../.github/actions/canonical-smoke/action.yml");
+    for required in [
+        "artifact-ids: ${{ inputs.assets-artifact-id }}",
+        "test \"$RUNNER_ENVIRONMENT\" = github-hosted",
+        "--expected-digest \"$RMUX_ASSETS_ARTIFACT_DIGEST\"",
+        "--expected-record-sha256 \"$RMUX_EXPECTED_BUILD_RECORD_SHA256\"",
+        "canonical-build-record.py verify",
+        "artifact-ids: ${{ inputs.fast-nextest-artifact-id }}",
+        "windows-nextest.tar.zst.sha256",
+        "sha256sum --check",
+        "inputs.smoke-kind == 'runtime'",
+        "inputs.smoke-kind == 'sdk'",
+        "inputs.smoke-kind == 'mouse'",
+        "-RunCtrlMatrixSmoke",
+        "-RunSdkSmoke",
+        "-RunMouseBorderSmoke",
+    ] {
+        assert!(smoke.contains(required), "canonical smoke lost {required}");
+    }
+    let record_step = smoke
+        .split("    - name: Verify the build record and all downloaded bytes\n")
+        .nth(1)
+        .expect("canonical record verification step")
+        .split("\n    - name: Install Linux verification tools\n")
+        .next()
+        .expect("bounded canonical record verification step");
+    assert!(record_step
+        .contains("RMUX_EXPECTED_BUILD_RECORD_SHA256: ${{ inputs.expected-build-record-sha256 }}"));
+    assert!(record_step.contains("--expected-record-sha256 \"$RMUX_EXPECTED_BUILD_RECORD_SHA256\""));
+    let workflow = include_str!("../.github/workflows/canonical-native-build.yml");
+    assert!(workflow.contains("smoke: [runtime, sdk, mouse]"));
+    assert!(workflow.contains("max-parallel: 3"));
+    assert_eq!(
+        workflow
+            .matches("expected-build-record-sha256: ${{ needs.build-")
+            .count(),
+        5
+    );
+}
+
+#[test]
+fn canonical_record_rejects_mutated_record_or_downloaded_bytes() {
+    let root = temp_dir("record");
+    let assets = root.join("assets");
+    fs::create_dir(&assets).expect("create asset directory");
+    fs::write(
+        assets.join("rmux-0.9.0-linux-x86_64.tar.gz"),
+        b"canonical-bytes",
+    )
+    .expect("write canonical asset");
+    fs::write(assets.join("rmux_0.9.0_amd64.deb"), b"canonical-deb").expect("write canonical deb");
+    fs::write(assets.join("rmux-0.9.0-1.x86_64.rpm"), b"canonical-rpm")
+        .expect("write canonical rpm");
+    let archive_sha = "77b08d303821794feed7d5c213090d47b4e46165dabb86f4cb9dbfc1d6d1d66a";
+    let deb_sha = "a73e52bfe4a4457942e464e620bbbfd47f05d776b03c4b45fa052c81179b6d78";
+    let rpm_sha = "e57fbfb31bdf4e80969d24be315835cb54498a9694a4175625d3b652f7e9808a";
+    fs::write(
+        assets.join("SHA256SUMS.txt"),
+        format!(
+            "{rpm_sha}  rmux-0.9.0-1.x86_64.rpm\n{archive_sha}  rmux-0.9.0-linux-x86_64.tar.gz\n{deb_sha}  rmux_0.9.0_amd64.deb\n"
+        ),
+    )
+    .expect("write canonical checksums");
+    let rustc = root.join("rustc-vV.txt");
+    fs::write(
+        &rustc,
+        b"rustc 1.96.1\nbinary: rustc\ncommit-hash: 0123456789abcdef0123456789abcdef01234567\nhost: x86_64-unknown-linux-gnu\nrelease: 1.96.1\n",
+    )
+    .expect("write rustc evidence");
+    let record = root.join("canonical-build-record.json");
+    let script = repo_root().join("scripts/release/canonical-build-record.py");
+    let source = "0123456789abcdef0123456789abcdef01234567";
+    let common = [
+        "--source-sha",
+        source,
+        "--fast-run-id",
+        "42",
+        "--candidate-run-id",
+        "77",
+        "--release-intent-id",
+        "shadow:canonical:test",
+        "--planned-release-ref",
+        "v0.9.0",
+        "--release-kind",
+        "shadow",
+        "--platform-key",
+        "linux-x86_64",
+        "--assets-dir",
+        assets.to_str().expect("asset path"),
+    ];
+    let mut create = vec!["create"];
+    create.extend(common);
+    create.extend([
+        "--candidate-run-attempt",
+        "1",
+        "--runner-image",
+        "ubuntu-22.04",
+        "--runner-os",
+        "Linux",
+        "--runner-arch",
+        "X64",
+        "--runner-environment",
+        "github-hosted",
+        "--rustc-verbose",
+        rustc.to_str().expect("rustc path"),
+        "--output",
+        record.to_str().expect("record path"),
+    ]);
+    let created = run(&script, &create);
+    assert!(
+        created.status.success(),
+        "{}",
+        String::from_utf8_lossy(&created.stderr)
+    );
+    let record_sha = String::from_utf8(created.stdout).expect("record digest is UTF-8");
+    let record_sha = record_sha.trim();
+    let mut verify = vec!["verify"];
+    verify.extend(common);
+    verify.extend([
+        "--record",
+        record.to_str().expect("record path"),
+        "--expected-record-sha256",
+        record_sha,
+    ]);
+    assert!(run(&script, &verify).status.success());
+    let mut noncanonical_digest = verify.clone();
+    *noncanonical_digest
+        .last_mut()
+        .expect("expected record digest argument") =
+        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    let rejected_digest = run(&script, &noncanonical_digest);
+    assert!(!rejected_digest.status.success());
+    assert!(String::from_utf8_lossy(&rejected_digest.stderr)
+        .contains("expected canonical build record digest is invalid"));
+
+    let original_record = fs::read(&record).expect("read canonical record");
+    let mut substituted_record = original_record.clone();
+    substituted_record.push(b'\n');
+    fs::write(&record, substituted_record).expect("substitute equivalent record bytes");
+    let rejected_record = run(&script, &verify);
+    assert!(!rejected_record.status.success());
+    assert!(String::from_utf8_lossy(&rejected_record.stderr)
+        .contains("canonical build record digest differs from build output"));
+    fs::write(&record, original_record).expect("restore canonical record");
+
+    fs::write(
+        assets.join("rmux-0.9.0-linux-x86_64.tar.gz"),
+        b"mutated-bytes",
+    )
+    .expect("mutate asset");
+    fs::write(
+        assets.join("SHA256SUMS.txt"),
+        format!(
+            "{rpm_sha}  rmux-0.9.0-1.x86_64.rpm\nc5b6ec93d49dfee55a224f67fa567e3711f2ba30db20ac3d9c8ccd83e40a7e2c  rmux-0.9.0-linux-x86_64.tar.gz\n{deb_sha}  rmux_0.9.0_amd64.deb\n"
+        ),
+    )
+    .expect("update mutated checksums");
+    let rejected = run(&script, &verify);
+    assert!(!rejected.status.success());
+    assert!(String::from_utf8_lossy(&rejected.stderr).contains("asset set or digest changed"));
+    fs::remove_dir_all(root).expect("remove canonical record fixture");
+}
+
+#[test]
+fn actions_artifact_binding_rejects_digest_or_run_drift() {
+    let root = temp_dir("artifact");
+    let artifact_path = root.join("artifact.json");
+    let source = "0123456789abcdef0123456789abcdef01234567";
+    let name = format!("rmux-canonical-linux-x86_64-{source}");
+    let digest = format!("sha256:{}", "a".repeat(64));
+    fs::write(
+        &artifact_path,
+        serde_json::json!({
+            "id": 88,
+            "name": name,
+            "digest": digest,
+            "expired": false,
+            "size_in_bytes": 123,
+            "workflow_run": {
+                "id": 77,
+                "repository_id": 1239918790,
+                "head_repository_id": 1239918790,
+                "head_sha": source
+            }
+        })
+        .to_string(),
+    )
+    .expect("write artifact fixture");
+    let script = repo_root().join("scripts/release/actions-artifact.py");
+    let github_output = root.join("github-output.txt");
+    let resolved = run(
+        &script,
+        &[
+            "resolve-id",
+            "--run-id",
+            "77",
+            "--artifact-id",
+            "88",
+            "--name",
+            &name,
+            "--expected-source-sha",
+            source,
+            "--artifact-json",
+            artifact_path.to_str().expect("artifact fixture path"),
+            "--github-output",
+            github_output.to_str().expect("GitHub output path"),
+        ],
+    );
+    assert!(
+        resolved.status.success(),
+        "{}",
+        String::from_utf8_lossy(&resolved.stderr)
+    );
+    let api_outputs = fs::read_to_string(&github_output).expect("read API outputs");
+    let expected_outputs = [
+        "artifact_id=88".to_owned(),
+        format!("artifact_digest={digest}"),
+        format!("artifact_name={name}"),
+    ];
+    assert_eq!(api_outputs.lines().count(), expected_outputs.len());
+    for expected in expected_outputs {
+        assert!(api_outputs.lines().any(|line| line == expected));
+    }
+
+    let accepted = run(
+        &script,
+        &[
+            "verify",
+            "--run-id",
+            "77",
+            "--artifact-id",
+            "88",
+            "--name",
+            &name,
+            "--expected-digest",
+            &digest,
+            "--expected-source-sha",
+            source,
+            "--artifact-json",
+            artifact_path.to_str().expect("artifact fixture path"),
+        ],
+    );
+    assert!(
+        accepted.status.success(),
+        "{}",
+        String::from_utf8_lossy(&accepted.stderr)
+    );
+    let rejected = run(
+        &script,
+        &[
+            "verify",
+            "--run-id",
+            "78",
+            "--artifact-id",
+            "88",
+            "--name",
+            &name,
+            "--expected-digest",
+            &digest,
+            "--expected-source-sha",
+            source,
+            "--artifact-json",
+            artifact_path.to_str().expect("artifact fixture path"),
+        ],
+    );
+    assert!(!rejected.status.success());
+
+    fs::write(
+        &artifact_path,
+        serde_json::json!({
+            "id": 88,
+            "name": name,
+            "digest": "a".repeat(64),
+            "expired": false,
+            "size_in_bytes": 123,
+            "workflow_run": {
+                "id": 77,
+                "repository_id": 1239918790,
+                "head_repository_id": 1239918790,
+                "head_sha": source
+            }
+        })
+        .to_string(),
+    )
+    .expect("write raw digest fixture");
+    let raw_digest = run(
+        &script,
+        &[
+            "resolve-id",
+            "--run-id",
+            "77",
+            "--artifact-id",
+            "88",
+            "--name",
+            &name,
+            "--expected-source-sha",
+            source,
+            "--artifact-json",
+            artifact_path.to_str().expect("artifact fixture path"),
+        ],
+    );
+    assert!(!raw_digest.status.success());
+    assert!(String::from_utf8_lossy(&raw_digest.stderr)
+        .contains("artifact digest is not a SHA-256 digest"));
+
+    let wrong_id = run(
+        &script,
+        &[
+            "resolve-id",
+            "--run-id",
+            "77",
+            "--artifact-id",
+            "89",
+            "--name",
+            &name,
+            "--expected-source-sha",
+            source,
+            "--artifact-json",
+            artifact_path.to_str().expect("artifact fixture path"),
+        ],
+    );
+    assert!(!wrong_id.status.success());
+    assert!(String::from_utf8_lossy(&wrong_id.stderr)
+        .contains("artifact ID does not match the requested ID"));
+
+    let unbounded_retry = run(
+        &script,
+        &[
+            "resolve-id",
+            "--run-id",
+            "77",
+            "--artifact-id",
+            "88",
+            "--name",
+            &name,
+            "--expected-source-sha",
+            source,
+            "--artifact-json",
+            artifact_path.to_str().expect("artifact fixture path"),
+            "--max-attempts",
+            "11",
+        ],
+    );
+    assert!(!unbounded_retry.status.success());
+    assert!(String::from_utf8_lossy(&unbounded_retry.stderr)
+        .contains("artifact lookup max attempts must be between 1 and 10"));
+    fs::remove_dir_all(root).expect("remove artifact fixture");
+}
+
+#[test]
+fn canonical_post_upload_binding_rejects_bundle_mutation() {
+    let root = temp_dir("binding");
+    let record = root.join("canonical-build-record.json");
+    let bundle = root.join("build-provenance.sigstore.json");
+    let binding = root.join("canonical-artifact-binding.json");
+    fs::write(&record, b"{\"record\":true}\n").expect("write build record fixture");
+    fs::write(&bundle, b"{\"bundle\":true}\n").expect("write attestation fixture");
+    let record_sha = "5898faeed3cd8f317892bae8c3a05873926b10cc762135e2fef6fbb7b597fcba";
+    let source = "0123456789abcdef0123456789abcdef01234567";
+    let name = format!("rmux-canonical-linux-x86_64-{source}");
+    let digest = format!("sha256:{}", "a".repeat(64));
+    let script = repo_root().join("scripts/release/canonical-artifact-binding.py");
+    let common = [
+        "--source-sha",
+        source,
+        "--candidate-run-id",
+        "77",
+        "--platform-key",
+        "linux-x86_64",
+        "--assets-artifact-id",
+        "88",
+        "--assets-artifact-name",
+        &name,
+        "--assets-artifact-digest",
+        &digest,
+        "--build-record",
+        record.to_str().expect("record path"),
+        "--build-record-sha256",
+        record_sha,
+        "--attestation-id",
+        "attestation-1",
+        "--attestation-bundle",
+        bundle.to_str().expect("bundle path"),
+    ];
+    let mut create = vec!["create"];
+    create.extend(common);
+    create.extend(["--output", binding.to_str().expect("binding path")]);
+    let created = run(&script, &create);
+    assert!(
+        created.status.success(),
+        "{}",
+        String::from_utf8_lossy(&created.stderr)
+    );
+    let mut verify = vec!["verify"];
+    verify.extend(common);
+    verify.extend(["--binding", binding.to_str().expect("binding path")]);
+    assert!(run(&script, &verify).status.success());
+
+    fs::write(&bundle, b"{\"bundle\":false}\n").expect("mutate attestation fixture");
+    assert!(!run(&script, &verify).status.success());
+    fs::remove_dir_all(root).expect("remove binding fixture");
+}
+
+#[test]
+fn canonical_runner_schema_is_a_target_specific_allowlist() {
+    let schema: serde_json::Value = serde_json::from_str(include_str!(
+        "../.github/release/schemas/candidate-manifest.schema.json"
+    ))
+    .expect("parse candidate manifest schema");
+    assert_eq!(
+        schema["properties"]["artifacts"]["items"]["properties"]["runner_image"]["enum"],
+        serde_json::json!([
+            "macos-15",
+            "macos-15-intel",
+            "ubuntu-22.04",
+            "ubuntu-22.04-arm",
+            "windows-latest"
+        ])
+    );
+    assert_eq!(
+        schema["properties"]["artifacts"]["items"]["allOf"]
+            .as_array()
+            .expect("target runner bindings")
+            .len(),
+        5
+    );
+    let contract: serde_json::Value = serde_json::from_str(include_str!(
+        "../.github/release/canonical-build-contract.json"
+    ))
+    .expect("parse canonical build contract");
+    assert_eq!(
+        contract["platforms"].as_array().expect("platforms").len(),
+        5
+    );
+}
+
+#[test]
+fn canonical_contract_loader_rejects_duplicate_json_keys() {
+    let root = temp_dir("duplicate-json");
+    let fixture = root.join("contract.json");
+    fs::write(&fixture, b"{\"schema_version\":1,\"schema_version\":1}\n")
+        .expect("write duplicate-key contract");
+    let script = concat!(
+        "import pathlib, sys; ",
+        "sys.path.insert(0, 'scripts/release'); ",
+        "from canonical_contract import _load; ",
+        "_load(pathlib.Path(sys.argv[1]))"
+    );
+    let rejected = run_python(&[
+        "-c",
+        script,
+        fixture.to_str().expect("contract fixture path"),
+    ]);
+    assert!(!rejected.status.success());
+    let stderr = String::from_utf8_lossy(&rejected.stderr);
+    assert!(stderr.contains("duplicate JSON object key"), "{stderr}");
+    fs::remove_dir_all(root).expect("remove duplicate-key fixture");
+}

--- a/tests/release_shadow_spec.rs
+++ b/tests/release_shadow_spec.rs
@@ -281,8 +281,13 @@ fn exact_run_verifier_accepts_only_the_contracted_job_set() {
         serde_json::from_slice(&accepted.stdout).expect("parse exact-run proof");
     assert_eq!(proof["run_id"], 42);
     assert_eq!(proof["run_attempt"], 1);
-    assert_eq!(proof["jobs"][0]["runner_group_id"], 0);
-    assert_eq!(proof["jobs"][0]["runner_group_name"], "GitHub Actions");
+    let hosted = proof["jobs"]
+        .as_array()
+        .expect("proof jobs")
+        .iter()
+        .find(|job| job["runner_group_id"] == 0)
+        .expect("hosted runner proof");
+    assert_eq!(hosted["runner_group_name"], "GitHub Actions");
 
     let original_jobs = fs::read_to_string(&jobs_path).expect("read accepted jobs fixture");
     let mut self_hosted: serde_json::Value =
@@ -322,7 +327,12 @@ fn exact_run_verifier_accepts_only_the_contracted_job_set() {
         .as_array_mut()
         .expect("jobs array")
         .iter_mut()
-        .find(|job| job["conclusion"] == "skipped")
+        .find(|job| {
+            job["conclusion"] == "skipped"
+                && job["labels"]
+                    .as_array()
+                    .is_some_and(|labels| !labels.is_empty())
+        })
         .expect("skipped fixture job");
     skipped["runner_id"] = serde_json::json!(1234);
     skipped["runner_name"] = serde_json::json!("GitHub Actions 1234");
@@ -339,7 +349,12 @@ fn exact_run_verifier_accepts_only_the_contracted_job_set() {
         .as_array_mut()
         .expect("jobs array")
         .iter_mut()
-        .find(|job| job["conclusion"] == "skipped")
+        .find(|job| {
+            job["conclusion"] == "skipped"
+                && job["labels"]
+                    .as_array()
+                    .is_some_and(|labels| !labels.is_empty())
+        })
         .expect("skipped fixture job");
     skipped
         .as_object_mut()
@@ -726,7 +741,8 @@ fn candidate_artifacts_allow_only_standard_github_runner_labels() {
         serde_json::json!([
             "macos-15",
             "macos-15-intel",
-            "ubuntu-latest",
+            "ubuntu-22.04",
+            "ubuntu-22.04-arm",
             "windows-latest"
         ])
     );


### PR DESCRIPTION
## Scope

PR3 adds object-cold, build-once native producers for the five contracted GitHub-hosted platforms. Every package is uploaded, rebound by numeric artifact ID and the API canonical `sha256:` digest, downloaded again, and smoke-tested from the persisted bytes.

The aggregate candidate manifest is intentionally sealed post-run in PR4: a run cannot exhaustively prove its own final job/artifact set before completion. PR3 emits the immutable build records and post-upload bindings consumed by that sealer.

## Safety

- draft stacked on PR #106
- no publishing trigger, environment, secret, tag, Release, or package-store authority
- literal GitHub-hosted runners only; no self-hosted or paid external runner
- fresh target, `CARGO_INCREMENTAL=0`, `--locked`, no object cache
- exact asset roles/checksums, Rust toolchain identity, build attestation, numeric artifact ID/API digest binding
- bounded post-upload API resolution (6 attempts x 2s)
- Windows package built once under static CRT and smoke-tested with the exact fast Nextest driver artifact

The initial implementation used upload-artifact output `artifact-digest`, which is raw hex while the contract requires the Actions API `sha256:` representation. Commit d1353e963 fixes this by resolving each uploaded artifact directly by numeric ID and binding the API digest; adversarial tests reject raw hex, wrong IDs, and excessive retries.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked --no-fail-fast`
- focused release suites
- release contract validation and Ruff
- actionlint 1.7.7 (known GitHub `macos-15-intel` label allowlisted)
- composite action metadata validated

No candidate dispatch was executed from this stacked branch; exact main/SHA/attempt-1 producer runs remain a post-merge simulation requirement.