### PR TITLE
ci(release): support Python 3.10 canonical builders

### DIFF
--- a/.github/actions/canonical-build/action.yml
+++ b/.github/actions/canonical-build/action.yml
@@ -118,6 +118,37 @@ runs:
         toolchain: "1.96.1"
         targets: ${{ inputs.target-triple }}
 
+    - name: Resolve the exact workspace version
+      shell: bash
+      env:
+        RMUX_PLANNED_RELEASE_REF: ${{ inputs.planned-release-ref }}
+      run: |
+        set -euo pipefail
+        metadata="$RUNNER_TEMP/rmux-canonical-cargo-metadata.json"
+        cargo metadata --locked --no-deps --format-version 1 > "$metadata"
+        version="$(python3 - "$metadata" "$GITHUB_WORKSPACE/Cargo.toml" <<'PY'
+        import json
+        import pathlib
+        import sys
+
+        metadata = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+        root_manifest = pathlib.Path(sys.argv[2]).resolve()
+        versions = [
+            package["version"]
+            for package in metadata["packages"]
+            if pathlib.Path(package["manifest_path"]).resolve() == root_manifest
+        ]
+        if len(versions) != 1:
+            raise SystemExit("cargo metadata did not identify one root package")
+        print(versions[0])
+        PY
+        )"
+        [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
+        planned_version="${RMUX_PLANNED_RELEASE_REF#v}"
+        planned_version="${planned_version%%-rc.*}"
+        test "$planned_version" = "$version"
+        echo "RMUX_PACKAGE_VERSION=$version" >> "$GITHUB_ENV"
+
     - name: Capture toolchain and fetch locked dependencies
       shell: bash
       run: |
@@ -184,7 +215,7 @@ runs:
         set -euo pipefail
         test -f "$RMUX_SNAP_PACKAGE"
         test ! -L "$RMUX_SNAP_PACKAGE"
-        version="$(python3 -c 'import pathlib,tomllib; print(tomllib.loads(pathlib.Path("Cargo.toml").read_text())["workspace"]["package"]["version"])')"
+        version="$RMUX_PACKAGE_VERSION"
         case "$RMUX_PLATFORM_KEY" in
           linux-x86_64) snap_arch=amd64 ;;
           linux-aarch64) snap_arch=arm64 ;;
@@ -199,7 +230,7 @@ runs:
         RMUX_EXPECTED_SOURCE_SHA: ${{ inputs.expected-source-sha }}
       run: |
         set -euo pipefail
-        version="$(python3 -c 'import pathlib,tomllib; print(tomllib.loads(pathlib.Path("Cargo.toml").read_text())["workspace"]["package"]["version"])')"
+        version="$RMUX_PACKAGE_VERSION"
         tools="$RUNNER_TEMP/rmux-canonical-tools"
         wasm_target="$RUNNER_TEMP/rmux-canonical-wasm-target"
         crate_target="$RUNNER_TEMP/rmux-canonical-crate-target"
@@ -235,7 +266,7 @@ runs:
         RMUX_PLANNED_RELEASE_REF: ${{ inputs.planned-release-ref }}
       run: |
         set -euo pipefail
-        version="$(python3 -c 'import pathlib,tomllib; print(tomllib.loads(pathlib.Path("Cargo.toml").read_text())["workspace"]["package"]["version"])')"
+        version="$RMUX_PACKAGE_VERSION"
         package_root="$RUNNER_TEMP/rmux-canonical-chocolatey"
         test ! -e "$package_root"
         scripts/generate-chocolatey-package.sh \

--- a/tests/release_canonical_build_spec.rs
+++ b/tests/release_canonical_build_spec.rs
@@ -189,6 +189,26 @@ fn canonical_producers_are_object_cold_and_non_publishing() {
     assert_eq!(smoke.matches("required: true").count(), 13);
 }
 
+#[test]
+fn canonical_version_resolution_is_structured_and_python_310_compatible() {
+    let build = include_str!("../.github/actions/canonical-build/action.yml");
+
+    assert_eq!(
+        build
+            .matches("cargo metadata --locked --no-deps --format-version 1")
+            .count(),
+        1
+    );
+    assert!(build.contains("RMUX_PACKAGE_VERSION=$version"));
+    assert_eq!(
+        build.matches("version=\"$RMUX_PACKAGE_VERSION\"").count(),
+        3
+    );
+    assert!(build.contains("package[\"manifest_path\"]"));
+    assert!(build.contains("planned_version=\"${planned_version%%-rc.*}\""));
+    assert!(!build.contains("tomllib"));
+}
+
 #[cfg(unix)]
 #[test]
 fn canonical_checksums_reject_a_symbolic_manifest() {


### PR DESCRIPTION
Fix the exact-SHA release qualification failure on Ubuntu 22.04 canonical builders.

- resolve the root package version once through structured `cargo metadata`
- keep stable and RC tag/version identity checks
- reuse the verified version for Snap, crates/WASM, and Chocolatey payloads
- prevent `tomllib` from returning to the Ubuntu 22.04 path

Validation: all release tests, release contracts, formatting, and Actionlint pass.

Failed qualification: https://github.com/Helvesec/rmux/actions/runs/29771849426