### PR TITLE
fix(release): honor GitHub publication timestamps

### DIFF
--- a/scripts/release/publication_release_state.py
+++ b/scripts/release/publication_release_state.py
@@ -82,7 +82,13 @@ def validate_release_state(
     audit_expires = timestamp(
         predicate["policy_audit"]["expires_at"], "policy audit expires_at"
     )
-    if not issued <= created <= published <= expires or published > audit_expires:
+    # GitHub derives a Release's created_at from the tagged commit. Only the
+    # immutable publication transition must occur inside the authorization TTL.
+    if (
+        created > published
+        or not issued <= published <= expires
+        or published > audit_expires
+    ):
         raise ValueError("GitHub Release changed state outside the authorization TTL")
     expected = _expected_release_assets(predicate, envelope)
     actual = state["assets"]

--- a/tests/release_promotion_evidence_spec.rs
+++ b/tests/release_promotion_evidence_spec.rs
@@ -487,7 +487,7 @@ fn complete_release_state(fixture: &Fixture) {
             "repository_id": 1239918790, "release_id": 1234,
             "release_ref": "v1.0.0", "source_git_sha": SOURCE,
             "tag_object_sha": TAG_OBJECT, "draft": false, "prerelease": false,
-            "immutable": true, "created_at": "2026-07-19T00:32:00Z",
+            "immutable": true, "created_at": "2026-07-19T00:29:00Z",
             "published_at": "2026-07-19T00:33:00Z", "assets": assets
         }),
     );
@@ -749,6 +749,18 @@ fn publication_receipt_round_trip_rejects_asset_and_authorization_drift() {
         ),
         "authorized immutable release",
     );
+    for published_at in ["2026-07-19T00:30:00Z", "2026-07-19T00:41:00Z"] {
+        let mut outside_ttl = original_state.clone();
+        outside_ttl["published_at"] = json!(published_at);
+        write_json(&fixture.release_state, &outside_ttl);
+        assert_rejected(
+            invoke(
+                "publication-receipt.py",
+                &receipt_predicate_args(&fixture, "--output", &duplicate),
+            ),
+            "outside the authorization TTL",
+        );
+    }
     write_json(&fixture.release_state, &original_state);
     let original_envelope = read_json(&fixture.authorization_envelope);
     let mut forged_envelope = original_envelope.clone();


### PR DESCRIPTION
GitHub reports a Release `created_at` derived from the tagged commit, so it may predate the short-lived promotion authorization. Validate the immutable publication transition (`published_at`) against the authorization and audit TTLs while retaining causal ordering.

The regression suite now covers a pre-authorization `created_at` and rejects publications before issuance or after expiry. The corrected validator also accepts the exact immutable RC8 state (release 359024869, 13 assets).

Validation:
- `cargo test --locked --test release_promotion_evidence_spec`
- `scripts/release-review-gate.sh --section static`
- `cargo fmt --all -- --check`
- `ruff check` / `ruff format --check`
- `git diff --check`