### PR TITLE
ci(release): invoke promotion simulation with Python

### DIFF
--- a/.github/workflows/release-promotion-simulation.yml
+++ b/.github/workflows/release-promotion-simulation.yml
@@ -377,7 +377,7 @@ jobs:
         run: |
           set -euo pipefail
           root="$RUNNER_TEMP/rmux-promotion-simulation"
-          scripts/release/promotion-simulation.py \
+          python3 scripts/release/promotion-simulation.py \
             --candidate-manifest "$root/manifest/candidate-manifest.json" \
             --candidate-resolution "$root/candidate-artifacts.json" \
             --verified-candidate-artifacts "$root/verified-candidate-artifacts.json" \

--- a/tests/release_promoter_workflows_spec.rs
+++ b/tests/release_promoter_workflows_spec.rs
@@ -324,7 +324,10 @@ fn promotion_simulation_pins_a_draft_2020_schema_validator() {
 
 #[test]
 fn promotion_simulation_reports_only_the_work_it_executes() {
-    assert!(SIMULATION.contains("promotion-simulation.py"));
+    assert!(SIMULATION.contains("python3 scripts/release/promotion-simulation.py"));
+    assert!(!SIMULATION.lines().any(|line| line
+        .trim_start()
+        .starts_with("scripts/release/promotion-simulation.py")));
     assert!(SIMULATION.contains("Resolve the eleven original candidate artifact IDs"));
     assert!(SIMULATION.contains("verify-candidate-attestations.sh"));
     assert!(SIMULATION.contains("\"exact_candidate_bytes_exercised\": True"));


### PR DESCRIPTION
## Summary

- invoke the nonpublishing promotion simulator through its pinned Python runtime
- add a contract test that rejects direct execution of the non-executable source file

## Validation

- `python3 scripts/release/validate-contracts.py`
- `cargo test --locked --test release_promoter_workflows_spec`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo fmt --all -- --check`
- Actionlint and Ruff

No release capability is enabled. The version remains 0.9.0.