### PR TITLE
test(windows): remove dynamic raw-probe compilation

### DIFF
--- a/tests/windows_attach_exit.rs
+++ b/tests/windows_attach_exit.rs
@@ -2339,38 +2339,7 @@ fn write_python_descendant_sleep_script(label: &str) -> Result<PathBuf, Box<dyn 
 }
 
 const RAW_CONSOLE_PROBE_SCRIPT: &str = r#"
-Add-Type @"
-using System;
-using System.ComponentModel;
-using System.Runtime.InteropServices;
-
-public static class RmuxRawConsoleProbe {
-    private const int STD_INPUT_HANDLE = -10;
-    private const uint ENABLE_PROCESSED_INPUT = 0x0001;
-
-    [DllImport("kernel32.dll", SetLastError = true)]
-    private static extern IntPtr GetStdHandle(int nStdHandle);
-
-    [DllImport("kernel32.dll", SetLastError = true)]
-    private static extern bool GetConsoleMode(IntPtr hConsoleHandle, out uint lpMode);
-
-    [DllImport("kernel32.dll", SetLastError = true)]
-    private static extern bool SetConsoleMode(IntPtr hConsoleHandle, uint dwMode);
-
-    public static void DisableProcessedInput() {
-        IntPtr handle = GetStdHandle(STD_INPUT_HANDLE);
-        uint mode;
-        if (!GetConsoleMode(handle, out mode)) {
-            throw new Win32Exception(Marshal.GetLastWin32Error());
-        }
-        if (!SetConsoleMode(handle, mode & ~ENABLE_PROCESSED_INPUT)) {
-            throw new Win32Exception(Marshal.GetLastWin32Error());
-        }
-    }
-}
-"@
-
-[RmuxRawConsoleProbe]::DisableProcessedInput()
+[Console]::TreatControlCAsInput = $true
 [Console]::Out.WriteLine("RAW_READY")
 [Console]::Out.Flush()
 while ($true) {


### PR DESCRIPTION
Replace the raw-console probe\u2019s runtime C# compilation with the equivalent .NET console API. This removes cold-run startup variance while preserving the Ctrl-C raw-input oracle.\n\nValidation:\n- cargo fmt --all -- --check\n- cargo clippy --locked --target x86_64-pc-windows-gnu --test windows_attach_exit -- -D warnings