### PR TITLE
release: bind downstream writer app

### DIFF
--- a/.github/release/downstream-channel-contract.json
+++ b/.github/release/downstream-channel-contract.json
@@ -141,10 +141,7 @@
         "rpm"
       ],
       "retryable": true,
-      "blockers": [
-        "environment_admin_bypass_enabled",
-        "downstream_writer_app_missing"
-      ]
+      "blockers": []
     },
     {
       "name": "chocolatey",
@@ -202,10 +199,7 @@
         "homebrew-formula"
       ],
       "retryable": true,
-      "blockers": [
-        "environment_admin_bypass_enabled",
-        "downstream_writer_app_missing"
-      ]
+      "blockers": []
     },
     {
       "name": "rmux_io",
@@ -237,10 +231,7 @@
         "scoop-manifest"
       ],
       "retryable": true,
-      "blockers": [
-        "environment_admin_bypass_enabled",
-        "downstream_writer_app_missing"
-      ]
+      "blockers": []
     },
     {
       "name": "snap_candidate",
@@ -285,8 +276,6 @@
       ],
       "retryable": true,
       "blockers": [
-        "environment_admin_bypass_enabled",
-        "downstream_writer_app_missing",
         "floating_actions_present",
         "unprotected_secret_deployment_workflow"
       ]

--- a/.github/release/downstream-repositories.json
+++ b/.github/release/downstream-repositories.json
@@ -2,11 +2,11 @@
   "schema_version": 1,
   "status": "review-only-disarmed",
   "description": "Observed downstream repository identities and fail-closed activation blockers. This file grants no write authority.",
-  "observed_at": "2026-07-21T05:30:51Z",
+  "observed_at": "2026-07-21T06:33:50Z",
   "writer_app": {
-    "configured": false,
-    "app_id": null,
-    "installation_id": null,
+    "configured": true,
+    "app_id": 4352876,
+    "installation_id": 147959477,
     "repository_selection": "selected",
     "pat_fallback": false,
     "required_permissions": {
@@ -58,11 +58,8 @@
       "branch_protected": true,
       "ruleset_count": 1,
       "environment_count": 1,
-      "activation_ready": false,
-      "blockers": [
-        "environment_admin_bypass_enabled",
-        "downstream_writer_app_missing"
-      ]
+      "activation_ready": true,
+      "blockers": []
     },
     {
       "key": "rmux-packages",
@@ -78,11 +75,8 @@
       "branch_protected": true,
       "ruleset_count": 1,
       "environment_count": 1,
-      "activation_ready": false,
-      "blockers": [
-        "environment_admin_bypass_enabled",
-        "downstream_writer_app_missing"
-      ]
+      "activation_ready": true,
+      "blockers": []
     },
     {
       "key": "rmux-web-share",
@@ -100,8 +94,6 @@
       "environment_count": 1,
       "activation_ready": false,
       "blockers": [
-        "environment_admin_bypass_enabled",
-        "downstream_writer_app_missing",
         "floating_actions_present",
         "unprotected_secret_deployment_workflow"
       ]
@@ -140,11 +132,8 @@
       "branch_protected": true,
       "ruleset_count": 1,
       "environment_count": 1,
-      "activation_ready": false,
-      "blockers": [
-        "environment_admin_bypass_enabled",
-        "downstream_writer_app_missing"
-      ]
+      "activation_ready": true,
+      "blockers": []
     },
     {
       "key": "winget-pkgs",

--- a/scripts/release/downstream_contract.py
+++ b/scripts/release/downstream_contract.py
@@ -286,18 +286,32 @@ def _validate_channel_contract(release: Path, policy: dict[str, Any]) -> None:
         ]
     ):
         raise ValueError("rmux.io must remain the blocked final channel")
+    by_name = {item["name"]: item for item in channels}
+    for name in ("apt_rpm", "homebrew_tap", "scoop"):
+        if by_name[name].get("blockers") != []:
+            raise ValueError(f"configured channel still blocked: {name}")
+    if by_name["web_share"].get("blockers") != [
+        "floating_actions_present",
+        "unprotected_secret_deployment_workflow",
+    ]:
+        raise ValueError("Web Share legacy channel blockers changed")
 
 
 def _validate_repositories(release: Path) -> None:
     registry = _read(release / "downstream-repositories.json")
-    writer = registry.get("writer_app", {})
-    if (
-        writer.get("configured") is not False
-        or writer.get("app_id") is not None
-        or writer.get("installation_id") is not None
-        or writer.get("pat_fallback") is not False
-    ):
-        raise ValueError("downstream writer identity must remain unconfigured")
+    if registry.get("writer_app", {}) != {
+        "configured": True,
+        "app_id": 4352876,
+        "installation_id": 147959477,
+        "repository_selection": "selected",
+        "pat_fallback": False,
+        "required_permissions": {
+            "actions": "read",
+            "contents": "write",
+            "metadata": "read",
+        },
+    }:
+        raise ValueError("downstream writer App identity or permissions changed")
     protection = registry.get("required_protection", {})
     if (
         protection.get("enforce_admins") is not True
@@ -317,18 +331,16 @@ def _validate_repositories(release: Path) -> None:
         raise ValueError("downstream repository inventory changed")
     for key, expected in REPOSITORIES.items():
         record = records[key]
-        actual = tuple(
-            record.get(field)
-            for field in (
-                "id",
-                "full_name",
-                "visibility",
-                "default_branch",
-                "required_path",
-                "ownership",
-            )
+        actual = (
+            record.get("id"),
+            record.get("full_name"),
+            record.get("visibility"),
+            record.get("default_branch"),
+            record.get("required_path"),
+            record.get("ownership"),
         )
-        if actual != expected or record.get("activation_ready") is not False:
+        expected_ready = key in {"homebrew-rmux", "rmux-packages", "scoop-rmux"}
+        if actual != expected or record.get("activation_ready") is not expected_ready:
             raise ValueError(f"downstream repository identity drifted: {key}")
     rmux_io = records["rmux.io"]
     if (
@@ -353,18 +365,17 @@ def _validate_repositories(release: Path) -> None:
             or record.get("ruleset_count") != 1
             or record.get("environment_count") != 1
             or "repository_protection_missing" in blockers
-            or "environment_admin_bypass_enabled" not in blockers
-            or "downstream_writer_app_missing" not in blockers
+            or "environment_admin_bypass_enabled" in blockers
+            or "downstream_writer_app_missing" in blockers
         ):
             raise ValueError(f"public downstream protection snapshot drifted: {key}")
-    web_blockers = set(records["rmux-web-share"].get("blockers", []))
-    if (
-        not {
-            "floating_actions_present",
-            "unprotected_secret_deployment_workflow",
-        }
-        <= web_blockers
-    ):
+    for key in ("homebrew-rmux", "rmux-packages", "scoop-rmux"):
+        if records[key].get("blockers") != []:
+            raise ValueError(f"ready downstream repository still has blockers: {key}")
+    if records["rmux-web-share"].get("blockers") != [
+        "floating_actions_present",
+        "unprotected_secret_deployment_workflow",
+    ]:
         raise ValueError("Web Share legacy deployment blockers disappeared")
 
 

--- a/scripts/release/verify-downstream-repository.py
+++ b/scripts/release/verify-downstream-repository.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from downstream_channels import REPOSITORY_CONTRACT, exact_keys, read_object
+from strict_json import read_json
 
 EXPECTED_REPOSITORIES = {
     "homebrew-core": (52855516, "Homebrew/homebrew-core", "external"),
@@ -19,6 +20,19 @@ EXPECTED_REPOSITORIES = {
     "scoop-rmux": (1259135161, "Helvesec/scoop-rmux", "rmux-owned"),
     "winget-pkgs": (197275551, "microsoft/winget-pkgs", "external"),
 }
+WRITER_APP = {
+    "configured": True,
+    "app_id": 4352876,
+    "installation_id": 147959477,
+    "repository_selection": "selected",
+    "pat_fallback": False,
+    "required_permissions": {
+        "actions": "read",
+        "contents": "write",
+        "metadata": "read",
+    },
+}
+READY_REPOSITORIES = {"homebrew-rmux", "rmux-packages", "scoop-rmux"}
 
 
 def load_contract() -> dict[str, Any]:
@@ -39,13 +53,8 @@ def load_contract() -> dict[str, Any]:
     if contract["schema_version"] != 1 or contract["status"] != "review-only-disarmed":
         raise ValueError("downstream repository contract must remain disarmed")
     app = contract["writer_app"]
-    if (
-        app.get("configured") is not False
-        or app.get("app_id") is not None
-        or app.get("installation_id") is not None
-        or app.get("pat_fallback") is not False
-    ):
-        raise ValueError("downstream writer identity must remain unconfigured")
+    if app != WRITER_APP:
+        raise ValueError("downstream writer App identity or permissions changed")
     repositories = contract["repositories"]
     if not isinstance(repositories, list):
         raise ValueError("downstream repository inventory must be an array")
@@ -60,8 +69,10 @@ def load_contract() -> dict[str, Any]:
         raise ValueError("downstream registry must contain exactly five owned repos")
     if sum(item["ownership"] == "external" for item in repositories) != 2:
         raise ValueError("downstream registry must contain exactly two external repos")
-    if any(item.get("activation_ready") is not False for item in repositories):
-        raise ValueError("downstream repositories must remain activation-blocked")
+    for item in repositories:
+        expected_ready = item["key"] in READY_REPOSITORIES
+        if item.get("activation_ready") is not expected_ready:
+            raise ValueError("downstream repository readiness changed")
     return contract
 
 
@@ -84,10 +95,19 @@ def validate_metadata(expected: dict[str, Any], value: dict[str, Any]) -> None:
             raise ValueError(f"downstream repository metadata {field} changed")
 
 
-def require_fixture(path: Path | None, label: str) -> dict[str, Any]:
+def require_object_fixture(path: Path | None, label: str) -> dict[str, Any]:
     if path is None:
         raise ValueError(f"owned downstream repository requires {label} fixture")
     return read_object(path, label)
+
+
+def require_array_fixture(path: Path | None, label: str) -> list[Any]:
+    if path is None:
+        raise ValueError(f"owned downstream repository requires {label} fixture")
+    value = read_json(path, label)
+    if not isinstance(value, list):
+        raise ValueError(f"{label} must be a JSON array")
+    return value
 
 
 def validate_owned_fixtures(expected: dict[str, Any], args: argparse.Namespace) -> None:
@@ -95,7 +115,7 @@ def validate_owned_fixtures(expected: dict[str, Any], args: argparse.Namespace) 
         raise ValueError(
             "private downstream repository protection is unavailable on the current plan"
         )
-    protection = require_fixture(args.protection, "branch protection")
+    protection = require_object_fixture(args.protection, "branch protection")
     enforce_admins = protection.get("enforce_admins", {})
     if (
         not isinstance(enforce_admins, dict)
@@ -105,14 +125,14 @@ def validate_owned_fixtures(expected: dict[str, Any], args: argparse.Namespace) 
         or protection.get("required_signatures", {}).get("enabled") is not True
     ):
         raise ValueError("owned downstream branch protection is incomplete")
-    rulesets = require_fixture(args.rulesets, "repository rulesets")
-    if not isinstance(rulesets, list) or not any(
+    rulesets = require_array_fixture(args.rulesets, "repository rulesets")
+    if not any(
         item.get("enforcement") == "active"
         for item in rulesets
         if isinstance(item, dict)
     ):
         raise ValueError("owned downstream repository has no active ruleset")
-    environments = require_fixture(args.environments, "repository environments")
+    environments = require_object_fixture(args.environments, "repository environments")
     matches = [
         item
         for item in environments.get("environments", [])
@@ -124,15 +144,21 @@ def validate_owned_fixtures(expected: dict[str, Any], args: argparse.Namespace) 
         or not matches[0].get("protection_rules")
     ):
         raise ValueError("owned downstream environment is not protected")
-    runners = require_fixture(args.runners, "self-hosted runners")
+    runners = require_object_fixture(args.runners, "self-hosted runners")
     if runners.get("total_count") != 0:
         raise ValueError("self-hosted downstream runners are forbidden")
-    installation = require_fixture(args.installation, "writer App installation")
+    installation = require_object_fixture(args.installation, "writer App installation")
     contract = load_contract()
     app = contract["writer_app"]
     if app["configured"] is not True:
         raise ValueError("downstream writer App is intentionally not configured")
-    if installation.get("id") != app["installation_id"]:
+    if (
+        installation.get("id") != app["installation_id"]
+        or installation.get("app_id") != app["app_id"]
+        or installation.get("repository_selection") != "selected"
+        or installation.get("permissions") != app["required_permissions"]
+        or installation.get("events") != []
+    ):
         raise ValueError("downstream writer App installation identity changed")
     repository_ids = installation.get("repository_ids")
     owned_ids = sorted(

--- a/tests/release_downstream_summary_spec.rs
+++ b/tests/release_downstream_summary_spec.rs
@@ -283,7 +283,10 @@ with tempfile.TemporaryDirectory(dir=pathlib.Path.cwd()) as root:
 
     references['apt_rpm'] = write_reference(root, 'apt_rpm', plan_path, plan, 0)
     value = __import__('json').loads(reference.read_text(encoding='utf-8'))
-    value['state'] = 'prepared'
+    decision = next(item for item in plan['channels'] if item['name'] == 'apt_rpm')['execution_decision']
+    value['state'] = {
+        'denied': 'prepared', 'blocked': 'prepared', 'disarmed': 'blocked'
+    }[decision]
     write_object(reference, value)
     try:
         create_summary(
@@ -294,7 +297,7 @@ with tempfile.TemporaryDirectory(dir=pathlib.Path.cwd()) as root:
             created_at='2026-07-20T00:00:40Z',
         )
     except ValueError as error:
-        if 'differs from its exact plan' not in str(error):
+        if 'exact plan' not in str(error):
             raise
     else:
         raise SystemExit('result state contradicting the plan was accepted')
@@ -328,7 +331,10 @@ with tempfile.TemporaryDirectory(dir=pathlib.Path.cwd()) as root:
 
     changed = copy.deepcopy(pre)
     apt = next(item for item in changed['results'] if item['channel'] == 'apt_rpm')
-    apt['reference']['state'] = 'prepared'
+    decision = next(item for item in plan['channels'] if item['name'] == 'apt_rpm')['execution_decision']
+    apt['reference']['state'] = {
+        'denied': 'prepared', 'blocked': 'prepared', 'disarmed': 'blocked'
+    }[decision]
     write_object(pre_path, changed)
     try:
         channel_request = None
@@ -345,7 +351,7 @@ with tempfile.TemporaryDirectory(dir=pathlib.Path.cwd()) as root:
             requested_at='2026-07-20T00:00:45Z',
         )
     except ValueError as error:
-        if 'differs from its exact plan' not in str(error):
+        if 'exact plan' not in str(error):
             raise
     else:
         raise SystemExit('pre-site summary contradicting the plan was accepted')

--- a/tests/release_downstream_workflows_spec.rs
+++ b/tests/release_downstream_workflows_spec.rs
@@ -1,6 +1,8 @@
 use std::collections::BTreeSet;
 use std::fs;
 use std::path::PathBuf;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 const DOWNSTREAM: &str = include_str!("../.github/workflows/release-downstream.yml");
 
@@ -309,8 +311,6 @@ fn all_eleven_channels_are_default_denied_and_rmux_io_is_last() {
     assert_eq!(
         web_share["blockers"],
         serde_json::json!([
-            "environment_admin_bypass_enabled",
-            "downstream_writer_app_missing",
             "floating_actions_present",
             "unprotected_secret_deployment_workflow"
         ])
@@ -391,6 +391,11 @@ fn public_owned_downstream_protection_layers_are_recorded_but_disarmed() {
         "../.github/release/downstream-repositories.json"
     ))
     .expect("downstream repository registry");
+    assert_eq!(registry["writer_app"]["configured"], true);
+    assert_eq!(registry["writer_app"]["app_id"], 4352876);
+    assert_eq!(registry["writer_app"]["installation_id"], 147959477);
+    assert_eq!(registry["writer_app"]["repository_selection"], "selected");
+    assert_eq!(registry["writer_app"]["pat_fallback"], false);
     let repositories = registry["repositories"].as_array().expect("repositories");
 
     for key in [
@@ -406,19 +411,18 @@ fn public_owned_downstream_protection_layers_are_recorded_but_disarmed() {
         assert_eq!(repository["branch_protected"], true, "{key}");
         assert_eq!(repository["ruleset_count"], 1, "{key}");
         assert_eq!(repository["environment_count"], 1, "{key}");
-        assert_eq!(repository["activation_ready"], false, "{key}");
         let blockers = repository["blockers"].as_array().expect("blockers");
         assert!(
             blockers
                 .iter()
-                .any(|blocker| blocker == "environment_admin_bypass_enabled"),
-            "{key} lost its environment bypass blocker"
+                .all(|blocker| blocker != "environment_admin_bypass_enabled"),
+            "{key} still reports environment bypass"
         );
         assert!(
             blockers
                 .iter()
-                .any(|blocker| blocker == "downstream_writer_app_missing"),
-            "{key} lost its writer App blocker"
+                .all(|blocker| blocker != "downstream_writer_app_missing"),
+            "{key} still reports a missing writer App"
         );
         assert!(
             blockers
@@ -427,6 +431,28 @@ fn public_owned_downstream_protection_layers_are_recorded_but_disarmed() {
             "{key} still reports missing repository protection"
         );
     }
+
+    for key in ["homebrew-rmux", "rmux-packages", "scoop-rmux"] {
+        let repository = repositories
+            .iter()
+            .find(|repository| repository["key"] == key)
+            .unwrap_or_else(|| panic!("missing downstream repository {key}"));
+        assert_eq!(repository["activation_ready"], true, "{key}");
+        assert_eq!(repository["blockers"], serde_json::json!([]), "{key}");
+    }
+
+    let web_share = repositories
+        .iter()
+        .find(|repository| repository["key"] == "rmux-web-share")
+        .expect("missing downstream repository rmux-web-share");
+    assert_eq!(web_share["activation_ready"], false);
+    assert_eq!(
+        web_share["blockers"],
+        serde_json::json!([
+            "floating_actions_present",
+            "unprotected_secret_deployment_workflow"
+        ])
+    );
 
     let rmux_io = repositories
         .iter()
@@ -440,6 +466,92 @@ fn public_owned_downstream_protection_layers_are_recorded_but_disarmed() {
             "private_repository_protection_unavailable_on_current_plan",
             "manual_site_update_required"
         ])
+    );
+}
+
+#[test]
+fn downstream_repository_verifier_accepts_github_ruleset_arrays() {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time")
+        .as_nanos();
+    let root = std::env::temp_dir().join(format!(
+        "rmux-downstream-repository-{}-{nonce}",
+        std::process::id()
+    ));
+    fs::create_dir_all(&root).expect("create fixture directory");
+    let write = |name: &str, value: serde_json::Value| {
+        let path = root.join(name);
+        fs::write(&path, serde_json::to_vec(&value).expect("encode fixture"))
+            .expect("write fixture");
+        path
+    };
+    let metadata = write(
+        "metadata.json",
+        serde_json::json!({
+            "id": 1259133629,
+            "full_name": "Helvesec/homebrew-rmux",
+            "visibility": "public",
+            "default_branch": "main",
+            "archived": false
+        }),
+    );
+    let protection = write(
+        "protection.json",
+        serde_json::json!({
+            "enforce_admins": {"enabled": true},
+            "allow_force_pushes": {"enabled": false},
+            "allow_deletions": {"enabled": false},
+            "required_signatures": {"enabled": true}
+        }),
+    );
+    let rulesets = write(
+        "rulesets.json",
+        serde_json::json!([{"enforcement": "active"}]),
+    );
+    let environments = write(
+        "environments.json",
+        serde_json::json!({"environments": [{
+            "name": "release-homebrew-tap",
+            "can_admins_bypass": false,
+            "protection_rules": [{"type": "required_reviewers"}]
+        }]}),
+    );
+    let runners = write("runners.json", serde_json::json!({"total_count": 0}));
+    let installation = write(
+        "installation.json",
+        serde_json::json!({
+            "id": 147959477,
+            "app_id": 4352876,
+            "repository_selection": "selected",
+            "permissions": {"actions": "read", "contents": "write", "metadata": "read"},
+            "events": [],
+            "repository_ids": [1249553407, 1258602064, 1259133629, 1259135161]
+        }),
+    );
+    let output = Command::new("python3")
+        .arg(repo_root().join("scripts/release/verify-downstream-repository.py"))
+        .args(["fixtures", "--repository-key", "homebrew-rmux"])
+        .arg("--metadata")
+        .arg(metadata)
+        .arg("--protection")
+        .arg(protection)
+        .arg("--rulesets")
+        .arg(rulesets)
+        .arg("--environments")
+        .arg(environments)
+        .arg("--runners")
+        .arg(runners)
+        .arg("--installation")
+        .arg(installation)
+        .current_dir(repo_root())
+        .output()
+        .expect("run downstream repository verifier");
+    fs::remove_dir_all(root).expect("remove fixture directory");
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
     );
 }
 


### PR DESCRIPTION
## Summary
- bind the dedicated downstream GitHub App and exact four-repository scope
- record protected downstream environments and clear resolved blockers
- fix live ruleset fixture validation and keep Web Share and rmux.io blockers explicit

## Validation
- live verification of all four downstream repositories
- cargo fmt and Clippy with warnings denied
- downstream release tests and 524 rmux binary tests
- release contract, Ruff, JSON, hygiene, and disarmed-capability checks

No release capability is enabled. No tag, package, Release, or deployment is created.