### PR TITLE
ci: fix canonical Windows package smokes

### DIFF
--- a/.github/actions/canonical-smoke/action.yml
+++ b/.github/actions/canonical-smoke/action.yml
@@ -193,6 +193,13 @@ runs:
         test -f windows-nextest.tar.zst.sha256
         sha256sum --check windows-nextest.tar.zst.sha256
 
+    - name: Install cargo-nextest for persisted Windows test drivers
+      if: runner.os == 'Windows' && inputs.smoke-kind != 'runtime'
+      uses: taiki-e/install-action@c7eb1735f09259a5035e8e5d44b1406b1cddc0fb # v2.83.0
+      with:
+        tool: nextest@0.9.138
+        fallback: none
+
     - name: Smoke persisted Windows runtime bytes
       if: runner.os == 'Windows' && inputs.smoke-kind == 'runtime'
       shell: pwsh

--- a/scripts/verify-package-windows.ps1
+++ b/scripts/verify-package-windows.ps1
@@ -447,14 +447,14 @@ function InvokeCtrlMatrixSmoke([string]$Binary, [string]$GitSha, [string]$Eviden
     $outDir = Join-Path ([System.IO.Path]::GetTempPath()) "rmux-package-ctrl-matrix-$PID-$([guid]::NewGuid().ToString('N'))"
     try {
         $global:LASTEXITCODE = 0
-        $arguments = @(
-            "-Rmux", [System.IO.Path]::GetFullPath($Binary),
-            "-OutDir", $outDir,
-            "-PortableSmokeOnly",
-            "-ExpectedGitSha", $GitSha
-        )
+        $arguments = @{
+            Rmux = [System.IO.Path]::GetFullPath($Binary)
+            OutDir = $outDir
+            PortableSmokeOnly = $true
+            ExpectedGitSha = $GitSha
+        }
         if (-not [string]::IsNullOrWhiteSpace($Evidence)) {
-            $arguments += @("-EvidencePath", [System.IO.Path]::GetFullPath($Evidence))
+            $arguments.EvidencePath = [System.IO.Path]::GetFullPath($Evidence)
         }
         & (Join-Path $PSScriptRoot "windows_ctrl_matrix.ps1") @arguments
         if ($LASTEXITCODE -ne 0) {

--- a/tests/release_canonical_build_spec.rs
+++ b/tests/release_canonical_build_spec.rs
@@ -195,6 +195,10 @@ fn canonical_smokes_consume_numeric_ids_and_exact_fast_drivers() {
         "artifact-ids: ${{ inputs.fast-nextest-artifact-id }}",
         "windows-nextest.tar.zst.sha256",
         "sha256sum --check",
+        "Install cargo-nextest for persisted Windows test drivers",
+        "uses: taiki-e/install-action@c7eb1735f09259a5035e8e5d44b1406b1cddc0fb",
+        "tool: nextest@0.9.138",
+        "fallback: none",
         "inputs.smoke-kind == 'runtime'",
         "inputs.smoke-kind == 'sdk'",
         "inputs.smoke-kind == 'mouse'",
@@ -204,6 +208,7 @@ fn canonical_smokes_consume_numeric_ids_and_exact_fast_drivers() {
     ] {
         assert!(smoke.contains(required), "canonical smoke lost {required}");
     }
+    assert_eq!(smoke.matches("tool: nextest@0.9.138").count(), 1);
     let record_step = smoke
         .split("    - name: Verify the build record and all downloaded bytes\n")
         .nth(1)

--- a/tests/windows_ctrl_matrix_spec.rs
+++ b/tests/windows_ctrl_matrix_spec.rs
@@ -169,11 +169,18 @@ fn windows_release_gate_uses_hosted_checks_and_nonempty_cargo_filters() {
     assert!(
         package_verify.contains("RunCtrlMatrixSmoke")
             && package_verify.contains("windows_ctrl_matrix.ps1")
-            && package_verify.contains("-PortableSmokeOnly")
+            && package_verify.contains("PortableSmokeOnly = $true")
             && package_verify.contains("ExpectedGitSha")
             && package_verify.contains("CtrlMatrixEvidence")
             && package_verify.contains("produced no passing evidence"),
         "manual Windows package verification must keep the optional interactive Ctrl matrix smoke"
+    );
+    assert!(
+        package_verify.contains("$arguments = @{\n            Rmux =")
+            && package_verify.contains("PortableSmokeOnly = $true")
+            && package_verify.contains("$arguments.EvidencePath =")
+            && !package_verify.contains("\"-Rmux\", [System.IO.Path]::GetFullPath($Binary)"),
+        "PowerShell script parameters must use named hashtable splatting"
     );
     assert!(workflow.contains("if-no-files-found: error"));
 }


### PR DESCRIPTION
Fix the two failures exposed by canonical Windows qualification:

- install the pinned cargo-nextest tool before consuming persisted Nextest archives;
- pass the Ctrl matrix parameters through named PowerShell splatting.

Adds focused release-contract regressions. No release capability is enabled.