### PR TITLE
release: record downstream repository boundaries

### DIFF
--- a/.github/release/downstream-channel-contract.json
+++ b/.github/release/downstream-channel-contract.json
@@ -142,7 +142,7 @@
       ],
       "retryable": true,
       "blockers": [
-        "private_repository_protection_unavailable_on_current_plan",
+        "environment_admin_bypass_enabled",
         "downstream_writer_app_missing"
       ]
     },
@@ -222,7 +222,7 @@
       "retryable": true,
       "blockers": [
         "private_repository_protection_unavailable_on_current_plan",
-        "downstream_writer_app_missing"
+        "manual_site_update_required"
       ]
     },
     {

--- a/.github/release/downstream-repositories.json
+++ b/.github/release/downstream-repositories.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "status": "review-only-disarmed",
   "description": "Observed downstream repository identities and fail-closed activation blockers. This file grants no write authority.",
-  "observed_at": "2026-07-20T21:47:46Z",
+  "observed_at": "2026-07-21T05:30:51Z",
   "writer_app": {
     "configured": false,
     "app_id": null,
@@ -69,18 +69,18 @@
       "ownership": "rmux-owned",
       "id": 1258602064,
       "full_name": "Helvesec/rmux-packages",
-      "visibility": "private",
+      "visibility": "public",
       "default_branch": "main",
       "required_path": ".",
       "environment": "release-linux-repositories",
       "archived": false,
-      "protection_api_supported": false,
-      "branch_protected": false,
-      "ruleset_count": 0,
-      "environment_count": 0,
+      "protection_api_supported": true,
+      "branch_protected": true,
+      "ruleset_count": 1,
+      "environment_count": 1,
       "activation_ready": false,
       "blockers": [
-        "private_repository_protection_unavailable_on_current_plan",
+        "environment_admin_bypass_enabled",
         "downstream_writer_app_missing"
       ]
     },
@@ -123,7 +123,7 @@
       "activation_ready": false,
       "blockers": [
         "private_repository_protection_unavailable_on_current_plan",
-        "downstream_writer_app_missing"
+        "manual_site_update_required"
       ]
     },
     {

--- a/scripts/release/downstream_contract.py
+++ b/scripts/release/downstream_contract.py
@@ -52,7 +52,7 @@ REPOSITORIES = {
     "rmux-packages": (
         1258602064,
         "Helvesec/rmux-packages",
-        "private",
+        "public",
         "main",
         ".",
         "rmux-owned",
@@ -282,7 +282,7 @@ def _validate_channel_contract(release: Path, policy: dict[str, Any]) -> None:
         or rmux_io.get("blockers")
         != [
             "private_repository_protection_unavailable_on_current_plan",
-            "downstream_writer_app_missing",
+            "manual_site_update_required",
         ]
     ):
         raise ValueError("rmux.io must remain the blocked final channel")
@@ -330,15 +330,21 @@ def _validate_repositories(release: Path) -> None:
         )
         if actual != expected or record.get("activation_ready") is not False:
             raise ValueError(f"downstream repository identity drifted: {key}")
-    for key in ("rmux-packages", "rmux.io"):
-        record = records[key]
-        if (
-            record.get("protection_api_supported") is not False
-            or "private_repository_protection_unavailable_on_current_plan"
-            not in record.get("blockers", [])
-        ):
-            raise ValueError(f"private Free-plan blocker disappeared: {key}")
-    for key in ("homebrew-rmux", "rmux-web-share", "scoop-rmux"):
+    rmux_io = records["rmux.io"]
+    if (
+        rmux_io.get("protection_api_supported") is not False
+        or "private_repository_protection_unavailable_on_current_plan"
+        not in rmux_io.get("blockers", [])
+        or "manual_site_update_required" not in rmux_io.get("blockers", [])
+        or "downstream_writer_app_missing" in rmux_io.get("blockers", [])
+    ):
+        raise ValueError("private rmux.io manual-update contract drifted")
+    for key in (
+        "homebrew-rmux",
+        "rmux-packages",
+        "rmux-web-share",
+        "scoop-rmux",
+    ):
         record = records[key]
         blockers = set(record.get("blockers", []))
         if (

--- a/scripts/release/verify-downstream-repository.py
+++ b/scripts/release/verify-downstream-repository.py
@@ -138,7 +138,7 @@ def validate_owned_fixtures(expected: dict[str, Any], args: argparse.Namespace) 
     owned_ids = sorted(
         item["id"]
         for item in contract["repositories"]
-        if item["ownership"] == "rmux-owned"
+        if item["ownership"] == "rmux-owned" and item["key"] != "rmux.io"
     )
     if repository_ids != owned_ids:
         raise ValueError("downstream writer App repository scope is not exact")

--- a/tests/release_downstream_workflows_spec.rs
+++ b/tests/release_downstream_workflows_spec.rs
@@ -393,7 +393,12 @@ fn public_owned_downstream_protection_layers_are_recorded_but_disarmed() {
     .expect("downstream repository registry");
     let repositories = registry["repositories"].as_array().expect("repositories");
 
-    for key in ["homebrew-rmux", "rmux-web-share", "scoop-rmux"] {
+    for key in [
+        "homebrew-rmux",
+        "rmux-packages",
+        "rmux-web-share",
+        "scoop-rmux",
+    ] {
         let repository = repositories
             .iter()
             .find(|repository| repository["key"] == key)
@@ -422,6 +427,20 @@ fn public_owned_downstream_protection_layers_are_recorded_but_disarmed() {
             "{key} still reports missing repository protection"
         );
     }
+
+    let rmux_io = repositories
+        .iter()
+        .find(|repository| repository["key"] == "rmux.io")
+        .expect("missing downstream repository rmux.io");
+    assert_eq!(rmux_io["visibility"], "private");
+    assert_eq!(rmux_io["activation_ready"], false);
+    assert_eq!(
+        rmux_io["blockers"],
+        serde_json::json!([
+            "private_repository_protection_unavailable_on_current_plan",
+            "manual_site_update_required"
+        ])
+    );
 }
 
 #[test]


### PR DESCRIPTION
Records the live public protections for `rmux-packages` and keeps the private `rmux.io` repository outside automated mutation.

- keeps every release capability disabled
- requires a protected writer App for public owned repositories
- treats the private site as a prepared manual final channel
- adds focused contract coverage

No version, tag, Release, package, or deployment is changed.