### PR TITLE
ci: canonicalize release asset ordering

### DIFF
--- a/scripts/release/canonical-build-record.py
+++ b/scripts/release/canonical-build-record.py
@@ -164,7 +164,11 @@ def asset_files(directory: Path, platform: dict[str, Any]) -> list[dict[str, Any
     if not root.is_dir():
         raise ValueError("assets path must be a directory")
     files: list[dict[str, Any]] = []
-    for path in sorted(root.rglob("*")):
+    paths = sorted(
+        root.rglob("*"),
+        key=lambda path: path.relative_to(root).as_posix().encode("utf-8"),
+    )
+    for path in paths:
         if path.is_symlink():
             raise ValueError(f"canonical assets cannot contain symlinks: {path}")
         if path.is_dir():

--- a/tests/release_canonical_build_spec.rs
+++ b/tests/release_canonical_build_spec.rs
@@ -309,6 +309,25 @@ fn canonical_record_rejects_mutated_record_or_downloaded_bytes() {
         "{}",
         String::from_utf8_lossy(&created.stderr)
     );
+    let created_record: serde_json::Value =
+        serde_json::from_slice(&fs::read(&record).expect("read created record"))
+            .expect("parse created record");
+    let created_paths = created_record["files"]
+        .as_array()
+        .expect("created record files")
+        .iter()
+        .map(|entry| entry["path"].as_str().expect("created record file path"))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        created_paths,
+        [
+            "SHA256SUMS.txt",
+            "rmux-0.9.0-1.x86_64.rpm",
+            "rmux-0.9.0-linux-x86_64.tar.gz",
+            "rmux_0.9.0_amd64.deb",
+        ],
+        "canonical asset order must not depend on host path semantics"
+    );
     let record_sha = String::from_utf8(created.stdout).expect("record digest is UTF-8");
     let record_sha = record_sha.trim();
     let mut verify = vec!["verify"];


### PR DESCRIPTION
Make canonical release records independent of host path comparison semantics. Asset paths are now ordered by their POSIX UTF-8 representation, so records produced on Windows verify identically on Linux.

Adds a cross-platform record-order regression. No release capability is enabled.