### PR TITLE
fix(release): flatten signed-tag evidence bundle

### DIFF
--- a/.github/workflows/release-tag-authoring.yml
+++ b/.github/workflows/release-tag-authoring.yml
@@ -325,15 +325,27 @@ jobs:
             --verified-at "$verified_at" \
             --document "$RUNNER_TEMP/signed-tag-proof.json"
 
+      - name: Stage the exact signed-tag evidence bundle
+        shell: bash
+        run: |
+          set -euo pipefail
+          bundle="$RUNNER_TEMP/rmux-signed-tag"
+          install -d -m 0700 "$bundle"
+          install -m 0600 \
+            "$RUNNER_TEMP/rmux-tag-input/candidate-reference.json" \
+            "$bundle/candidate-reference.json"
+          install -m 0600 "$RUNNER_TEMP/signed-tag-proof.json" "$bundle/signed-tag-proof.json"
+          install -m 0600 "$RUNNER_TEMP/tag-verification.json" "$bundle/tag-verification.json"
+
       - id: tag-proof
         name: Upload only exact signed-tag evidence
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: rmux-signed-tag-${{ inputs.expected_source_sha }}
           path: |
-            ${{ runner.temp }}/rmux-tag-input/candidate-reference.json
-            ${{ runner.temp }}/signed-tag-proof.json
-            ${{ runner.temp }}/tag-verification.json
+            ${{ runner.temp }}/rmux-signed-tag/candidate-reference.json
+            ${{ runner.temp }}/rmux-signed-tag/signed-tag-proof.json
+            ${{ runner.temp }}/rmux-signed-tag/tag-verification.json
           if-no-files-found: error
           retention-days: 1
           compression-level: 0

--- a/crates/rmux-client/src/attach_windows/stream_tests.rs
+++ b/crates/rmux-client/src/attach_windows/stream_tests.rs
@@ -1574,7 +1574,7 @@ fn cancellation_remains_active_while_output_drop_blocks() -> Result<(), Box<dyn 
     drop_started_rx
         .recv_timeout(Duration::from_secs(1))
         .map_err(|_| io::Error::other("output Drop did not start"))?;
-    let joined = match joined_rx.recv_timeout(Duration::from_secs(2)) {
+    let joined = match joined_rx.recv_timeout(Duration::from_secs(10)) {
         Ok(joined) => joined,
         Err(_) => {
             drop(blocked_output_reader);

--- a/tests/release_promoter_workflows_spec.rs
+++ b/tests/release_promoter_workflows_spec.rs
@@ -185,6 +185,30 @@ fn signed_tag_gate_preserves_dedicated_ssh_signature_and_app_boundary() {
 }
 
 #[test]
+fn signed_tag_artifact_stages_all_evidence_at_its_root() {
+    let create = job(TAG, "create-signed-tag", Some("dispatch-promoter"));
+    assert!(create.contains("bundle=\"$RUNNER_TEMP/rmux-signed-tag\""));
+    assert!(create.contains(
+        "\"$RUNNER_TEMP/rmux-tag-input/candidate-reference.json\" \\\n            \"$bundle/candidate-reference.json\""
+    ));
+    for filename in [
+        "candidate-reference.json",
+        "signed-tag-proof.json",
+        "tag-verification.json",
+    ] {
+        assert!(
+            create.contains(&format!(
+                "${{{{ runner.temp }}}}/rmux-signed-tag/{filename}"
+            )),
+            "signed-tag artifact does not stage {filename} at its root"
+        );
+    }
+    assert!(!create.contains(
+        "${{ runner.temp }}/rmux-tag-input/candidate-reference.json\n            ${{ runner.temp }}/signed-tag-proof.json"
+    ));
+}
+
+#[test]
 fn signed_tag_gate_accepts_rfc3339_fractional_seconds() {
     for variable in ["RMUX_MANIFEST_CREATED_AT", "RMUX_MANIFEST_EXPIRES_AT"] {
         let check = format!(


### PR DESCRIPTION
## Summary

- stage the three signed-tag evidence files in one explicit bundle root
- prevent `upload-artifact` from nesting `candidate-reference.json`
- add a regression contract for the promoter input layout

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- targeted release contract and adversarial tests
- `scripts/release/validate-contracts.py`
- `actionlint` 1.7.12