### PR TITLE
fix(release): bind signed tags to maintainer identity

### DIFF
--- a/scripts/release/sign-and-push-release-tag.sh
+++ b/scripts/release/sign-and-push-release-tag.sh
@@ -200,8 +200,8 @@ fi
 
 clone=$temporary/repository
 git clone --quiet --no-checkout --no-hardlinks --local "$repository_root" "$clone"
-git -C "$clone" config user.name 'RMUX Release'
-git -C "$clone" config user.email 'release@rmux.io'
+git -C "$clone" config user.name 'Sidney Sissaoui'
+git -C "$clone" config user.email 'shideneyu@gmail.com'
 git -C "$clone" config gpg.format ssh
 git -C "$clone" config user.signingkey "$(realpath "$signing_key")"
 git -C "$clone" tag --annotate --sign --file "$message_file" "$release_ref" "$source_sha"

--- a/tests/release_tag_contract_spec.rs
+++ b/tests/release_tag_contract_spec.rs
@@ -44,6 +44,9 @@ fn release_tag_surface_has_a_dedicated_signer_and_is_create_only() {
     assert!(driver.contains("refs/tags/$release_ref:refs/tags/$release_ref"));
     assert!(driver.contains("https://github.com/Helvesec/rmux.git"));
     assert!(driver.contains("GIT_ASKPASS=$askpass"));
+    assert!(driver.contains("config user.name 'Sidney Sissaoui'"));
+    assert!(driver.contains("config user.email 'shideneyu@gmail.com'"));
+    assert!(!driver.contains("config user.email 'release@rmux.io'"));
     assert!(driver.contains("github_verification=$(verify_existing_ref \"$created_ref\")"));
     assert_eq!(driver.matches("verify_existing_ref").count(), 3);
     for forbidden in [


### PR DESCRIPTION
GitHub rejected the first immutable RC tag proof with `reason=no_user`: the dedicated SSH signature was present, but the tagger used an address not associated with the maintainer account.

Use the verified maintainer identity for tag metadata while retaining the dedicated allowlisted release signing key, and contract the exact values. The failed immutable `v0.9.1-rc.1` tag is not rewritten; the next drill will use `v0.9.1-rc.2`.

Validation:
- cargo test --locked --test release_tag_contract_spec --test release_signed_tag_spec
- cargo test --locked --test release_automation_spec
- python3 scripts/release/validate-contracts.py
- bash -n scripts/release/sign-and-push-release-tag.sh
- cargo fmt --all -- --check
- git diff --check