### PR TITLE
test(windows): stabilize Ctrl-D timeout probe

### DIFF
--- a/tests/windows_attach_exit.rs
+++ b/tests/windows_attach_exit.rs
@@ -877,11 +877,10 @@ fn windows_send_keys_ctrl_d_releases_cmd_timeout() -> Result<(), Box<dyn Error>>
         &label,
         ["send-keys", "-t", target, "timeout /T 10000", "Enter"],
     )?;
-    thread::sleep(Duration::from_millis(500));
-    run_rmux(&binary, &label, ["send-keys", "-t", target, "C-d"])?;
+    wait_for_timeout_countdown_started(&binary, &label, target)?;
 
     let (returned, output) =
-        capture_until_occurrences(&binary, &label, target, prompt, 2, EXIT_TIMEOUT)?;
+        send_ctrl_d_until_cmd_timeout_releases(&binary, &label, target, prompt)?;
     assert!(
         returned,
         "send-keys C-d did not release cmd.exe/timeout.exe; observed output: {}",
@@ -1314,6 +1313,27 @@ fn send_synchronized_ctrl_d_until_cmd_timeout_releases(
     }
 
     Ok((false, last_cmd_output))
+}
+
+fn send_ctrl_d_until_cmd_timeout_releases(
+    binary: &Path,
+    label: &str,
+    target: &str,
+    prompt: &[u8],
+) -> Result<(bool, Vec<u8>), Box<dyn Error>> {
+    let mut last_output = Vec::new();
+
+    for _ in 0..CTRL_D_SYNTHETIC_ATTEMPTS {
+        run_rmux(binary, label, ["send-keys", "-t", target, "C-d"])?;
+        let (returned, output) =
+            capture_until_occurrences(binary, label, target, prompt, 2, Duration::from_secs(2))?;
+        last_output = output;
+        if returned {
+            return Ok((true, last_output));
+        }
+    }
+
+    Ok((false, last_output))
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- wait until `timeout.exe` has entered its countdown before injecting Ctrl-D
- apply the existing bounded three-attempt ConPTY policy to the single-pane probe
- preserve the product assertion while avoiding a host event-loss flake

## Evidence

Main run `29827668712` lost one synthetic Ctrl-D event after the same shard passed on PR run `29827070196`.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo clippy --workspace --all-targets --target x86_64-pc-windows-gnu --locked -- -D warnings`