### PR TITLE
ci(release): harden downstream payload evidence

### DIFF
--- a/.github/release/schemas/policy-audit-reference.schema.json
+++ b/.github/release/schemas/policy-audit-reference.schema.json
@@ -21,8 +21,8 @@
     "predicate_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
     "emitted_at": {"type": "string", "format": "date-time"},
     "expires_at": {"type": "string", "format": "date-time"},
-    "app_id": {"type": "integer", "minimum": 1},
-    "installation_id": {"type": "integer", "minimum": 1},
+    "app_id": {"const": 4344532},
+    "installation_id": {"const": 147749910},
     "workflow_id": {"type": "integer", "minimum": 1},
     "workflow_path": {"enum": [".github/workflows/release-promote.yml", ".github/workflows/release-promotion-simulation.yml"]},
     "release_policy_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"}

--- a/scripts/release/downstream_payload.py
+++ b/scripts/release/downstream_payload.py
@@ -334,18 +334,20 @@ def collect_files(root: Path, values: list[str] | None) -> list[dict[str, Any]]:
         raise ValueError("at least one ROLE=NAME payload file is required")
     if root.is_symlink() or not root.is_dir():
         raise ValueError("payload root must be one real directory")
-    mapped: dict[str, str] = {}
+    mapped: list[tuple[str, str]] = []
+    names: set[str] = set()
     for value in values:
         if "=" not in value:
             raise ValueError("payload file must use ROLE=NAME")
         role, name = value.split("=", 1)
-        if not role or role in mapped or SAFE_NAME.fullmatch(name) is None:
+        if not role or name in names or SAFE_NAME.fullmatch(name) is None:
             raise ValueError("payload file role or name is invalid")
-        mapped[role] = name
+        mapped.append((role, name))
+        names.add(name)
     paths = list(root.iterdir())
     if any(path.is_symlink() or not path.is_file() for path in paths):
         raise ValueError("payload root can contain only regular files")
-    if {path.name for path in paths} != set(mapped.values()):
+    if {path.name for path in paths} != names:
         raise ValueError("payload root file set differs from its role mapping")
     files = [
         {
@@ -354,7 +356,7 @@ def collect_files(root: Path, values: list[str] | None) -> list[dict[str, Any]]:
             "size": (root / name).stat().st_size,
             "sha256": file_hash(root / name),
         }
-        for role, name in mapped.items()
+        for role, name in mapped
     ]
     files.sort(key=lambda item: item["name"])
     return files

--- a/tests/release_downstream_payload_spec.rs
+++ b/tests/release_downstream_payload_spec.rs
@@ -36,7 +36,7 @@ import sys
 import tempfile
 
 sys.path.insert(0, 'scripts/release')
-from downstream_payload import validate_payload_document
+from downstream_payload import collect_files, validate_payload_document
 
 SOURCE = 'a' * 40
 RELEASE = {
@@ -260,6 +260,45 @@ with tempfile.TemporaryDirectory(dir=pathlib.Path.cwd()) as directory:
     rejected = run_cli(['create', *value['common'], '--output', str(value['document']), '--subject-output', str(value['subject'])])
     if rejected.returncode == 0 or 'regular files' not in rejected.stderr:
         raise SystemExit(f'symlink payload was not rejected: {rejected.stderr}')
+"#
+    ));
+}
+
+#[test]
+fn payload_collection_supports_multiarch_roles_and_rejects_duplicate_names() {
+    assert_fixture(&format!(
+        "{PRELUDE}\n{}",
+        r#"
+with tempfile.TemporaryDirectory(dir=pathlib.Path.cwd()) as directory:
+    root = pathlib.Path(directory)
+    names = [
+        'rmux_0.9.0_amd64.deb',
+        'rmux_0.9.0_arm64.deb',
+        'rmux-0.9.0-1.x86_64.rpm',
+        'rmux-0.9.0-1.aarch64.rpm',
+    ]
+    for name in names:
+        (root / name).write_bytes(name.encode('ascii'))
+    files = collect_files(root, [
+        'debian=rmux_0.9.0_amd64.deb',
+        'debian=rmux_0.9.0_arm64.deb',
+        'rpm=rmux-0.9.0-1.x86_64.rpm',
+        'rpm=rmux-0.9.0-1.aarch64.rpm',
+    ])
+    if [item['name'] for item in files] != sorted(names):
+        raise SystemExit('multiarch payload files are not sorted')
+    roles = [item['role'] for item in files]
+    if roles.count('debian') != 2 or roles.count('rpm') != 2:
+        raise SystemExit('multiarch payload roles were collapsed')
+    try:
+        collect_files(root, [
+            'debian=rmux_0.9.0_amd64.deb',
+            'rpm=rmux_0.9.0_amd64.deb',
+        ])
+    except ValueError:
+        pass
+    else:
+        raise SystemExit('duplicate payload filename was accepted')
 "#
     ));
 }

--- a/tests/release_policy_audit_spec.rs
+++ b/tests/release_policy_audit_spec.rs
@@ -20,6 +20,10 @@ fn policy_audit_simulation_is_nonpublishing_with_two_exact_callers() {
         "../.github/release/policy-audit-contract.json"
     ))
     .expect("parse policy audit contract");
+    let reference_schema: serde_json::Value = serde_json::from_str(include_str!(
+        "../.github/release/schemas/policy-audit-reference.schema.json"
+    ))
+    .expect("parse policy audit reference schema");
 
     assert!(workflow.contains("on:\n  workflow_call:"));
     assert_eq!(workflow.matches("if: ${{ inputs.simulation }}").count(), 1);
@@ -90,6 +94,11 @@ fn policy_audit_simulation_is_nonpublishing_with_two_exact_callers() {
     assert_eq!(contract["audit_app"]["configured"], true);
     assert_eq!(contract["audit_app"]["app_id"], 4344532);
     assert_eq!(contract["audit_app"]["installation_id"], 147749910);
+    assert_eq!(reference_schema["properties"]["app_id"]["const"], 4344532);
+    assert_eq!(
+        reference_schema["properties"]["installation_id"]["const"],
+        147749910
+    );
     assert_eq!(contract["audit_app"]["pat_fallback"], false);
     assert_eq!(contract["workflow"]["caller_count"], 2);
     assert_eq!(
@@ -240,12 +249,6 @@ def write(path, value):
     path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n")
 
 contract = copy.deepcopy(base_contract)
-contract["audit_app"].update({
-    "configured": True,
-    "app_id": 9001,
-    "installation_id": 9002,
-    "app_slug": "rmux-policy-audit-test",
-})
 contract_path = root / "contract.json"
 write(contract_path, contract)
 
@@ -301,7 +304,7 @@ responses = {
     "immutable_releases": {"enabled": True, "enforced_by_owner": True},
     "self_hosted_runners": {"total_count": 0, "runners": []},
     "audit_app": {
-        "id": 9001, "slug": "rmux-policy-audit-test",
+        "id": 4344532, "slug": "helvesec-rmux-policy-audit",
         "owner": {"login": "Helvesec"}, "events": [],
         "permissions": {"actions": "read", "administration": "write", "metadata": "read"},
     },
@@ -334,8 +337,8 @@ common = [
     "--release-kind", "stable", "--audit-run-id", "111", "--audit-run-attempt", "1",
     "--audit-workflow-id", "316591947",
     "--audit-workflow-path", ".github/workflows/release-promotion-simulation.yml",
-    "--audit-app-id", "9001", "--audit-installation-id", "9002",
-    "--audit-app-slug", "rmux-policy-audit-test",
+    "--audit-app-id", "4344532", "--audit-installation-id", "147749910",
+    "--audit-app-slug", "helvesec-rmux-policy-audit",
     "--contract", contract_path, "--policy-root", policy,
     "--api-fixture-dir", fixture, "--now", "2026-07-19T12:00:00Z", "--output", predicate,
 ]


### PR DESCRIPTION
## Summary

- permit repeated payload roles for multiarchitecture APT/RPM artifacts while keeping filenames unique
- bind policy-audit references to the exact audit App installation
- add focused multiarchitecture and schema regressions

## Validation

- `cargo test --locked` for every `release_*_spec` integration suite
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo fmt --all -- --check`
- `ruff check scripts/release/downstream_payload.py`
- `python3 scripts/release/validate-contracts.py`

All release capabilities remain disabled.