### PR TITLE
fix(release): unblock v0.9.1 qualification

### DIFF
--- a/crates/rmux-pty/tests/windows_conpty.rs
+++ b/crates/rmux-pty/tests/windows_conpty.rs
@@ -358,20 +358,24 @@ fn conpty_force_kill_reaps_child() -> Result<(), Box<dyn std::error::Error>> {
 #[test]
 fn conpty_force_kill_reaps_grandchild_process_tree() -> Result<(), Box<dyn std::error::Error>> {
     let command = concat!(
-        "powershell -NoLogo -NoProfile -NonInteractive -Command ",
-        "\"$child = Start-Process -FilePath ($PSHOME + '\\powershell.exe') ",
+        "$child = Start-Process -FilePath ($PSHOME + '\\powershell.exe') ",
         "-ArgumentList '-NoLogo -NoProfile -NonInteractive -Command Start-Sleep -Seconds 30' ",
         "-WindowStyle Hidden -PassThru; ",
         "[Console]::Out.WriteLine('RMUX_' + 'GRANDCHILD=' + $child.Id); ",
-        "[Console]::Out.Flush()\"\r\n"
+        "[Console]::Out.Flush(); ",
+        "Start-Sleep -Seconds 30"
     );
-    let mut spawned = ChildCommand::new("C:\\Windows\\System32\\cmd.exe")
-        .args(["/D", "/K"])
-        .size(TerminalSize::new(100, 30))
-        .spawn()?;
-    let io = spawned.master().try_clone_io()?;
-    let _ = read_until_io(&io, b">", Duration::from_secs(2))?;
-    io.write_all(command.as_bytes())?;
+    let mut spawned =
+        ChildCommand::new("C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe")
+            .args([
+                "-NoLogo",
+                "-NoProfile",
+                "-NonInteractive",
+                "-Command",
+                command,
+            ])
+            .size(TerminalSize::new(100, 30))
+            .spawn()?;
 
     let output = read_until_or_kill(
         &mut spawned,

--- a/scripts/check-release-versions.sh
+++ b/scripts/check-release-versions.sh
@@ -193,7 +193,7 @@ if match is None:
 identity_re = match.group(1)
 identity = (
     "https://github.com/Helvesec/rmux/.github/workflows/"
-    f"release.yml@refs/tags/v{version}"
+    f"release-promote.yml@refs/tags/v{version}"
 )
 if re.fullmatch(identity_re, identity) is None:
     print(

--- a/tests/release_promoter_workflows_spec.rs
+++ b/tests/release_promoter_workflows_spec.rs
@@ -17,6 +17,7 @@ const CI: &str = include_str!("../.github/workflows/ci.yml");
 const LEGACY_RELEASE: &str = include_str!("../.github/workflows/release.yml");
 const LEGACY_CHOCOLATEY: &str = include_str!("../.github/workflows/publish-chocolatey.yml");
 const SECURITY: &str = include_str!("../SECURITY.md");
+const CHECK_RELEASE_VERSIONS: &str = include_str!("../scripts/check-release-versions.sh");
 
 fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -329,6 +330,8 @@ fn release_verification_docs_match_current_and_legacy_bundle_types() {
     assert!(SECURITY.contains("For releases from `v0.6.5` through `v0.9.0`"));
     assert!(SECURITY.contains("cosign verify-blob \\"));
     assert!(SECURITY.contains("release\\.yml@refs/tags/"));
+    assert!(CHECK_RELEASE_VERSIONS.contains("f\"release-promote.yml@refs/tags/v{version}\""));
+    assert!(!CHECK_RELEASE_VERSIONS.contains("f\"release.yml@refs/tags/v{version}\""));
 }
 
 #[test]


### PR DESCRIPTION
Two independent qualification failures blocked the v0.9.1 candidate path:

- the release version gate still constructed the legacy `release.yml` certificate identity after verification moved to `release-promote.yml`;
- the Windows ConPTY process-tree fixture used an interactive `cmd /K` prompt plus nested PowerShell startup, making its 15-second output deadline nondeterministic under parallel load. The fixture now starts the PowerShell parent directly and keeps it alive while the grandchild is checked.

Validated locally with:
- `scripts/check-release-versions.sh`
- static release review gate
- `cargo test --locked --test release_promoter_workflows_spec`
- `cargo fmt --all -- --check`
- `git diff --check`

The Windows fixture is validated by the native Windows CI job; the local Windows GNU link prerequisite (`x86_64-w64-mingw32-dlltool`) is not installed on this host.