### PR TITLE
fix(release): preserve downstream environment secrets

### DIFF
--- a/.github/actions/release-downstream-audit/action.yml
+++ b/.github/actions/release-downstream-audit/action.yml
@@ -1,0 +1,69 @@
+name: Audit downstream repository authority
+description: Mint a scoped App token and verify the exact downstream repositories
+
+inputs:
+  expected-source-sha:
+    description: Exact trusted RMUX source commit
+    required: true
+  app-id:
+    description: Downstream GitHub App ID
+    required: true
+  app-private-key:
+    description: Downstream GitHub App private key
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - id: app
+      name: Mint a read-only downstream audit token
+      uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349
+      with:
+        app-id: ${{ inputs.app-id }}
+        private-key: ${{ inputs.app-private-key }}
+        owner: Helvesec
+        repositories: |
+          homebrew-rmux
+          rmux-packages
+          rmux-web-share
+          scoop-rmux
+        permission-actions: read
+        # GitHub only returns ruleset bypass_actors with write access.
+        # The collector remains GET-only and receives no contents write token.
+        permission-administration: write
+        permission-contents: read
+
+    - name: Collect and verify live downstream authority
+      shell: bash
+      env:
+        RMUX_DOWNSTREAM_TOKEN: ${{ steps.app.outputs.token }}
+        RMUX_DOWNSTREAM_APP_ID: ${{ inputs.app-id }}
+        RMUX_DOWNSTREAM_APP_SLUG: ${{ steps.app.outputs.app-slug }}
+        RMUX_DOWNSTREAM_INSTALLATION_ID: ${{ steps.app.outputs.installation-id }}
+      run: |
+        set -euo pipefail
+        root="$RUNNER_TEMP/rmux-downstream-authority"
+        scripts/release/collect-downstream-repository.py \
+          --app-id "$RMUX_DOWNSTREAM_APP_ID" \
+          --app-slug "$RMUX_DOWNSTREAM_APP_SLUG" \
+          --installation-id "$RMUX_DOWNSTREAM_INSTALLATION_ID" \
+          --output-dir "$root"
+        for key in homebrew-rmux rmux-packages rmux-web-share scoop-rmux; do
+          scripts/release/verify-downstream-repository.py fixtures \
+            --repository-key "$key" \
+            --metadata "$root/$key/metadata.json" \
+            --protection "$root/$key/protection.json" \
+            --rulesets "$root/$key/rulesets.json" \
+            --environments "$root/$key/environments.json" \
+            --runners "$root/$key/runners.json" \
+            --installation "$root/installation.json"
+        done
+
+    - name: Upload exact downstream audit fixtures
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+      with:
+        name: rmux-downstream-authority-${{ inputs.expected-source-sha }}-${{ github.run_id }}
+        path: ${{ runner.temp }}/rmux-downstream-authority
+        if-no-files-found: error
+        retention-days: 7
+        compression-level: 0

--- a/.github/release/candidate-contract.json
+++ b/.github/release/candidate-contract.json
@@ -316,6 +316,7 @@
     ".github/actions/release-channel-prepare/action.yml",
     ".github/actions/release-channel-result/action.yml",
     ".github/actions/release-channel-retry-prepare/action.yml",
+    ".github/actions/release-downstream-audit/action.yml",
     ".github/actions/release-policy-audit/action.yml",
     ".github/actions/release-publication-inputs/action.yml",
     ".github/actions/release-snap-candidate-write/action.yml",

--- a/.github/workflows/release-downstream-audit.yml
+++ b/.github/workflows/release-downstream-audit.yml
@@ -40,55 +40,9 @@ jobs:
           ref: ${{ inputs.expected_source_sha }}
           persist-credentials: false
 
-      - id: app
-        name: Mint a read-only downstream audit token
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349
+      - name: Audit exact downstream repository authority
+        uses: ./.github/actions/release-downstream-audit
         with:
           app-id: ${{ vars.RMUX_DOWNSTREAM_APP_ID }}
-          private-key: ${{ secrets.RMUX_DOWNSTREAM_APP_PRIVATE_KEY }}
-          owner: Helvesec
-          repositories: |
-            homebrew-rmux
-            rmux-packages
-            rmux-web-share
-            scoop-rmux
-          permission-actions: read
-          # GitHub only returns ruleset bypass_actors with write access.
-          # The collector remains GET-only and receives no contents write token.
-          permission-administration: write
-          permission-contents: read
-
-      - name: Collect and verify live downstream authority
-        shell: bash
-        env:
-          RMUX_DOWNSTREAM_TOKEN: ${{ steps.app.outputs.token }}
-          RMUX_DOWNSTREAM_APP_ID: ${{ vars.RMUX_DOWNSTREAM_APP_ID }}
-          RMUX_DOWNSTREAM_APP_SLUG: ${{ steps.app.outputs.app-slug }}
-          RMUX_DOWNSTREAM_INSTALLATION_ID: ${{ steps.app.outputs.installation-id }}
-        run: |
-          set -euo pipefail
-          root="$RUNNER_TEMP/rmux-downstream-authority"
-          scripts/release/collect-downstream-repository.py \
-            --app-id "$RMUX_DOWNSTREAM_APP_ID" \
-            --app-slug "$RMUX_DOWNSTREAM_APP_SLUG" \
-            --installation-id "$RMUX_DOWNSTREAM_INSTALLATION_ID" \
-            --output-dir "$root"
-          for key in homebrew-rmux rmux-packages rmux-web-share scoop-rmux; do
-            scripts/release/verify-downstream-repository.py fixtures \
-              --repository-key "$key" \
-              --metadata "$root/$key/metadata.json" \
-              --protection "$root/$key/protection.json" \
-              --rulesets "$root/$key/rulesets.json" \
-              --environments "$root/$key/environments.json" \
-              --runners "$root/$key/runners.json" \
-              --installation "$root/installation.json"
-          done
-
-      - name: Upload exact downstream audit fixtures
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
-        with:
-          name: rmux-downstream-authority-${{ inputs.expected_source_sha }}-${{ github.run_id }}
-          path: ${{ runner.temp }}/rmux-downstream-authority
-          if-no-files-found: error
-          retention-days: 7
-          compression-level: 0
+          app-private-key: ${{ secrets.RMUX_DOWNSTREAM_APP_PRIVATE_KEY }}
+          expected-source-sha: ${{ inputs.expected_source_sha }}

--- a/.github/workflows/release-downstream.yml
+++ b/.github/workflows/release-downstream.yml
@@ -206,11 +206,36 @@ jobs:
   audit-downstream-authority:
     name: Audit live downstream repository authority
     needs: prepare-plan
-    uses: ./.github/workflows/release-downstream-audit.yml
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    environment: release-publication
     permissions:
       contents: read
-    with:
-      expected_source_sha: ${{ inputs.expected_source_sha }}
+    env:
+      RMUX_EXPECTED_SOURCE_SHA: ${{ inputs.expected_source_sha }}
+    steps:
+      - name: Reject malformed or stale audit identity
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REPOSITORY" = "Helvesec/rmux"
+          test "$GITHUB_REPOSITORY_ID" = "1239918790"
+          test "$GITHUB_RUN_ATTEMPT" = 1
+          test "$GITHUB_SHA" = "$RMUX_EXPECTED_SOURCE_SHA"
+          [[ "$RMUX_EXPECTED_SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$GITHUB_REF" =~ ^refs/(heads/main|tags/v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?)$ ]]
+
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ inputs.expected_source_sha }}
+          persist-credentials: false
+
+      - name: Audit exact downstream repository authority
+        uses: ./.github/actions/release-downstream-audit
+        with:
+          app-id: ${{ vars.RMUX_DOWNSTREAM_APP_ID }}
+          app-private-key: ${{ secrets.RMUX_DOWNSTREAM_APP_PRIVATE_KEY }}
+          expected-source-sha: ${{ inputs.expected_source_sha }}
 
   prepare-payloads:
     name: Prepare exact downstream payloads

--- a/scripts/release/downstream_workflow_contract.py
+++ b/scripts/release/downstream_workflow_contract.py
@@ -44,6 +44,10 @@ def _audit_path(root: Path) -> Path:
     return root / ".github/workflows/release-downstream-audit.yml"
 
 
+def _audit_action_path(root: Path) -> Path:
+    return root / ".github/actions/release-downstream-audit/action.yml"
+
+
 def _validate_reusable_workflow(path: Path, *, require_repository_guard: bool) -> None:
     text = path.read_text(encoding="utf-8")
     if "on:\n  workflow_call:" not in text or "permissions: {}" not in text:
@@ -186,21 +190,30 @@ def _validate_retry_prepare(path: Path) -> None:
         raise ValueError("channel retry preparer regained a wrong origin or rebuild")
 
 
-def _validate_live_audit(path: Path) -> None:
-    text = path.read_text(encoding="utf-8")
-    required = (
+def _validate_live_audit(path: Path, action_path: Path, main: str) -> None:
+    workflow = path.read_text(encoding="utf-8")
+    action = action_path.read_text(encoding="utf-8")
+    workflow_required = (
         "on:\n  workflow_call:",
         "  workflow_dispatch:",
         "permissions: {}",
         "environment: release-publication",
+        "uses: ./.github/actions/release-downstream-audit",
+        "app-private-key: ${{ secrets.RMUX_DOWNSTREAM_APP_PRIVATE_KEY }}",
+        'test "$GITHUB_RUN_ATTEMPT" = 1',
+        'test "$GITHUB_SHA" = "$RMUX_EXPECTED_SOURCE_SHA"',
+    )
+    action_required = (
+        "using: composite",
+        "actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349",
         "permission-administration: write",
         "permission-contents: read",
         "collect-downstream-repository.py",
         "verify-downstream-repository.py fixtures",
-        'test "$GITHUB_RUN_ATTEMPT" = 1',
-        'test "$GITHUB_SHA" = "$RMUX_EXPECTED_SOURCE_SHA"',
     )
-    if any(text.count(value) != 1 for value in required):
+    if any(workflow.count(value) != 1 for value in workflow_required):
+        raise ValueError("standalone downstream audit lost an exact authority gate")
+    if any(action.count(value) != 1 for value in action_required):
         raise ValueError("downstream live audit lost an exact authority gate")
     for repository in (
         "homebrew-rmux",
@@ -208,14 +221,27 @@ def _validate_live_audit(path: Path) -> None:
         "rmux-web-share",
         "scoop-rmux",
     ):
-        if text.count(repository) != 2:
+        if action.count(repository) != 2:
             raise ValueError(f"downstream live audit lost repository {repository}")
     if (
-        "permission-contents: write" in text
-        or "secrets: inherit" in text
-        or "self-hosted" in text
+        "permission-contents: write" in action
+        or "secrets: inherit" in workflow
+        or "secrets: inherit" in main
+        or "self-hosted" in workflow
+        or "self-hosted" in main
     ):
         raise ValueError("downstream live audit gained mutation authority")
+    direct_required = (
+        "\n  audit-downstream-authority:\n",
+        "environment: release-publication",
+        "uses: ./.github/actions/release-downstream-audit",
+        "app-private-key: ${{ secrets.RMUX_DOWNSTREAM_APP_PRIVATE_KEY }}",
+        "needs: [prepare-plan, audit-downstream-authority]",
+    )
+    if any(main.count(value) < 1 for value in direct_required):
+        raise ValueError("nested downstream path lost its direct environment audit")
+    if "uses: ./.github/workflows/release-downstream-audit.yml" in main:
+        raise ValueError("downstream audit must not cross a nested reusable secret boundary")
 
 
 def _validate_helper_sizes(root: Path) -> None:
@@ -246,7 +272,6 @@ def _validate_channel_orchestration(main: str) -> None:
         "release-channel-summary.yml": 2,
         "release-chocolatey-channel.yml": 1,
         "release-crates-channel.yml": 1,
-        "release-downstream-audit.yml": 1,
         "release-linux-repository-build.yml": 1,
         "release-linux-repository-publish.yml": 1,
         "release-owned-repository-channel.yml": 3,
@@ -285,7 +310,7 @@ def _validate_channel_orchestration(main: str) -> None:
         raise ValueError("downstream mutation workflows expose inherited secrets")
     if (
         "needs: [prepare-plan, audit-downstream-authority]" not in main
-        or "uses: ./.github/workflows/release-downstream-audit.yml" not in main
+        or "uses: ./.github/actions/release-downstream-audit" not in main
     ):
         raise ValueError(
             "downstream payloads do not depend on the live authority audit"
@@ -308,7 +333,7 @@ def validate_downstream_workflows(root: Path) -> None:
         _validate_retry(path)
     _validate_retry_dispatch(_retry_dispatch_path(root))
     _validate_retry_prepare(_retry_prepare_path(root))
-    _validate_live_audit(_audit_path(root))
+    _validate_live_audit(_audit_path(root), _audit_action_path(root), main)
     verifier = root / "scripts/release/verify-receipt-attestation.py"
     if "--deny-self-hosted-runners" not in verifier.read_text(encoding="utf-8"):
         raise ValueError("receipt verifier lost its GitHub-hosted runner gate")

--- a/tests/release_downstream_workflows_spec.rs
+++ b/tests/release_downstream_workflows_spec.rs
@@ -6,6 +6,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 const DOWNSTREAM: &str = include_str!("../.github/workflows/release-downstream.yml");
 const DOWNSTREAM_AUDIT: &str = include_str!("../.github/workflows/release-downstream-audit.yml");
+const DOWNSTREAM_AUDIT_ACTION: &str =
+    include_str!("../.github/actions/release-downstream-audit/action.yml");
 const RECEIPT: &str = include_str!("../.github/workflows/release-receipt.yml");
 const CI: &str = include_str!("../.github/workflows/ci.yml");
 const RECEIPT_REFERENCE_BUILDER: &str =
@@ -91,7 +93,13 @@ fn downstream_workflow_is_receipt_gated_read_only_and_active() {
     assert_eq!(DOWNSTREAM.matches("if: ${{ false }}").count(), 0);
     assert!(!DOWNSTREAM.contains("contents: write"));
     assert!(!DOWNSTREAM.contains("secrets: inherit"));
-    assert!(!DOWNSTREAM.contains("environment:"));
+    assert_eq!(
+        DOWNSTREAM
+            .matches("environment: release-publication")
+            .count(),
+        1
+    );
+    assert_eq!(DOWNSTREAM.matches("environment:").count(), 1);
     assert!(!DOWNSTREAM.contains("self-hosted"));
     assert!(!DOWNSTREAM.contains("larger-runner"));
 
@@ -180,25 +188,34 @@ fn downstream_authority_is_rechecked_live_before_payload_staging() {
     assert!(DOWNSTREAM_AUDIT.contains("on:\n  workflow_call:"));
     assert!(DOWNSTREAM_AUDIT.contains("  workflow_dispatch:"));
     assert!(DOWNSTREAM_AUDIT.contains("environment: release-publication"));
-    assert!(DOWNSTREAM_AUDIT.contains("permission-administration: write"));
-    assert!(DOWNSTREAM_AUDIT.contains("permission-contents: read"));
-    assert!(!DOWNSTREAM_AUDIT.contains("permission-administration: read"));
-    assert!(!DOWNSTREAM_AUDIT.contains("permission-contents: write"));
+    assert!(DOWNSTREAM_AUDIT.contains("uses: ./.github/actions/release-downstream-audit"));
     assert!(!DOWNSTREAM_AUDIT.contains("secrets: inherit"));
-    assert!(DOWNSTREAM_AUDIT.contains("collect-downstream-repository.py"));
-    assert!(DOWNSTREAM_AUDIT.contains("verify-downstream-repository.py fixtures"));
+    assert!(DOWNSTREAM_AUDIT_ACTION.contains("permission-administration: write"));
+    assert!(DOWNSTREAM_AUDIT_ACTION.contains("permission-contents: read"));
+    assert!(!DOWNSTREAM_AUDIT_ACTION.contains("permission-administration: read"));
+    assert!(!DOWNSTREAM_AUDIT_ACTION.contains("permission-contents: write"));
+    assert!(DOWNSTREAM_AUDIT_ACTION.contains("collect-downstream-repository.py"));
+    assert!(DOWNSTREAM_AUDIT_ACTION.contains("verify-downstream-repository.py fixtures"));
     assert_eq!(
-        DOWNSTREAM_AUDIT
+        DOWNSTREAM_AUDIT_ACTION
             .matches("actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349")
             .count(),
         1
     );
+    assert!(!DOWNSTREAM.contains("uses: ./.github/workflows/release-downstream-audit.yml"));
     assert_eq!(
         DOWNSTREAM
-            .matches("uses: ./.github/workflows/release-downstream-audit.yml")
+            .matches("uses: ./.github/actions/release-downstream-audit")
             .count(),
         1
     );
+    let audit = job(
+        DOWNSTREAM,
+        "audit-downstream-authority",
+        Some("prepare-payloads"),
+    );
+    assert!(audit.contains("environment: release-publication"));
+    assert!(audit.contains("app-private-key: ${{ secrets.RMUX_DOWNSTREAM_APP_PRIVATE_KEY }}"));
     let payloads = job(
         DOWNSTREAM,
         "prepare-payloads",


### PR DESCRIPTION
## Summary

- keep the downstream App key scoped to the protected release-publication environment
- execute the authority audit as a direct environment job instead of crossing a nested reusable-workflow boundary
- share the audited implementation through a policy-covered composite action

## Validation

- cargo test --locked --test release_downstream_workflows_spec --test release_shadow_spec
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo fmt --all -- --check
- python3 scripts/release/validate-contracts.py
- scripts/release-review-gate.sh --evidence-mode candidate-delta --skip-package --section static --target-dir target/release-candidate-static