### PR TITLE
release: audit downstream ruleset bypasses

### DIFF
--- a/.github/release/downstream-repositories.json
+++ b/.github/release/downstream-repositories.json
@@ -11,7 +11,7 @@
     "pat_fallback": false,
     "required_permissions": {
       "actions": "read",
-      "administration": "read",
+      "administration": "write",
       "contents": "write",
       "metadata": "read"
     }

--- a/.github/workflows/release-downstream-audit.yml
+++ b/.github/workflows/release-downstream-audit.yml
@@ -53,7 +53,9 @@ jobs:
             rmux-web-share
             scoop-rmux
           permission-actions: read
-          permission-administration: read
+          # GitHub only returns ruleset bypass_actors with write access.
+          # The collector remains GET-only and receives no contents write token.
+          permission-administration: write
           permission-contents: read
 
       - name: Collect and verify live downstream authority

--- a/scripts/release/downstream_contract.py
+++ b/scripts/release/downstream_contract.py
@@ -335,7 +335,7 @@ def _validate_repositories(release: Path) -> None:
         "pat_fallback": False,
         "required_permissions": {
             "actions": "read",
-            "administration": "read",
+            "administration": "write",
             "contents": "write",
             "metadata": "read",
         },

--- a/scripts/release/downstream_workflow_contract.py
+++ b/scripts/release/downstream_workflow_contract.py
@@ -191,7 +191,7 @@ def _validate_live_audit(path: Path) -> None:
         "  workflow_dispatch:",
         "permissions: {}",
         "environment: release-publication",
-        "permission-administration: read",
+        "permission-administration: write",
         "permission-contents: read",
         "collect-downstream-repository.py",
         "verify-downstream-repository.py fixtures",
@@ -209,8 +209,7 @@ def _validate_live_audit(path: Path) -> None:
         if text.count(repository) != 2:
             raise ValueError(f"downstream live audit lost repository {repository}")
     if (
-        "permission-administration: write" in text
-        or "permission-contents: write" in text
+        "permission-contents: write" in text
         or "secrets: inherit" in text
         or "self-hosted" in text
     ):

--- a/scripts/release/verify-downstream-repository.py
+++ b/scripts/release/verify-downstream-repository.py
@@ -28,7 +28,7 @@ WRITER_APP = {
     "pat_fallback": False,
     "required_permissions": {
         "actions": "read",
-        "administration": "read",
+        "administration": "write",
         "contents": "write",
         "metadata": "read",
     },

--- a/tests/release_downstream_workflows_spec.rs
+++ b/tests/release_downstream_workflows_spec.rs
@@ -180,9 +180,9 @@ fn downstream_authority_is_rechecked_live_before_payload_staging() {
     assert!(DOWNSTREAM_AUDIT.contains("on:\n  workflow_call:"));
     assert!(DOWNSTREAM_AUDIT.contains("  workflow_dispatch:"));
     assert!(DOWNSTREAM_AUDIT.contains("environment: release-publication"));
-    assert!(DOWNSTREAM_AUDIT.contains("permission-administration: read"));
+    assert!(DOWNSTREAM_AUDIT.contains("permission-administration: write"));
     assert!(DOWNSTREAM_AUDIT.contains("permission-contents: read"));
-    assert!(!DOWNSTREAM_AUDIT.contains("permission-administration: write"));
+    assert!(!DOWNSTREAM_AUDIT.contains("permission-administration: read"));
     assert!(!DOWNSTREAM_AUDIT.contains("permission-contents: write"));
     assert!(!DOWNSTREAM_AUDIT.contains("secrets: inherit"));
     assert!(DOWNSTREAM_AUDIT.contains("collect-downstream-repository.py"));
@@ -519,7 +519,7 @@ fn public_owned_downstream_protection_layers_are_recorded_but_disarmed() {
     assert_eq!(registry["writer_app"]["pat_fallback"], false);
     assert_eq!(
         registry["writer_app"]["required_permissions"]["administration"],
-        "read"
+        "write"
     );
     let repositories = registry["repositories"].as_array().expect("repositories");
 
@@ -646,7 +646,7 @@ fn downstream_repository_verifier_accepts_github_ruleset_arrays() {
             "id": 147959477,
             "app_id": 4352876,
             "repository_selection": "selected",
-            "permissions": {"actions": "read", "administration": "read", "contents": "write", "metadata": "read"},
+            "permissions": {"actions": "read", "administration": "write", "contents": "write", "metadata": "read"},
             "events": [],
             "repository_ids": [1249553407, 1258602064, 1259133629, 1259135161]
         }),


### PR DESCRIPTION
## Summary

- request Administration write for the downstream audit so GitHub returns ruleset bypass actors
- keep repository contents read-only in the audit token and retain the GET-only collector
- align release contracts and regression coverage with the installed App permissions

## Validation

- cargo fmt --all -- --check
- cargo test --locked --test release_downstream_workflows_spec --test release_downstream_writer_spec --test release_automation_spec
- python3 scripts/release/validate-contracts.py
- ruff check and format check on changed Python files
- actionlint v1.7.12