### PR TITLE
ci: forward audit environment secret binding

### DIFF
--- a/.github/workflows/release-policy-audit.yml
+++ b/.github/workflows/release-policy-audit.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     secrets:
       RMUX_POLICY_AUDIT_APP_PRIVATE_KEY:
-        required: false
+        required: true
     inputs:
       simulation:
         required: false

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -308,6 +308,8 @@ jobs:
     needs: verify-candidate
     if: ${{ false }}
     uses: ./.github/workflows/release-policy-audit.yml
+    secrets:
+      RMUX_POLICY_AUDIT_APP_PRIVATE_KEY: ${{ github.token }}
     with:
       candidate_run_id: ${{ inputs.candidate_run_id }}
       candidate_manifest_run_id: ${{ inputs.candidate_manifest_run_id }}

--- a/.github/workflows/release-promotion-simulation.yml
+++ b/.github/workflows/release-promotion-simulation.yml
@@ -61,6 +61,8 @@ jobs:
       actions: read
       contents: read
     uses: ./.github/workflows/release-policy-audit.yml
+    secrets:
+      RMUX_POLICY_AUDIT_APP_PRIVATE_KEY: ${{ github.token }}
     with:
       simulation: true
       candidate_run_id: ${{ inputs.candidate_run_id }}

--- a/scripts/release/policy_audit_contract.py
+++ b/scripts/release/policy_audit_contract.py
@@ -247,7 +247,7 @@ def validate_repository_contracts(root: Path) -> None:
     if (
         "    secrets:\n"
         "      RMUX_POLICY_AUDIT_APP_PRIVATE_KEY:\n"
-        "        required: false\n"
+        "        required: true\n"
     ) not in workflow:
         raise ValueError("policy audit App key must be declared for workflow_call")
     required_markers = (
@@ -287,6 +287,16 @@ def validate_repository_contracts(root: Path) -> None:
         caller_paths.extend([candidate.name] * count)
     if caller_paths != ["release-promote.yml", "release-promotion-simulation.yml"]:
         raise ValueError("policy audit callers differ from the exact allowlist")
+    secret_forwarding = (
+        "    secrets:\n"
+        "      RMUX_POLICY_AUDIT_APP_PRIVATE_KEY: ${{ github.token }}\n"
+    )
+    for caller_name in caller_paths:
+        caller = (root / ".github" / "workflows" / caller_name).read_text(
+            encoding="utf-8"
+        )
+        if caller.count(secret_forwarding) != 1 or "secrets: inherit" in caller:
+            raise ValueError(f"policy audit secret forwarding changed in {caller_name}")
     promote = (root / ".github/workflows/release-promote.yml").read_text(
         encoding="utf-8"
     )

--- a/tests/release_policy_audit_spec.rs
+++ b/tests/release_policy_audit_spec.rs
@@ -22,7 +22,7 @@ fn policy_audit_simulation_is_nonpublishing_with_two_exact_callers() {
 
     assert!(workflow.contains("on:\n  workflow_call:"));
     assert!(workflow.contains(
-        "    secrets:\n      RMUX_POLICY_AUDIT_APP_PRIVATE_KEY:\n        required: false\n"
+        "    secrets:\n      RMUX_POLICY_AUDIT_APP_PRIVATE_KEY:\n        required: true\n"
     ));
     assert_eq!(
         workflow
@@ -123,6 +123,17 @@ fn policy_audit_simulation_is_nonpublishing_with_two_exact_callers() {
     assert_eq!(callers.len(), 2, "policy audit must have two exact callers");
     assert!(callers[0].ends_with("release-promote.yml"));
     assert!(callers[1].ends_with("release-promotion-simulation.yml"));
+    for caller in &callers {
+        let text = fs::read_to_string(caller).expect("read policy audit caller");
+        assert_eq!(
+            text.matches(
+                "    secrets:\n      RMUX_POLICY_AUDIT_APP_PRIVATE_KEY: ${{ github.token }}\n"
+            )
+            .count(),
+            1
+        );
+        assert!(!text.contains("secrets: inherit"));
+    }
     let caller = fs::read_to_string(&callers[0]).expect("read promote workflow");
     let audit_job = caller
         .split("\n  policy-audit:\n")


### PR DESCRIPTION
Bind the reusable audit secret explicitly at both callers so the protected environment can override it at job start.

The fallback is the caller read token; no repository secret is inherited and all release capabilities remain disabled.