### PR TITLE
fix(release): unblock RC promotion

### DIFF
--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -309,6 +309,8 @@ jobs:
   prepare-policy-audit:
     name: Prepare exact policy audit inputs
     needs: verify-candidate
+    permissions:
+      contents: read
     uses: ./.github/workflows/release-policy-audit.yml
     with:
       candidate_run_id: ${{ inputs.candidate_run_id }}

--- a/crates/rmux-server/src/handler_lifecycle/retained_target_tests/special_paths.rs
+++ b/crates/rmux-server/src/handler_lifecycle/retained_target_tests/special_paths.rs
@@ -418,7 +418,7 @@ fn unique_temp_path(label: &str) -> PathBuf {
 }
 
 async fn wait_for_file(path: &std::path::Path) {
-    tokio::time::timeout(Duration::from_secs(3), async {
+    tokio::time::timeout(Duration::from_secs(10), async {
         while !path.exists() {
             tokio::time::sleep(Duration::from_millis(10)).await;
         }

--- a/scripts/release/policy_audit_contract.py
+++ b/scripts/release/policy_audit_contract.py
@@ -438,6 +438,10 @@ def validate_repository_contracts(root: Path) -> None:
     for caller_name, prepare, audit, workflow_id, caller_path in caller_contracts:
         if prepare.count("uses: ./.github/workflows/release-policy-audit.yml") != 1:
             raise ValueError(f"policy preparer call changed in {caller_name}")
+        if "      contents: read" not in prepare:
+            raise ValueError(
+                f"policy preparer caller lacks contents read in {caller_name}"
+            )
         required_audit = (
             "environment: release-policy-audit",
             "runs-on: ubuntu-22.04",

--- a/tests/release_promoter_workflows_spec.rs
+++ b/tests/release_promoter_workflows_spec.rs
@@ -214,6 +214,7 @@ fn promotion_splits_oidc_from_contents_write_and_keeps_exact_dag() {
     assert!(authorize.contains("rmux-authorization/verified"));
     assert!(authorize.contains("rmux-authorization/policy"));
     assert!(!prepare.contains("if: ${{ false }}"));
+    assert!(prepare.contains("permissions:\n      contents: read"));
     assert!(prepare.contains("uses: ./.github/workflows/release-policy-audit.yml"));
     assert!(!audit.contains("if: ${{ false }}"));
     assert!(audit.contains("environment: release-policy-audit"));


### PR DESCRIPTION
The RC4 promoter was rejected by GitHub before job startup because the reusable policy-audit workflow requested `contents: read` while its caller granted no contents permission. This passes the minimum permission at the reusable-workflow call boundary and adds contract coverage for both promoter and simulation callers.

The first PR run also exposed a Windows timing flake in a newly added background-shell fixture: PowerShell startup exceeded its three-second polling deadline while the other 342 tests in the shard passed. The deadline is now ten seconds without adding delay to successful runs.

Validation:
- controlled promoter dispatch created all six jobs and failed at the expected fake-ref guard rather than workflow startup
- `cargo test --locked --test release_promoter_workflows_spec --test release_policy_audit_spec`
- `cargo test --locked -p rmux-server admitted_background_shell_finishes_after_its_lifecycle_target_retires`
- `python3 scripts/release/validate-contracts.py`
- `python3 -m ruff check scripts/release/policy_audit_contract.py`
- `python3 -m ruff format --check scripts/release/policy_audit_contract.py`
- `cargo fmt --all -- --check`
- `git diff --check`