### PR TITLE
release: make simulation artifact names portable

### DIFF
--- a/.github/workflows/release-promotion-simulation.yml
+++ b/.github/workflows/release-promotion-simulation.yml
@@ -433,7 +433,7 @@ jobs:
       - name: Upload the nonauthoritative simulation record
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
-          name: rmux-promotion-simulation-${{ inputs.simulation_id }}
+          name: rmux-promotion-simulation-${{ github.run_id }}
           path: ${{ runner.temp }}/rmux-promotion-simulation/e2e/promotion-simulation-record.json
           if-no-files-found: error
           retention-days: 7

--- a/tests/release_promoter_workflows_spec.rs
+++ b/tests/release_promoter_workflows_spec.rs
@@ -365,6 +365,12 @@ fn promotion_simulation_reports_only_the_work_it_executes() {
 }
 
 #[test]
+fn promotion_simulation_uses_a_portable_unique_artifact_name() {
+    assert!(SIMULATION.contains("name: rmux-promotion-simulation-${{ github.run_id }}"));
+    assert!(!SIMULATION.contains("name: rmux-promotion-simulation-${{ inputs.simulation_id }}"));
+}
+
+#[test]
 fn promotion_simulation_and_publisher_stay_below_the_release_file_budget() {
     assert!(PROMOTION_SIMULATION.lines().count() < 600);
     let publisher = include_str!("../scripts/release/publish-github-release.py");


### PR DESCRIPTION
Fix the final nonpublishing simulation artifact upload after run 29831602437 exposed an invalid colon in the artifact name.

Use the numeric GitHub run ID for the portable unique artifact name while retaining the semantic simulation ID inside the signed evidence record. Add focused regression coverage.