### PR TITLE
ci: keep canonical Windows smoke headless

### DIFF
--- a/.github/actions/canonical-smoke/action.yml
+++ b/.github/actions/canonical-smoke/action.yml
@@ -214,7 +214,6 @@ runs:
           -Checksums "$assets/SHA256SUMS.txt" `
           -RunBinary `
           -RunDaemonSmoke `
-          -RunCtrlMatrixSmoke `
           -RequireReleaseArtifact `
           -ExpectedGitSha $env:RMUX_EXPECTED_GIT_SHA
 

--- a/tests/release_canonical_build_spec.rs
+++ b/tests/release_canonical_build_spec.rs
@@ -202,13 +202,18 @@ fn canonical_smokes_consume_numeric_ids_and_exact_fast_drivers() {
         "inputs.smoke-kind == 'runtime'",
         "inputs.smoke-kind == 'sdk'",
         "inputs.smoke-kind == 'mouse'",
-        "-RunCtrlMatrixSmoke",
+        "-RunBinary",
+        "-RunDaemonSmoke",
         "-RunSdkSmoke",
         "-RunMouseBorderSmoke",
     ] {
         assert!(smoke.contains(required), "canonical smoke lost {required}");
     }
     assert_eq!(smoke.matches("tool: nextest@0.9.138").count(), 1);
+    assert!(
+        !smoke.contains("-RunCtrlMatrixSmoke"),
+        "GitHub-hosted canonical smokes cannot run the interactive Ctrl matrix"
+    );
     let record_step = smoke
         .split("    - name: Verify the build record and all downloaded bytes\n")
         .nth(1)

--- a/tests/windows_ctrl_matrix_spec.rs
+++ b/tests/windows_ctrl_matrix_spec.rs
@@ -117,6 +117,7 @@ fn windows_release_gate_uses_hosted_checks_and_nonempty_cargo_filters() {
     let gate = include_str!("../scripts/gate-windows-fast.ps1");
     let assert_filter = include_str!("../scripts/assert-cargo-filter-nonempty.ps1");
     let package_verify = include_str!("../scripts/verify-package-windows.ps1");
+    let canonical_smoke = include_str!("../.github/actions/canonical-smoke/action.yml");
 
     for required in [
         r#"Run "./scripts/assert-cargo-filter-nonempty.ps1" @("1", "--", "test", "-p", "rmux-client", "--locked", "output_writer_failure_wakes")"#,
@@ -181,6 +182,12 @@ fn windows_release_gate_uses_hosted_checks_and_nonempty_cargo_filters() {
             && package_verify.contains("$arguments.EvidencePath =")
             && !package_verify.contains("\"-Rmux\", [System.IO.Path]::GetFullPath($Binary)"),
         "PowerShell script parameters must use named hashtable splatting"
+    );
+    assert!(
+        canonical_smoke.contains("-RunBinary")
+            && canonical_smoke.contains("-RunDaemonSmoke")
+            && !canonical_smoke.contains("-RunCtrlMatrixSmoke"),
+        "GitHub-hosted package smokes must not require an interactive Windows session"
     );
     assert!(workflow.contains("if-no-files-found: error"));
 }


### PR DESCRIPTION
Keep canonical GitHub-hosted Windows qualification compatible with Session 0. Runtime qualification still exercises the persisted binary and daemon bytes; the interactive Ctrl matrix remains available as a local Windows diagnostic.

Adds regression contracts preventing the hosted smoke from regaining an interactive-runner dependency. No release capability is enabled.