### PR TITLE
ci: bind audit environment secret

### DIFF
--- a/.github/workflows/release-policy-audit.yml
+++ b/.github/workflows/release-policy-audit.yml
@@ -2,6 +2,9 @@ name: Disarmed reusable release policy audit
 
 on:
   workflow_call:
+    secrets:
+      RMUX_POLICY_AUDIT_APP_PRIVATE_KEY:
+        required: false
     inputs:
       simulation:
         required: false

--- a/scripts/release/policy_audit_contract.py
+++ b/scripts/release/policy_audit_contract.py
@@ -244,6 +244,12 @@ def validate_repository_contracts(root: Path) -> None:
             raise ValueError(f"policy audit gained public trigger {trigger.strip()}")
     if workflow.count("\n    if: ${{ inputs.simulation }}") != 1:
         raise ValueError("privileged policy audit must be simulation-only before PR8")
+    if (
+        "    secrets:\n"
+        "      RMUX_POLICY_AUDIT_APP_PRIVATE_KEY:\n"
+        "        required: false\n"
+    ) not in workflow:
+        raise ValueError("policy audit App key must be declared for workflow_call")
     required_markers = (
         "assert-release-capability.py policy_audit",
         "environment: release-policy-audit",

--- a/tests/release_policy_audit_spec.rs
+++ b/tests/release_policy_audit_spec.rs
@@ -21,6 +21,9 @@ fn policy_audit_simulation_is_nonpublishing_with_two_exact_callers() {
     .expect("parse policy audit contract");
 
     assert!(workflow.contains("on:\n  workflow_call:"));
+    assert!(workflow.contains(
+        "    secrets:\n      RMUX_POLICY_AUDIT_APP_PRIVATE_KEY:\n        required: false\n"
+    ));
     assert_eq!(
         workflow
             .matches("\n    if: ${{ inputs.simulation }}")


### PR DESCRIPTION
Declare the audit App key in the reusable workflow contract so the protected environment can supply it at job start.

Adds contract and regression checks; no release capability is enabled.