### PR TITLE
fix(release): accept enriched tag targets in receipts

### DIFF
--- a/.github/workflows/release-receipt.yml
+++ b/.github/workflows/release-receipt.yml
@@ -186,7 +186,15 @@ jobs:
           if ref.get("ref") != f"refs/tags/{os.environ['RMUX_RELEASE_REF']}" or ref_object.get("type") != "tag" or ref_object.get("sha") != predicate.get("signed_tag", {}).get("tag_object_sha"):
               raise SystemExit("live release ref differs from authorized tag object")
           verification, target = tag.get("verification", {}), tag.get("object", {})
-          if tag.get("sha") != ref_object.get("sha") or tag.get("tag") != os.environ["RMUX_RELEASE_REF"] or target != {"type": "commit", "sha": os.environ["RMUX_EXPECTED_SOURCE_SHA"]} or verification.get("verified") is not True or verification.get("reason") != "valid":
+          if (
+              tag.get("sha") != ref_object.get("sha")
+              or tag.get("tag") != os.environ["RMUX_RELEASE_REF"]
+              or not isinstance(target, dict)
+              or target.get("type") != "commit"
+              or target.get("sha") != os.environ["RMUX_EXPECTED_SOURCE_SHA"]
+              or verification.get("verified") is not True
+              or verification.get("reason") != "valid"
+          ):
               raise SystemExit("live annotated tag signature or target differs")
           rendered_assets = sorted(
               ({"id": item.get("id"), "name": item.get("name"), "size": item.get("size"), "digest": item.get("digest")} for item in assets),

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,12 +21,24 @@ Verify an asset attestation with:
 gh attestation verify <asset> --repo Helvesec/rmux
 ```
 
-Verify the signed checksums with:
+For `v0.9.1` and later, verify that an asset is covered by the signed release
+authorization bundle:
+
+```sh
+cosign verify-blob-attestation \
+  --bundle SHA256SUMS.sigstore.json \
+  --certificate-identity-regexp '^https://github.com/Helvesec/rmux/\.github/workflows/release-promote\.yml@refs/tags/v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --type https://rmux.io/attestations/release-promotion-authorization/v1 \
+  <asset>
+```
+
+For releases from `v0.6.5` through `v0.9.0`, verify the signed checksums with:
 
 ```sh
 cosign verify-blob \
   --bundle SHA256SUMS.sigstore.json \
-  --certificate-identity-regexp '^https://github.com/Helvesec/rmux/.github/workflows/release.yml@refs/tags/v0\.(6|7|8|9)\.[0-9]+(-[0-9A-Za-z.-]+)?$' \
+  --certificate-identity-regexp '^https://github.com/Helvesec/rmux/\.github/workflows/release\.yml@refs/tags/(v0\.[678]\.[0-9]+(-[0-9A-Za-z.-]+)?|v0\.9\.0)$' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   SHA256SUMS
 ```

--- a/tests/release_promoter_workflows_spec.rs
+++ b/tests/release_promoter_workflows_spec.rs
@@ -16,6 +16,7 @@ const PROMOTION_SIMULATION: &str = include_str!("../scripts/release/promotion-si
 const CI: &str = include_str!("../.github/workflows/ci.yml");
 const LEGACY_RELEASE: &str = include_str!("../.github/workflows/release.yml");
 const LEGACY_CHOCOLATEY: &str = include_str!("../.github/workflows/publish-chocolatey.yml");
+const SECURITY: &str = include_str!("../SECURITY.md");
 
 fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -302,6 +303,10 @@ fn receipt_is_separate_receipt_only_and_never_writes_contents() {
     assert!(RECEIPT.contains("\"run_attempt\": 1"));
     assert!(RECEIPT.contains("live immutable Release identity differs"));
     assert!(RECEIPT.contains("live annotated tag signature or target differs"));
+    assert!(RECEIPT.contains("not isinstance(target, dict)"));
+    assert!(RECEIPT.contains("target.get(\"type\") != \"commit\""));
+    assert!(RECEIPT.contains("target.get(\"sha\") != os.environ[\"RMUX_EXPECTED_SOURCE_SHA\"]"));
+    assert!(!RECEIPT.contains("target != {\"type\": \"commit\""));
     assert!(RECEIPT.contains("Accept: application/octet-stream"));
     assert!(RECEIPT.contains("attestation verify"));
     assert!(RECEIPT.contains(
@@ -311,6 +316,19 @@ fn receipt_is_separate_receipt_only_and_never_writes_contents() {
     assert!(RECEIPT.contains("signed authorization predicate differs"));
     assert!(RECEIPT.contains("${{ runner.temp }}/rmux-receipt/release-state.json"));
     assert!(!RECEIPT.contains("release_state_artifact_id"));
+}
+
+#[test]
+fn release_verification_docs_match_current_and_legacy_bundle_types() {
+    assert!(SECURITY.contains("For `v0.9.1` and later"));
+    assert!(SECURITY.contains("cosign verify-blob-attestation"));
+    assert!(SECURITY.contains("release-promote\\.yml@refs/tags/"));
+    assert!(
+        SECURITY.contains("--type https://rmux.io/attestations/release-promotion-authorization/v1")
+    );
+    assert!(SECURITY.contains("For releases from `v0.6.5` through `v0.9.0`"));
+    assert!(SECURITY.contains("cosign verify-blob \\"));
+    assert!(SECURITY.contains("release\\.yml@refs/tags/"));
 }
 
 #[test]


### PR DESCRIPTION
Validate the annotated tag target by its required `type` and `sha` fields while permitting additional GitHub API metadata such as `url`. Document and contract the current release-authorization attestation command while retaining the legacy checksum-signature command through v0.9.0.