### PR TITLE
fix(release): verify current receipt artifacts

### DIFF
--- a/.github/workflows/release-downstream.yml
+++ b/.github/workflows/release-downstream.yml
@@ -97,7 +97,7 @@ jobs:
             --expected-workflow-id "$RMUX_RECEIPT_RUN_WORKFLOW_ID" \
             --expected-workflow-path .github/workflows/release-receipt.yml \
             --expected-event workflow_dispatch --expected-head-branch "$RMUX_RELEASE_REF" \
-            --max-attempts 1 > "$root/receipt-artifact.json"
+            --allow-running-current-run --max-attempts 1 > "$root/receipt-artifact.json"
           python3 scripts/release/actions-artifact.py verify \
             --repository "$GITHUB_REPOSITORY" --run-id "$RMUX_RECEIPT_RUN_ID" \
             --artifact-id "$RMUX_RECEIPT_ENVELOPE_ARTIFACT_ID" \
@@ -107,7 +107,7 @@ jobs:
             --expected-workflow-id "$RMUX_RECEIPT_RUN_WORKFLOW_ID" \
             --expected-workflow-path .github/workflows/release-receipt.yml \
             --expected-event workflow_dispatch --expected-head-branch "$RMUX_RELEASE_REF" \
-            --max-attempts 1 > "$root/envelope-artifact.json"
+            --allow-running-current-run --max-attempts 1 > "$root/envelope-artifact.json"
 
       - name: Download only the exact receipt predicate bundle ID
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093

--- a/tests/release_downstream_workflows_spec.rs
+++ b/tests/release_downstream_workflows_spec.rs
@@ -261,8 +261,11 @@ fn exact_receipt_ids_digests_origin_and_documents_are_bound() {
         "rmux-publication-receipt-$RMUX_EXPECTED_SOURCE_SHA-$RMUX_RELEASE_ID",
         "rmux-publication-receipt-envelope-$RMUX_EXPECTED_SOURCE_SHA-$RMUX_RELEASE_ID",
     ] {
-        assert!(artifact_verification(prepare, artifact_name)
-            .contains("--expected-workflow-path .github/workflows/release-receipt.yml"));
+        let verification = artifact_verification(prepare, artifact_name);
+        assert!(
+            verification.contains("--expected-workflow-path .github/workflows/release-receipt.yml")
+        );
+        assert!(verification.contains("--allow-running-current-run"));
     }
     assert_eq!(
         prepare


### PR DESCRIPTION
The downstream workflow consumes receipt artifacts produced earlier in the same workflow run. Pass the existing fail-closed current-run allowance to those two exact verifications, and contract-test both invocations.

Validated locally:
- cargo test --locked --test release_downstream_workflows_spec
- cargo test --locked --test release_canonical_build_spec actions_artifact
- scripts/release-review-gate.sh --section static
- git diff --check