### PR TITLE
ci: fix exact artifact extraction layout

### DIFF
--- a/.github/actions/canonical-smoke/action.yml
+++ b/.github/actions/canonical-smoke/action.yml
@@ -89,6 +89,7 @@ runs:
       uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
       with:
         artifact-ids: ${{ inputs.assets-artifact-id }}
+        merge-multiple: true
         path: ${{ runner.temp }}/rmux-canonical-download
 
     - name: Verify the build record and all downloaded bytes
@@ -176,6 +177,7 @@ runs:
       uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
       with:
         artifact-ids: ${{ inputs.fast-nextest-artifact-id }}
+        merge-multiple: true
         path: ${{ runner.temp }}/rmux-fast-nextest
         github-token: ${{ github.token }}
         repository: ${{ github.repository }}

--- a/.github/actions/release-publication-inputs/action.yml
+++ b/.github/actions/release-publication-inputs/action.yml
@@ -77,6 +77,7 @@ runs:
       uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
       with:
         artifact-ids: ${{ inputs.manifest-artifact-id }}
+        merge-multiple: true
         path: ${{ runner.temp }}/rmux-publication/manifest
         github-token: ${{ inputs.github-token }}
         repository: ${{ inputs.repository }}
@@ -95,6 +96,7 @@ runs:
       uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
       with:
         artifact-ids: ${{ inputs.authorization-artifact-id }}
+        merge-multiple: true
         path: ${{ runner.temp }}/rmux-publication/authorization
         github-token: ${{ inputs.github-token }}
         repository: ${{ inputs.repository }}
@@ -104,6 +106,7 @@ runs:
       uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
       with:
         artifact-ids: ${{ inputs.envelope-artifact-id }}
+        merge-multiple: true
         path: ${{ runner.temp }}/rmux-publication/envelope
         github-token: ${{ inputs.github-token }}
         repository: ${{ inputs.repository }}

--- a/.github/release/candidate-contract.json
+++ b/.github/release/candidate-contract.json
@@ -498,6 +498,7 @@
     "tests/reference/tmux_compat/divergences.toml",
     "tests/reference/tmux_compat/error_exit_matrix.yaml",
     "tests/reference/tmux_compat/frozen_reference.yaml",
+    "tests/release_artifact_download_spec.rs",
     "tests/release_automation_spec.rs",
     "tests/release_candidate_artifacts_spec.rs",
     "tests/release_candidate_manifest_spec.rs",

--- a/.github/workflows/release-chocolatey-retry.yml
+++ b/.github/workflows/release-chocolatey-retry.yml
@@ -166,6 +166,7 @@ jobs:
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           artifact-ids: ${{ inputs.receipt_artifact_id }}
+          merge-multiple: true
           path: ${{ runner.temp }}/rmux-chocolatey-retry/receipt
           github-token: ${{ github.token }}
           repository: ${{ github.repository }}
@@ -174,6 +175,7 @@ jobs:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           artifact-ids: ${{ inputs.receipt_envelope_artifact_id }}
+          merge-multiple: true
           path: ${{ runner.temp }}/rmux-chocolatey-retry/receipt-envelope
           github-token: ${{ github.token }}
           repository: ${{ github.repository }}
@@ -182,6 +184,7 @@ jobs:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           artifact-ids: ${{ inputs.prior_result_artifact_id }}
+          merge-multiple: true
           path: ${{ runner.temp }}/rmux-chocolatey-retry/result
           github-token: ${{ github.token }}
           repository: ${{ github.repository }}
@@ -190,6 +193,7 @@ jobs:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           artifact-ids: ${{ inputs.prior_result_envelope_artifact_id }}
+          merge-multiple: true
           path: ${{ runner.temp }}/rmux-chocolatey-retry/result-envelope
           github-token: ${{ github.token }}
           repository: ${{ github.repository }}

--- a/.github/workflows/release-downstream.yml
+++ b/.github/workflows/release-downstream.yml
@@ -113,6 +113,7 @@ jobs:
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           artifact-ids: ${{ inputs.receipt_artifact_id }}
+          merge-multiple: true
           path: ${{ runner.temp }}/rmux-downstream/receipt
           github-token: ${{ github.token }}
           repository: ${{ github.repository }}
@@ -122,6 +123,7 @@ jobs:
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           artifact-ids: ${{ inputs.receipt_envelope_artifact_id }}
+          merge-multiple: true
           path: ${{ runner.temp }}/rmux-downstream/envelope
           github-token: ${{ github.token }}
           repository: ${{ github.repository }}
@@ -375,6 +377,7 @@ jobs:
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           artifact-ids: ${{ needs.prepare-plan.outputs.plan_artifact_id }}
+          merge-multiple: true
           path: ${{ runner.temp }}/rmux-downstream-summary
 
       - name: Fail closed before consuming incomplete channel results
@@ -439,6 +442,7 @@ jobs:
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           artifact-ids: ${{ needs.prepare-plan.outputs.plan_artifact_id }}
+          merge-multiple: true
           path: ${{ runner.temp }}/rmux-downstream-summary
 
       - name: Fail closed before consuming incomplete channel results

--- a/.github/workflows/release-policy-audit.yml
+++ b/.github/workflows/release-policy-audit.yml
@@ -171,6 +171,7 @@ jobs:
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           artifact-ids: ${{ needs.prepare-policy-audit.outputs.bundle_artifact_id }}
+          merge-multiple: true
           path: ${{ runner.temp }}/rmux-policy-audit
           github-token: ${{ github.token }}
           repository: ${{ github.repository }}

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -112,6 +112,7 @@ jobs:
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           artifact-ids: ${{ inputs.candidate_manifest_artifact_id }}
+          merge-multiple: true
           path: ${{ runner.temp }}/rmux-promotion/evidence
           github-token: ${{ github.token }}
           repository: ${{ github.repository }}
@@ -121,6 +122,7 @@ jobs:
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           artifact-ids: ${{ inputs.signed_tag_artifact_id }}
+          merge-multiple: true
           path: ${{ runner.temp }}/rmux-promotion/tag
           github-token: ${{ github.token }}
           repository: ${{ github.repository }}
@@ -368,6 +370,7 @@ jobs:
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           artifact-ids: ${{ needs.verify-candidate.outputs.bundle_artifact_id }}
+          merge-multiple: true
           path: ${{ runner.temp }}/rmux-authorization/verified
           github-token: ${{ github.token }}
           repository: ${{ github.repository }}
@@ -377,6 +380,7 @@ jobs:
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           artifact-ids: ${{ needs.policy-audit.outputs.policy_audit_reference_artifact_id }}
+          merge-multiple: true
           path: ${{ runner.temp }}/rmux-authorization/policy
           github-token: ${{ github.token }}
           repository: ${{ github.repository }}

--- a/.github/workflows/release-receipt.yml
+++ b/.github/workflows/release-receipt.yml
@@ -91,6 +91,7 @@ jobs:
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           artifact-ids: ${{ inputs.authorization_artifact_id }}
+          merge-multiple: true
           path: ${{ runner.temp }}/rmux-receipt/authorization
           github-token: ${{ github.token }}
           repository: ${{ github.repository }}
@@ -100,6 +101,7 @@ jobs:
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           artifact-ids: ${{ inputs.authorization_envelope_artifact_id }}
+          merge-multiple: true
           path: ${{ runner.temp }}/rmux-receipt/envelope
           github-token: ${{ github.token }}
           repository: ${{ github.repository }}

--- a/.github/workflows/release-snap-retry.yml
+++ b/.github/workflows/release-snap-retry.yml
@@ -166,6 +166,7 @@ jobs:
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           artifact-ids: ${{ inputs.receipt_artifact_id }}
+          merge-multiple: true
           path: ${{ runner.temp }}/rmux-snap-retry/receipt
           github-token: ${{ github.token }}
           repository: ${{ github.repository }}
@@ -174,6 +175,7 @@ jobs:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           artifact-ids: ${{ inputs.receipt_envelope_artifact_id }}
+          merge-multiple: true
           path: ${{ runner.temp }}/rmux-snap-retry/receipt-envelope
           github-token: ${{ github.token }}
           repository: ${{ github.repository }}
@@ -182,6 +184,7 @@ jobs:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           artifact-ids: ${{ inputs.prior_result_artifact_id }}
+          merge-multiple: true
           path: ${{ runner.temp }}/rmux-snap-retry/result
           github-token: ${{ github.token }}
           repository: ${{ github.repository }}
@@ -190,6 +193,7 @@ jobs:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           artifact-ids: ${{ inputs.prior_result_envelope_artifact_id }}
+          merge-multiple: true
           path: ${{ runner.temp }}/rmux-snap-retry/result-envelope
           github-token: ${{ github.token }}
           repository: ${{ github.repository }}

--- a/.github/workflows/release-tag-authoring.yml
+++ b/.github/workflows/release-tag-authoring.yml
@@ -116,6 +116,7 @@ jobs:
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           artifact-ids: ${{ inputs.candidate_manifest_artifact_id }}
+          merge-multiple: true
           path: ${{ runner.temp }}/rmux-tag-input
           github-token: ${{ github.token }}
           repository: ${{ github.repository }}
@@ -218,6 +219,7 @@ jobs:
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           artifact-ids: ${{ needs.verify-tag-inputs.outputs.bundle_artifact_id }}
+          merge-multiple: true
           path: ${{ runner.temp }}/rmux-tag-input
           github-token: ${{ github.token }}
           repository: ${{ github.repository }}

--- a/tests/release_artifact_download_spec.rs
+++ b/tests/release_artifact_download_spec.rs
@@ -1,0 +1,86 @@
+const SOURCES: &[(&str, &str)] = &[
+    (
+        ".github/actions/canonical-smoke/action.yml",
+        include_str!("../.github/actions/canonical-smoke/action.yml"),
+    ),
+    (
+        ".github/actions/release-publication-inputs/action.yml",
+        include_str!("../.github/actions/release-publication-inputs/action.yml"),
+    ),
+    (
+        ".github/workflows/release-chocolatey-retry.yml",
+        include_str!("../.github/workflows/release-chocolatey-retry.yml"),
+    ),
+    (
+        ".github/workflows/release-downstream.yml",
+        include_str!("../.github/workflows/release-downstream.yml"),
+    ),
+    (
+        ".github/workflows/release-policy-audit.yml",
+        include_str!("../.github/workflows/release-policy-audit.yml"),
+    ),
+    (
+        ".github/workflows/release-promote.yml",
+        include_str!("../.github/workflows/release-promote.yml"),
+    ),
+    (
+        ".github/workflows/release-receipt.yml",
+        include_str!("../.github/workflows/release-receipt.yml"),
+    ),
+    (
+        ".github/workflows/release-shadow.yml",
+        include_str!("../.github/workflows/release-shadow.yml"),
+    ),
+    (
+        ".github/workflows/release-snap-retry.yml",
+        include_str!("../.github/workflows/release-snap-retry.yml"),
+    ),
+    (
+        ".github/workflows/release-tag-authoring.yml",
+        include_str!("../.github/workflows/release-tag-authoring.yml"),
+    ),
+];
+
+fn indentation(line: &str) -> usize {
+    line.len() - line.trim_start().len()
+}
+
+#[test]
+fn exact_single_artifact_downloads_extract_into_the_requested_directory() {
+    let mut single_downloads = 0;
+    let mut multi_downloads = 0;
+
+    for (path, source) in SOURCES {
+        let lines: Vec<_> = source.lines().collect();
+        for (index, line) in lines.iter().enumerate() {
+            let Some(value) = line.trim().strip_prefix("artifact-ids:") else {
+                continue;
+            };
+            let value = value.trim();
+            let key_indent = indentation(line);
+            let merge = lines[index + 1..]
+                .iter()
+                .take_while(|next| next.trim().is_empty() || indentation(next) >= key_indent)
+                .find_map(|next| next.trim().strip_prefix("merge-multiple:").map(str::trim));
+
+            if value == "${{ steps.artifacts.outputs.artifact_ids }}" {
+                multi_downloads += 1;
+                assert_ne!(
+                    merge,
+                    Some("true"),
+                    "{path}:{index} flattens eleven artifacts"
+                );
+            } else {
+                single_downloads += 1;
+                assert_eq!(
+                    merge,
+                    Some("true"),
+                    "{path}:{index} leaves one artifact in an unexpected name directory"
+                );
+            }
+        }
+    }
+
+    assert_eq!(single_downloads, 26);
+    assert_eq!(multi_downloads, 3);
+}

--- a/tests/release_canonical_build_spec.rs
+++ b/tests/release_canonical_build_spec.rs
@@ -185,6 +185,7 @@ fn canonical_producers_are_object_cold_and_non_publishing() {
 #[test]
 fn canonical_smokes_consume_numeric_ids_and_exact_fast_drivers() {
     let smoke = include_str!("../.github/actions/canonical-smoke/action.yml");
+    assert_eq!(smoke.matches("merge-multiple: true").count(), 2);
     for required in [
         "artifact-ids: ${{ inputs.assets-artifact-id }}",
         "test \"$RUNNER_ENVIRONMENT\" = github-hosted",

--- a/tests/release_downstream_retry_spec.rs
+++ b/tests/release_downstream_retry_spec.rs
@@ -191,7 +191,7 @@ fn retries_bind_exact_receipt_result_origin_and_closed_bundle() {
         );
         assert_eq!(prepare.matches("--max-attempts 1").count(), 5);
         assert!(!prepare.contains("pattern:"));
-        assert!(!prepare.contains("merge-multiple:"));
+        assert_eq!(prepare.matches("merge-multiple: true").count(), 4);
         for exact_file in [
             "channel-payload.json",
             "downstream-channel-plan.json",

--- a/tests/release_downstream_workflows_spec.rs
+++ b/tests/release_downstream_workflows_spec.rs
@@ -174,7 +174,7 @@ fn exact_receipt_ids_digests_origin_and_documents_are_bound() {
         2
     );
     assert!(!prepare.contains("pattern:"));
-    assert!(!prepare.contains("merge-multiple:"));
+    assert_eq!(prepare.matches("merge-multiple: true").count(), 2);
     assert!(prepare.contains("receipt predicate acquired downstream authority"));
     assert!(prepare.contains("receipt envelope acquired downstream authority"));
     assert!(prepare.contains("receipt artifact contains a symlink"));

--- a/tests/release_promoter_workflows_spec.rs
+++ b/tests/release_promoter_workflows_spec.rs
@@ -165,7 +165,7 @@ fn promotion_splits_oidc_from_contents_write_and_keeps_exact_dag() {
     assert!(verify.contains("stage-candidate-release.py"));
     assert!(CANDIDATE_STAGING.contains("item.get(\"role\") == \"checksums\""));
     assert!(CANDIDATE_STAGING.contains("args.output / \"SHA256SUMS\""));
-    assert!(!PROMOTE.contains("merge-multiple:"));
+    assert_eq!(PROMOTE.matches("merge-multiple: true").count(), 4);
     assert!(authorize.contains("rmux-authorization/verified"));
     assert!(authorize.contains("rmux-authorization/policy"));
     assert!(audit.contains("if: ${{ false }}"));
@@ -219,7 +219,7 @@ fn receipt_is_separate_receipt_only_and_never_writes_contents() {
     assert!(!receipt.contains("contents: write"));
     assert!(!RECEIPT.contains("gh release"));
     assert!(!RECEIPT.contains("git push"));
-    assert!(!RECEIPT.contains("merge-multiple:"));
+    assert_eq!(RECEIPT.matches("merge-multiple: true").count(), 2);
     assert!(RECEIPT.contains("rmux-receipt/authorization"));
     assert!(RECEIPT.contains("rmux-receipt/envelope"));
     assert!(RECEIPT.contains("actions/runs/$RMUX_AUTHORIZATION_RUN_ID"));


### PR DESCRIPTION
`actions/download-artifact` nests `artifact-ids` downloads by artifact name unless `merge-multiple` is enabled. The release consumers expected direct extraction.

This enables direct extraction only for 26 downloads that each receive one exact, prevalidated numeric artifact ID. The three eleven-artifact downloads remain separated by name. A regression test enforces that distinction across every release workflow.

Validation:
- 25 focused release tests
- `cargo clippy --locked --test release_artifact_download_spec -- -D warnings`
- `python3 scripts/release/validate-contracts.py`
- YAML parse, Rustfmt, diff check