### PR TITLE
fix(release): normalize downstream release identity

### DIFF
--- a/scripts/release/build-downstream-receipt-reference.py
+++ b/scripts/release/build-downstream-receipt-reference.py
@@ -11,12 +11,24 @@ from typing import Any
 from downstream_channels import (
     file_hash,
     read_object,
+    timestamp,
     validate_receipt_reference,
     write_object,
 )
 
 REPOSITORY_ID = 1239918790
 RECEIPT_WORKFLOW = ".github/workflows/release-receipt.yml"
+DOWNSTREAM_RELEASE_FIELDS = (
+    "id",
+    "ref",
+    "intent_id",
+    "kind",
+    "tag_object_sha",
+    "immutable",
+)
+RECEIPT_RELEASE_FIELDS = frozenset(
+    (*DOWNSTREAM_RELEASE_FIELDS, "created_at", "published_at")
+)
 
 
 def parse_args() -> argparse.Namespace:
@@ -58,6 +70,21 @@ def artifact_reference(value: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def downstream_release_identity(value: dict[str, Any]) -> dict[str, Any]:
+    actual = set(value)
+    if actual != RECEIPT_RELEASE_FIELDS:
+        raise ValueError(
+            "publication receipt release keys differ: "
+            f"missing={sorted(RECEIPT_RELEASE_FIELDS - actual)}, "
+            f"extra={sorted(actual - RECEIPT_RELEASE_FIELDS)}"
+        )
+    created_at = timestamp(value["created_at"], "release created_at")
+    published_at = timestamp(value["published_at"], "release published_at")
+    if created_at > published_at:
+        raise ValueError("release publication predates release creation")
+    return {field: value[field] for field in DOWNSTREAM_RELEASE_FIELDS}
+
+
 def build(args: argparse.Namespace) -> None:
     exact_file_set(
         args.predicate.parent,
@@ -93,11 +120,12 @@ def build(args: argparse.Namespace) -> None:
         or not isinstance(release, dict)
     ):
         raise ValueError("publication receipt predicate identity differs")
+    release_identity = downstream_release_identity(release)
     if (
-        release.get("id") != args.release_id
-        or release.get("ref") != args.release_ref
-        or release.get("kind") != args.release_kind
-        or release.get("immutable") is not True
+        release_identity["id"] != args.release_id
+        or release_identity["ref"] != args.release_ref
+        or release_identity["kind"] != args.release_kind
+        or release_identity["immutable"] is not True
     ):
         raise ValueError("publication receipt release identity differs")
     predicate_sha = file_hash(args.predicate)
@@ -128,7 +156,7 @@ def build(args: argparse.Namespace) -> None:
         "downstream_authority": True,
         "repository_id": REPOSITORY_ID,
         "source_git_sha": args.source_sha,
-        "release": release,
+        "release": release_identity,
         "receipt": receipt,
         "predicate_bundle": predicate_artifact,
         "predicate_sha256": predicate_sha,

--- a/tests/release_downstream_receipt_reference_spec.rs
+++ b/tests/release_downstream_receipt_reference_spec.rs
@@ -1,0 +1,67 @@
+#![cfg(unix)]
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+#[test]
+fn rich_receipt_release_is_normalized_for_downstream_documents() {
+    let source = r#"
+import runpy
+import sys
+
+sys.path.insert(0, "scripts/release")
+module = runpy.run_path("scripts/release/build-downstream-receipt-reference.py")
+normalize = module["downstream_release_identity"]
+release = {
+    "id": 7,
+    "ref": "v1.2.3",
+    "intent_id": "release:v1.2.3:test",
+    "kind": "stable",
+    "tag_object_sha": "a" * 40,
+    "immutable": True,
+    "created_at": "2026-07-20T00:00:00Z",
+    "published_at": "2026-07-20T00:01:00Z",
+}
+expected = {
+    key: release[key]
+    for key in ("id", "ref", "intent_id", "kind", "tag_object_sha", "immutable")
+}
+assert normalize(release) == expected
+
+with_extra = {**release, "unexpected": True}
+try:
+    normalize(with_extra)
+except ValueError as error:
+    assert "publication receipt release keys differ" in str(error)
+else:
+    raise AssertionError("unexpected release fields were accepted")
+
+out_of_order = {
+    **release,
+    "created_at": "2026-07-20T00:02:00Z",
+    "published_at": "2026-07-20T00:01:00Z",
+}
+try:
+    normalize(out_of_order)
+except ValueError as error:
+    assert "publication predates release creation" in str(error)
+else:
+    raise AssertionError("out-of-order release timestamps were accepted")
+"#;
+    let output = Command::new("python3")
+        .arg("-c")
+        .arg(source)
+        .current_dir(repo_root())
+        .output()
+        .expect("run downstream receipt normalization");
+    assert!(
+        output.status.success(),
+        "stdout={}\nstderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}


### PR DESCRIPTION
Publication receipts carry GitHub release timestamps in addition to the canonical downstream identity. Validate the rich receipt fields and timestamp ordering, then project the six-field identity used by every downstream schema.

Validated locally:
- exact RC10 receipt and envelope artifacts
- cargo test --locked --test release_downstream_receipt_reference_spec --test release_downstream_payload_spec --test release_downstream_workflows_spec --test release_receipt_attestation_spec
- ruff check and format check
- scripts/release-review-gate.sh --section static
- git diff --check