### PR TITLE
ci(release): record downstream protection state

### DIFF
--- a/.github/release/downstream-channel-contract.json
+++ b/.github/release/downstream-channel-contract.json
@@ -203,7 +203,7 @@
       ],
       "retryable": true,
       "blockers": [
-        "repository_protection_missing",
+        "environment_admin_bypass_enabled",
         "downstream_writer_app_missing"
       ]
     },
@@ -238,7 +238,7 @@
       ],
       "retryable": true,
       "blockers": [
-        "repository_protection_missing",
+        "environment_admin_bypass_enabled",
         "downstream_writer_app_missing"
       ]
     },
@@ -285,7 +285,7 @@
       ],
       "retryable": true,
       "blockers": [
-        "repository_protection_missing",
+        "environment_admin_bypass_enabled",
         "downstream_writer_app_missing",
         "floating_actions_present",
         "unprotected_secret_deployment_workflow"

--- a/.github/release/downstream-repositories.json
+++ b/.github/release/downstream-repositories.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "status": "review-only-disarmed",
   "description": "Observed downstream repository identities and fail-closed activation blockers. This file grants no write authority.",
-  "observed_at": "2026-07-19T00:00:00Z",
+  "observed_at": "2026-07-20T21:47:46Z",
   "writer_app": {
     "configured": false,
     "app_id": null,
@@ -55,12 +55,12 @@
       "environment": "release-homebrew-tap",
       "archived": false,
       "protection_api_supported": true,
-      "branch_protected": false,
-      "ruleset_count": 0,
-      "environment_count": 0,
+      "branch_protected": true,
+      "ruleset_count": 1,
+      "environment_count": 1,
       "activation_ready": false,
       "blockers": [
-        "repository_protection_missing",
+        "environment_admin_bypass_enabled",
         "downstream_writer_app_missing"
       ]
     },
@@ -95,12 +95,12 @@
       "environment": "release-web-share",
       "archived": false,
       "protection_api_supported": true,
-      "branch_protected": false,
-      "ruleset_count": 0,
-      "environment_count": 0,
+      "branch_protected": true,
+      "ruleset_count": 1,
+      "environment_count": 1,
       "activation_ready": false,
       "blockers": [
-        "repository_protection_missing",
+        "environment_admin_bypass_enabled",
         "downstream_writer_app_missing",
         "floating_actions_present",
         "unprotected_secret_deployment_workflow"
@@ -137,12 +137,12 @@
       "environment": "release-scoop",
       "archived": false,
       "protection_api_supported": true,
-      "branch_protected": false,
-      "ruleset_count": 0,
-      "environment_count": 0,
+      "branch_protected": true,
+      "ruleset_count": 1,
+      "environment_count": 1,
       "activation_ready": false,
       "blockers": [
-        "repository_protection_missing",
+        "environment_admin_bypass_enabled",
         "downstream_writer_app_missing"
       ]
     },

--- a/scripts/release/downstream_contract.py
+++ b/scripts/release/downstream_contract.py
@@ -338,6 +338,19 @@ def _validate_repositories(release: Path) -> None:
             not in record.get("blockers", [])
         ):
             raise ValueError(f"private Free-plan blocker disappeared: {key}")
+    for key in ("homebrew-rmux", "rmux-web-share", "scoop-rmux"):
+        record = records[key]
+        blockers = set(record.get("blockers", []))
+        if (
+            record.get("protection_api_supported") is not True
+            or record.get("branch_protected") is not True
+            or record.get("ruleset_count") != 1
+            or record.get("environment_count") != 1
+            or "repository_protection_missing" in blockers
+            or "environment_admin_bypass_enabled" not in blockers
+            or "downstream_writer_app_missing" not in blockers
+        ):
+            raise ValueError(f"public downstream protection snapshot drifted: {key}")
     web_blockers = set(records["rmux-web-share"].get("blockers", []))
     if (
         not {

--- a/tests/release_downstream_workflows_spec.rs
+++ b/tests/release_downstream_workflows_spec.rs
@@ -309,7 +309,7 @@ fn all_eleven_channels_are_default_denied_and_rmux_io_is_last() {
     assert_eq!(
         web_share["blockers"],
         serde_json::json!([
-            "repository_protection_missing",
+            "environment_admin_bypass_enabled",
             "downstream_writer_app_missing",
             "floating_actions_present",
             "unprotected_secret_deployment_workflow"
@@ -382,6 +382,45 @@ fn all_eleven_channels_are_default_denied_and_rmux_io_is_last() {
     assert_eq!(DOWNSTREAM.matches("channel-summary.py create").count(), 0);
     for writer in [linux, chocolatey, rmux_io] {
         assert!(writer.contains("assert-release-capability.py downstream_channels"));
+    }
+}
+
+#[test]
+fn public_owned_downstream_protection_layers_are_recorded_but_disarmed() {
+    let registry: serde_json::Value = serde_json::from_str(include_str!(
+        "../.github/release/downstream-repositories.json"
+    ))
+    .expect("downstream repository registry");
+    let repositories = registry["repositories"].as_array().expect("repositories");
+
+    for key in ["homebrew-rmux", "rmux-web-share", "scoop-rmux"] {
+        let repository = repositories
+            .iter()
+            .find(|repository| repository["key"] == key)
+            .unwrap_or_else(|| panic!("missing downstream repository {key}"));
+        assert_eq!(repository["branch_protected"], true, "{key}");
+        assert_eq!(repository["ruleset_count"], 1, "{key}");
+        assert_eq!(repository["environment_count"], 1, "{key}");
+        assert_eq!(repository["activation_ready"], false, "{key}");
+        let blockers = repository["blockers"].as_array().expect("blockers");
+        assert!(
+            blockers
+                .iter()
+                .any(|blocker| blocker == "environment_admin_bypass_enabled"),
+            "{key} lost its environment bypass blocker"
+        );
+        assert!(
+            blockers
+                .iter()
+                .any(|blocker| blocker == "downstream_writer_app_missing"),
+            "{key} lost its writer App blocker"
+        );
+        assert!(
+            blockers
+                .iter()
+                .all(|blocker| blocker != "repository_protection_missing"),
+            "{key} still reports missing repository protection"
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

- record the live branch protection, ruleset, and environment state for public downstream repositories
- keep admin bypass and the missing writer App as explicit activation blockers
- validate the snapshot and preserve default-denied downstream publication

## Validation

- `python3 scripts/release/validate-contracts.py`
- downstream release integration tests
- `cargo test --locked --test release_automation_spec`
- `cargo test --locked --test release_policy_audit_spec`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo fmt --all -- --check`

No release capability is enabled. The version remains 0.9.0.