### PR TITLE
test(windows): allow cold mouse run-shell startup

### DIFF
--- a/crates/rmux-server/src/handler_send_keys_tests/live_attach.rs
+++ b/crates/rmux-server/src/handler_send_keys_tests/live_attach.rs
@@ -19,6 +19,12 @@ const ITERATIVE_INPUT_CHAIN_TIMEOUT: Duration = if cfg!(windows) {
     Duration::from_secs(30)
 };
 const BOUNDED_REROUTE_CHAIN_TIMEOUT: Duration = Duration::from_secs(30);
+const BACKGROUND_RUN_SHELL_TIMEOUT: Duration = if cfg!(windows) {
+    // A cold PowerShell process can exceed ten seconds on hosted Windows CI.
+    Duration::from_secs(30)
+} else {
+    Duration::from_secs(10)
+};
 
 async fn set_global_hook(handler: &RequestHandler, hook: HookName, command: &str) {
     let response = handler
@@ -3204,7 +3210,7 @@ async fn live_attach_mouse_binding_run_shell_tail_writes_its_file() {
         .await
         .expect("live attach mouse down input");
 
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    let deadline = tokio::time::Instant::now() + BACKGROUND_RUN_SHELL_TIMEOUT;
     loop {
         {
             let state = handler.state.lock().await;


### PR DESCRIPTION
Align the live mouse binding background PowerShell probe with the existing 30-second Windows liveness budget.

The exact main run 29832956385 showed the process exceeding the fixture's fixed 10-second timeout while all product behavior and the other 17 Windows shards remained green. No production code or retry policy changes.