### PR TITLE
fix(release): discover authenticated drafts

### DIFF
--- a/scripts/release/github_release_api.py
+++ b/scripts/release/github_release_api.py
@@ -154,8 +154,36 @@ class ApiClient:
     def get_release(self, release_ref: str) -> dict[str, Any] | None:
         path = f"/repos/{REPOSITORY}/releases/tags/{quote(release_ref, safe='')}"
         status, _, value = self.request("GET", path, statuses={200, 404})
-        if status == 404:
-            return None
+        if status == 200:
+            if not isinstance(value, dict):
+                raise ValueError("GitHub release response is not an object")
+            return value
+
+        # The tag endpoint returns published releases only. Authenticated release
+        # listings include drafts, so scan a bounded number of pages to support
+        # exact draft resumption without weakening public-release detection.
+        for page in range(1, 11):
+            _, headers, releases = self.request(
+                "GET",
+                f"/repos/{REPOSITORY}/releases?per_page=100&page={page}",
+            )
+            if not isinstance(releases, list) or not all(
+                isinstance(item, dict) for item in releases
+            ):
+                raise ValueError("GitHub release listing is invalid")
+            matches = [item for item in releases if item.get("tag_name") == release_ref]
+            if len(matches) > 1:
+                raise ValueError("GitHub release listing contains duplicate tags")
+            if matches:
+                return matches[0]
+            if 'rel="next"' not in headers.get("link", ""):
+                return None
+        raise ValueError("GitHub release listing exceeded the bounded scan")
+
+    def get_release_by_id(self, release_id: int) -> dict[str, Any]:
+        _, _, value = self.request(
+            "GET", f"/repos/{REPOSITORY}/releases/{positive(release_id, 'release ID')}"
+        )
         if not isinstance(value, dict):
             raise ValueError("GitHub release response is not an object")
         return value
@@ -338,7 +366,7 @@ def verify_live_inputs(
     client: ApiClient, evidence: Any, now: datetime, release_id: int
 ) -> None:
     verify_live_evidence(client, evidence, now)
-    current = client.get_release(evidence.release_ref)
-    if current is None or release_identity(current, evidence, draft=True) != release_id:
+    current = client.get_release_by_id(release_id)
+    if release_identity(current, evidence, draft=True) != release_id:
         raise ValueError("GitHub draft changed immediately before publication")
     inspect_assets(client.list_assets(release_id), evidence, complete=True)

--- a/tests/release_github_publisher_spec.rs
+++ b/tests/release_github_publisher_spec.rs
@@ -547,12 +547,27 @@ fn handle_request(mut stream: TcpStream, shared: &Arc<Mutex<ServerState>>) {
     let mut state = shared.lock().expect("fake API state");
     state.requests.push(request.clone());
     let release_path = "/repos/Helvesec/rmux/releases/tags/v1.2.3";
+    let release_list_path = "/repos/Helvesec/rmux/releases?per_page=100&page=1";
+    let release_id_path = "/repos/Helvesec/rmux/releases/42";
     let assets_path = "/repos/Helvesec/rmux/releases/42/assets?per_page=100";
     let (status, value) = match (request.method.as_str(), request.path.as_str()) {
         ("GET", path) if path == release_path => match state.draft {
-            Some(draft) => (200, release_json(draft)),
-            None => (404, json!({"message": "Not Found"})),
+            Some(false) => (200, release_json(false)),
+            Some(true) | None => (404, json!({"message": "Not Found"})),
         },
+        ("GET", path) if path == release_list_path => (
+            200,
+            Value::Array(
+                state
+                    .draft
+                    .map(release_json)
+                    .into_iter()
+                    .collect::<Vec<_>>(),
+            ),
+        ),
+        ("GET", path) if path == release_id_path && state.draft.is_some() => {
+            (200, release_json(state.draft.expect("release state")))
+        }
         ("POST", "/repos/Helvesec/rmux/releases") if state.draft.is_none() => {
             let body: Value = serde_json::from_slice(&request.body).expect("create draft body");
             assert_eq!(body["tag_name"], "v1.2.3");
@@ -666,7 +681,7 @@ fn default_mode_is_a_read_only_plan() {
     assert_eq!(result["action"], "create-draft");
     assert_eq!(result["mutations"], false);
     let requests = server.requests();
-    assert_eq!(requests.len(), 1);
+    assert_eq!(requests.len(), 2);
     assert!(requests.iter().all(|request| request.method == "GET"));
 }
 
@@ -815,6 +830,12 @@ fn resumes_only_the_exact_draft_without_clobbering_existing_asset() {
             .count(),
         1
     );
+    assert!(requests.iter().any(|item| {
+        item.method == "GET" && item.path == "/repos/Helvesec/rmux/releases?per_page=100&page=1"
+    }));
+    assert!(requests
+        .iter()
+        .any(|item| { item.method == "GET" && item.path == "/repos/Helvesec/rmux/releases/42" }));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- discover draft releases through the authenticated release listing
- revalidate the exact draft by release ID before publication
- model the published-only tag endpoint in the publisher regression fixture

## Validation

- `cargo test --locked --test release_github_publisher_spec`
- `cargo test --locked --test release_promoter_workflows_spec --test release_promotion_evidence_spec`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `ruff check scripts/release/github_release_api.py`
- live read-only draft discovery and ID lookup for `v0.9.1-rc.6`