### PR TITLE
fix(release): verify GitHub signed tag messages

### DIFF
--- a/scripts/release/verify-release-tag.py
+++ b/scripts/release/verify-release-tag.py
@@ -217,9 +217,10 @@ def verify_github_json(
     signature_text = require_string(verification.get("signature"), "signature envelope")
     raw = payload_text.encode("utf-8") + signature_text.encode("utf-8")
     result = verify_raw_tag(raw, tag_sha, identity)
-    if tag.get("message") != identity.message():
+    github_message = require_string(tag.get("message"), "GitHub tag message")
+    if github_message != identity.message() + signature_text:
         raise PolicyError(
-            "GitHub tag message differs from the canonical signed message"
+            "GitHub tag message differs from the canonical message and signature"
         )
     result["mode"] = "github-json-verified"
     return result

--- a/tests/release_signed_tag_spec.rs
+++ b/tests/release_signed_tag_spec.rs
@@ -313,6 +313,11 @@ fn write_github_tag_fixture(fixture: &Fixture, message: &Path) -> (PathBuf, Path
         String::from_utf8(raw.stdout[..marker_index].to_vec()).expect("signature payload UTF-8");
     let signature =
         String::from_utf8(raw.stdout[marker_index..].to_vec()).expect("signature envelope UTF-8");
+    let github_message = format!(
+        "{}{}",
+        fs::read_to_string(message).expect("read canonical message"),
+        signature
+    );
     let ref_json = fixture.root.join("ref.json");
     let tag_json = fixture.root.join("tag.json");
     fs::write(
@@ -329,7 +334,7 @@ fn write_github_tag_fixture(fixture: &Fixture, message: &Path) -> (PathBuf, Path
         serde_json::to_vec(&serde_json::json!({
             "sha": tag_sha,
             "tag": "v0.9.1",
-            "message": fs::read_to_string(message).expect("read canonical message"),
+            "message": github_message,
             "object": {
                 "type": "commit",
                 "sha": fixture.source_sha,
@@ -643,7 +648,7 @@ headers, message = payload.split("\n\n", 1)
 header = dict(line.split(" ", 1) for line in headers.splitlines()[:3])
 ref = {"ref": "refs/tags/v0.9.1", "object": {"type": "tag", "sha": sys.argv[2]}}
 tag = {
-    "sha": sys.argv[2], "tag": "v0.9.1", "message": message,
+    "sha": sys.argv[2], "tag": "v0.9.1", "message": message + signature,
     "object": {"type": "commit", "sha": header["object"]},
     "verification": {
         "verified": sys.argv[5] == "true", "reason": "valid" if sys.argv[5] == "true" else "unknown_key",


### PR DESCRIPTION
## Summary
- validate GitHub's signed annotated tag representation
- preserve byte-exact verification of payload and SSH signature
- cover the live API message shape in release tag tests

## Validation
- cargo test --test release_signed_tag_spec --locked
- cargo test --test release_promoter_workflows_spec --test release_automation_spec --test release_tag_contract_spec --locked
- cargo fmt --all -- --check
- scripts/release/validate-contracts.py
- bash -n scripts/release/sign-and-push-release-tag.sh
- verified the corrected parser against immutable v0.9.1-rc.2