### PR TITLE
fix(release): isolate signed tag JSON output

### DIFF
--- a/scripts/release/sign-and-push-release-tag.sh
+++ b/scripts/release/sign-and-push-release-tag.sh
@@ -229,11 +229,11 @@ printf '%s\n' \
 chmod 700 "$askpass"
 git -C "$clone" remote add release-origin 'https://github.com/Helvesec/rmux.git'
 set +e
-GIT_ASKPASS=$askpass \
+  GIT_ASKPASS=$askpass \
   GIT_TERMINAL_PROMPT=0 \
   RMUX_RELEASE_APP_TOKEN=$RMUX_RELEASE_APP_TOKEN \
   git -C "$clone" push --porcelain release-origin \
-    "refs/tags/$release_ref:refs/tags/$release_ref"
+    "refs/tags/$release_ref:refs/tags/$release_ref" >&2
 push_status=$?
 set -e
 

--- a/tests/release_signed_tag_spec.rs
+++ b/tests/release_signed_tag_spec.rs
@@ -658,6 +658,9 @@ tag = {
 Path(sys.argv[3]).write_text(json.dumps(ref), encoding="utf-8")
 Path(sys.argv[4]).write_text(json.dumps(tag), encoding="utf-8")
 PY
+  printf 'To https://github.com/Helvesec/rmux.git\n'
+  printf '*\trefs/tags/v0.9.1:refs/tags/v0.9.1\t[new tag]\n'
+  printf 'Done\n'
   exit 0
 fi
 exec "$REAL_GIT" "$@"


### PR DESCRIPTION
## Summary
- keep the signed-tag driver stdout as one JSON document
- route git push porcelain diagnostics to stderr
- reproduce real porcelain output in the creation-path regression test

## Validation
- cargo test --test release_signed_tag_spec --locked
- cargo test --test release_promoter_workflows_spec --test release_automation_spec --test release_tag_contract_spec --locked
- cargo fmt --all -- --check
- scripts/release/validate-contracts.py
- bash -n scripts/release/sign-and-push-release-tag.sh