### PR TITLE
ci: align candidate gate runner contract

### DIFF
--- a/.github/release/candidate-contract.json
+++ b/.github/release/candidate-contract.json
@@ -29,7 +29,8 @@
       "ubuntu-22.04": [
         "Build canonical native artifacts / Canonical build linux-x86_64",
         "Build canonical native artifacts / Canonical native build gate",
-        "Build canonical native artifacts / Canonical smoke linux-x86_64"
+        "Build canonical native artifacts / Canonical smoke linux-x86_64",
+        "Release candidate gate"
       ],
       "ubuntu-22.04-arm": [
         "Build canonical native artifacts / Canonical build linux-aarch64",
@@ -52,7 +53,6 @@
         "Nix flake gate",
         "Platform build and smoke on windows-latest",
         "Release candidate delta gate",
-        "Release candidate gate",
         "Release review (${{ matrix.section }})",
         "Release review (cli)",
         "Release review (lint)",

--- a/tests/release_candidate_spec.rs
+++ b/tests/release_candidate_spec.rs
@@ -63,6 +63,26 @@ fn candidate_route_proves_fast_before_release_only_work() {
 }
 
 #[test]
+fn release_candidate_gate_runner_contract_matches_workflow() {
+    let ci = include_str!("../.github/workflows/ci.yml");
+    let gate = job_block(ci, "release-candidate-gate", "linux-quality");
+    assert!(gate.contains("runs-on: ubuntu-22.04"));
+
+    let contract: serde_json::Value =
+        serde_json::from_str(include_str!("../.github/release/candidate-contract.json"))
+            .expect("parse candidate contract");
+    let jobs = &contract["runner_policy"]["jobs_by_label"];
+    let pinned = jobs["ubuntu-22.04"]
+        .as_array()
+        .expect("ubuntu-22.04 runner inventory");
+    let floating = jobs["ubuntu-latest"]
+        .as_array()
+        .expect("ubuntu-latest runner inventory");
+    assert!(pinned.iter().any(|job| job == "Release candidate gate"));
+    assert!(!floating.iter().any(|job| job == "Release candidate gate"));
+}
+
+#[test]
 fn candidate_mode_does_not_replay_fast_jobs() {
     let ci = include_str!("../.github/workflows/ci.yml");
     let fast_jobs = [


### PR DESCRIPTION
The release candidate gate runs on `ubuntu-22.04`, but the evidence contract expected `ubuntu-latest`. This aligns the contract with the workflow and adds a focused regression test.

Validation:
- `python3 scripts/release/validate-contracts.py`
- `cargo test --locked --test release_candidate_spec`
- `cargo clippy --locked --test release_candidate_spec -- -D warnings`
- `cargo fmt --all -- --check`