### PR TITLE
fix(release): bind downstream audit at top level

### DIFF
--- a/.github/actions/release-downstream-audit/action.yml
+++ b/.github/actions/release-downstream-audit/action.yml
@@ -12,6 +12,14 @@ inputs:
     description: Downstream GitHub App private key
     required: true
 
+outputs:
+  artifact-id:
+    description: Exact downstream authority audit artifact ID
+    value: ${{ steps.audit-upload.outputs.artifact-id }}
+  artifact-digest:
+    description: Exact downstream authority audit artifact digest
+    value: sha256:${{ steps.audit-upload.outputs.artifact-digest }}
+
 runs:
   using: composite
   steps:
@@ -59,7 +67,8 @@ runs:
             --installation "$root/installation.json"
         done
 
-    - name: Upload exact downstream audit fixtures
+    - id: audit-upload
+      name: Upload exact downstream audit fixtures
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
       with:
         name: rmux-downstream-authority-${{ inputs.expected-source-sha }}-${{ github.run_id }}

--- a/.github/actions/release-downstream-authority-proof/action.yml
+++ b/.github/actions/release-downstream-authority-proof/action.yml
@@ -1,0 +1,101 @@
+name: Verify downstream repository authority proof
+description: Verify and consume one exact non-secret downstream authority audit artifact
+
+inputs:
+  audit-run-id:
+    description: Workflow run that produced the audit artifact
+    required: true
+  audit-workflow-id:
+    description: Exact receipt workflow ID
+    required: true
+  audit-artifact-id:
+    description: Exact downstream authority audit artifact ID
+    required: true
+  audit-artifact-digest:
+    description: Exact downstream authority audit artifact digest
+    required: true
+  expected-source-sha:
+    description: Exact trusted RMUX source commit
+    required: true
+  release-ref:
+    description: Exact signed release tag
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Reject malformed downstream audit evidence
+      shell: bash
+      env:
+        RMUX_DOWNSTREAM_AUDIT_RUN_ID: ${{ inputs.audit-run-id }}
+        RMUX_DOWNSTREAM_AUDIT_WORKFLOW_ID: ${{ inputs.audit-workflow-id }}
+        RMUX_DOWNSTREAM_AUDIT_ARTIFACT_ID: ${{ inputs.audit-artifact-id }}
+        RMUX_DOWNSTREAM_AUDIT_ARTIFACT_DIGEST: ${{ inputs.audit-artifact-digest }}
+        RMUX_EXPECTED_SOURCE_SHA: ${{ inputs.expected-source-sha }}
+        RMUX_RELEASE_REF: ${{ inputs.release-ref }}
+      run: |
+        set -euo pipefail
+        test "$GITHUB_REPOSITORY" = "Helvesec/rmux"
+        test "$GITHUB_REPOSITORY_ID" = "1239918790"
+        test "$GITHUB_RUN_ATTEMPT" = 1
+        test "$GITHUB_SHA" = "$RMUX_EXPECTED_SOURCE_SHA"
+        for value in "$RMUX_DOWNSTREAM_AUDIT_RUN_ID" "$RMUX_DOWNSTREAM_AUDIT_WORKFLOW_ID" "$RMUX_DOWNSTREAM_AUDIT_ARTIFACT_ID"; do
+          [[ "$value" =~ ^[1-9][0-9]*$ ]]
+        done
+        test "$RMUX_DOWNSTREAM_AUDIT_WORKFLOW_ID" = 316435347
+        [[ "$RMUX_DOWNSTREAM_AUDIT_ARTIFACT_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]
+        [[ "$RMUX_EXPECTED_SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]
+        [[ "$RMUX_RELEASE_REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$ ]]
+        test "$GITHUB_REF" = "refs/tags/$RMUX_RELEASE_REF"
+
+    - name: Verify exact downstream authority artifact identity
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        set -euo pipefail
+        python3 scripts/release/actions-artifact.py verify \
+          --repository "$GITHUB_REPOSITORY" \
+          --run-id "${{ inputs.audit-run-id }}" \
+          --artifact-id "${{ inputs.audit-artifact-id }}" \
+          --name "rmux-downstream-authority-${{ inputs.expected-source-sha }}-${{ inputs.audit-run-id }}" \
+          --expected-source-sha "${{ inputs.expected-source-sha }}" \
+          --expected-digest "${{ inputs.audit-artifact-digest }}" \
+          --expected-workflow-id "${{ inputs.audit-workflow-id }}" \
+          --expected-workflow-path .github/workflows/release-receipt.yml \
+          --expected-event workflow_dispatch \
+          --expected-head-branch "${{ inputs.release-ref }}" \
+          --allow-running-current-run --max-attempts 1
+
+    - name: Download only the exact downstream authority artifact ID
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+      with:
+        artifact-ids: ${{ inputs.audit-artifact-id }}
+        merge-multiple: true
+        path: ${{ runner.temp }}/rmux-downstream-authority
+        github-token: ${{ github.token }}
+        repository: ${{ github.repository }}
+        run-id: ${{ inputs.audit-run-id }}
+
+    - name: Verify exact downstream authority fixtures
+      shell: bash
+      run: |
+        set -euo pipefail
+        root="$RUNNER_TEMP/rmux-downstream-authority"
+        files=(--file installation.json)
+        for key in homebrew-rmux rmux-packages rmux-web-share scoop-rmux; do
+          for name in metadata.json protection.json rulesets.json environments.json runners.json; do
+            files+=(--file "$key/$name")
+          done
+        done
+        scripts/release/verify-exact-file-set.py --root "$root" "${files[@]}"
+        for key in homebrew-rmux rmux-packages rmux-web-share scoop-rmux; do
+          scripts/release/verify-downstream-repository.py fixtures \
+            --repository-key "$key" \
+            --metadata "$root/$key/metadata.json" \
+            --protection "$root/$key/protection.json" \
+            --rulesets "$root/$key/rulesets.json" \
+            --environments "$root/$key/environments.json" \
+            --runners "$root/$key/runners.json" \
+            --installation "$root/installation.json"
+        done

--- a/.github/release/candidate-contract.json
+++ b/.github/release/candidate-contract.json
@@ -317,6 +317,7 @@
     ".github/actions/release-channel-result/action.yml",
     ".github/actions/release-channel-retry-prepare/action.yml",
     ".github/actions/release-downstream-audit/action.yml",
+    ".github/actions/release-downstream-authority-proof/action.yml",
     ".github/actions/release-policy-audit/action.yml",
     ".github/actions/release-publication-inputs/action.yml",
     ".github/actions/release-snap-candidate-write/action.yml",

--- a/.github/workflows/release-downstream.yml
+++ b/.github/workflows/release-downstream.yml
@@ -12,6 +12,10 @@ on:
       receipt_envelope_artifact_digest: {required: true, type: string}
       receipt_predicate_sha256: {required: true, type: string}
       receipt_envelope_sha256: {required: true, type: string}
+      downstream_audit_run_id: {required: true, type: string}
+      downstream_audit_workflow_id: {required: true, type: string}
+      downstream_audit_artifact_id: {required: true, type: string}
+      downstream_audit_artifact_digest: {required: true, type: string}
       expected_source_sha: {required: true, type: string}
       release_id: {required: true, type: string}
       release_ref: {required: true, type: string}
@@ -203,43 +207,40 @@ jobs:
           retention-days: 7
           compression-level: 0
 
-  audit-downstream-authority:
-    name: Audit live downstream repository authority
+  verify-downstream-authority:
+    name: Verify exact downstream repository authority audit
     needs: prepare-plan
     runs-on: ubuntu-22.04
     timeout-minutes: 10
-    environment: release-publication
     permissions:
+      actions: read
       contents: read
-    env:
-      RMUX_EXPECTED_SOURCE_SHA: ${{ inputs.expected_source_sha }}
     steps:
-      - name: Reject malformed or stale audit identity
+      - name: Bind downstream audit to this receipt run
         shell: bash
         run: |
           set -euo pipefail
-          test "$GITHUB_REPOSITORY" = "Helvesec/rmux"
-          test "$GITHUB_REPOSITORY_ID" = "1239918790"
-          test "$GITHUB_RUN_ATTEMPT" = 1
-          test "$GITHUB_SHA" = "$RMUX_EXPECTED_SOURCE_SHA"
-          [[ "$RMUX_EXPECTED_SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]
-          [[ "$GITHUB_REF" =~ ^refs/(heads/main|tags/v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?)$ ]]
+          test "${{ inputs.downstream_audit_run_id }}" = "${{ inputs.receipt_run_id }}"
+          test "${{ inputs.downstream_audit_workflow_id }}" = "${{ inputs.receipt_workflow_id }}"
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           ref: ${{ inputs.expected_source_sha }}
           persist-credentials: false
 
-      - name: Audit exact downstream repository authority
-        uses: ./.github/actions/release-downstream-audit
+      - name: Verify exact downstream repository authority proof
+        uses: ./.github/actions/release-downstream-authority-proof
         with:
-          app-id: ${{ vars.RMUX_DOWNSTREAM_APP_ID }}
-          app-private-key: ${{ secrets.RMUX_DOWNSTREAM_APP_PRIVATE_KEY }}
+          audit-run-id: ${{ inputs.downstream_audit_run_id }}
+          audit-workflow-id: ${{ inputs.downstream_audit_workflow_id }}
+          audit-artifact-id: ${{ inputs.downstream_audit_artifact_id }}
+          audit-artifact-digest: ${{ inputs.downstream_audit_artifact_digest }}
           expected-source-sha: ${{ inputs.expected_source_sha }}
+          release-ref: ${{ inputs.release_ref }}
 
   prepare-payloads:
     name: Prepare exact downstream payloads
-    needs: [prepare-plan, audit-downstream-authority]
+    needs: [prepare-plan, verify-downstream-authority]
     uses: ./.github/workflows/release-downstream-prepare.yml
     permissions:
       actions: read

--- a/.github/workflows/release-receipt.yml
+++ b/.github/workflows/release-receipt.yml
@@ -407,9 +407,47 @@ jobs:
               )
           PY
 
+  audit-downstream-authority:
+    name: Audit live downstream repository authority
+    needs: receipt-only
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    environment: release-publication
+    permissions:
+      contents: read
+    outputs:
+      artifact_id: ${{ steps.audit.outputs.artifact-id }}
+      artifact_digest: ${{ steps.audit.outputs.artifact-digest }}
+    env:
+      RMUX_EXPECTED_SOURCE_SHA: ${{ inputs.expected_source_sha }}
+    steps:
+      - name: Reject malformed or stale audit identity
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REPOSITORY" = "Helvesec/rmux"
+          test "$GITHUB_REPOSITORY_ID" = "1239918790"
+          test "$GITHUB_RUN_ATTEMPT" = 1
+          test "$GITHUB_SHA" = "$RMUX_EXPECTED_SOURCE_SHA"
+          [[ "$RMUX_EXPECTED_SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$GITHUB_REF" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$ ]]
+
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ inputs.expected_source_sha }}
+          persist-credentials: false
+
+      - id: audit
+        name: Audit exact downstream repository authority
+        uses: ./.github/actions/release-downstream-audit
+        with:
+          app-id: ${{ vars.RMUX_DOWNSTREAM_APP_ID }}
+          app-private-key: ${{ secrets.RMUX_DOWNSTREAM_APP_PRIVATE_KEY }}
+          expected-source-sha: ${{ inputs.expected_source_sha }}
+
   downstream:
     name: Receipt-gated downstream publication
-    needs: receipt-only
+    needs: [receipt-only, audit-downstream-authority]
     uses: ./.github/workflows/release-downstream.yml
     permissions:
       actions: read
@@ -426,6 +464,10 @@ jobs:
       receipt_envelope_artifact_digest: ${{ needs.receipt-only.outputs.envelope_artifact_digest }}
       receipt_predicate_sha256: ${{ needs.receipt-only.outputs.receipt_predicate_sha256 }}
       receipt_envelope_sha256: ${{ needs.receipt-only.outputs.receipt_envelope_sha256 }}
+      downstream_audit_run_id: ${{ github.run_id }}
+      downstream_audit_workflow_id: ${{ inputs.receipt_workflow_id }}
+      downstream_audit_artifact_id: ${{ needs.audit-downstream-authority.outputs.artifact_id }}
+      downstream_audit_artifact_digest: ${{ needs.audit-downstream-authority.outputs.artifact_digest }}
       expected_source_sha: ${{ inputs.expected_source_sha }}
       release_id: ${{ inputs.release_id }}
       release_ref: ${{ inputs.release_ref }}

--- a/scripts/release/downstream_workflow_contract.py
+++ b/scripts/release/downstream_workflow_contract.py
@@ -48,6 +48,14 @@ def _audit_action_path(root: Path) -> Path:
     return root / ".github/actions/release-downstream-audit/action.yml"
 
 
+def _audit_proof_action_path(root: Path) -> Path:
+    return root / ".github/actions/release-downstream-authority-proof/action.yml"
+
+
+def _receipt_path(root: Path) -> Path:
+    return root / ".github/workflows/release-receipt.yml"
+
+
 def _validate_reusable_workflow(path: Path, *, require_repository_guard: bool) -> None:
     text = path.read_text(encoding="utf-8")
     if "on:\n  workflow_call:" not in text or "permissions: {}" not in text:
@@ -190,9 +198,17 @@ def _validate_retry_prepare(path: Path) -> None:
         raise ValueError("channel retry preparer regained a wrong origin or rebuild")
 
 
-def _validate_live_audit(path: Path, action_path: Path, main: str) -> None:
+def _validate_live_audit(
+    path: Path,
+    action_path: Path,
+    proof_action_path: Path,
+    receipt_path: Path,
+    main: str,
+) -> None:
     workflow = path.read_text(encoding="utf-8")
     action = action_path.read_text(encoding="utf-8")
+    proof_action = proof_action_path.read_text(encoding="utf-8")
+    receipt = receipt_path.read_text(encoding="utf-8")
     workflow_required = (
         "on:\n  workflow_call:",
         "  workflow_dispatch:",
@@ -210,11 +226,24 @@ def _validate_live_audit(path: Path, action_path: Path, main: str) -> None:
         "permission-contents: read",
         "collect-downstream-repository.py",
         "verify-downstream-repository.py fixtures",
+        "artifact-id:",
+        "artifact-digest:",
     )
     if any(workflow.count(value) != 1 for value in workflow_required):
         raise ValueError("standalone downstream audit lost an exact authority gate")
     if any(action.count(value) != 1 for value in action_required):
         raise ValueError("downstream live audit lost an exact authority gate")
+    proof_required = (
+        "using: composite",
+        "actions-artifact.py verify",
+        "--expected-workflow-path .github/workflows/release-receipt.yml",
+        "actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093",
+        "verify-exact-file-set.py",
+        "verify-downstream-repository.py fixtures",
+        "--allow-running-current-run",
+    )
+    if any(proof_action.count(value) != 1 for value in proof_required):
+        raise ValueError("downstream authority proof lost its exact evidence gate")
     for repository in (
         "homebrew-rmux",
         "rmux-packages",
@@ -231,17 +260,35 @@ def _validate_live_audit(path: Path, action_path: Path, main: str) -> None:
         or "self-hosted" in main
     ):
         raise ValueError("downstream live audit gained mutation authority")
-    direct_required = (
+    receipt_required = (
         "\n  audit-downstream-authority:\n",
         "environment: release-publication",
         "uses: ./.github/actions/release-downstream-audit",
         "app-private-key: ${{ secrets.RMUX_DOWNSTREAM_APP_PRIVATE_KEY }}",
-        "needs: [prepare-plan, audit-downstream-authority]",
+        "needs: [receipt-only, audit-downstream-authority]",
+        "downstream_audit_artifact_id:",
+        "downstream_audit_artifact_digest:",
     )
-    if any(main.count(value) < 1 for value in direct_required):
-        raise ValueError("nested downstream path lost its direct environment audit")
-    if "uses: ./.github/workflows/release-downstream-audit.yml" in main:
-        raise ValueError("downstream audit must not cross a nested reusable secret boundary")
+    if any(receipt.count(value) < 1 for value in receipt_required):
+        raise ValueError("receipt lost its top-level protected downstream audit")
+    verifier_required = (
+        "\n  verify-downstream-authority:\n",
+        "uses: ./.github/actions/release-downstream-authority-proof",
+        'test "${{ inputs.downstream_audit_run_id }}" = "${{ inputs.receipt_run_id }}"',
+        "needs: [prepare-plan, verify-downstream-authority]",
+    )
+    if any(main.count(value) < 1 for value in verifier_required):
+        raise ValueError("downstream path lost its exact authority evidence gate")
+    for forbidden in (
+        "uses: ./.github/workflows/release-downstream-audit.yml",
+        "uses: ./.github/actions/release-downstream-audit",
+        "RMUX_DOWNSTREAM_APP_PRIVATE_KEY",
+        "environment: release-publication",
+    ):
+        if forbidden in main:
+            raise ValueError(
+                "downstream secret-bearing audit crossed the reusable workflow boundary"
+            )
 
 
 def _validate_helper_sizes(root: Path) -> None:
@@ -308,10 +355,7 @@ def _validate_channel_orchestration(main: str) -> None:
         raise ValueError("downstream graph contains an internal hard-coded stub")
     if "secrets: inherit" in main:
         raise ValueError("downstream mutation workflows expose inherited secrets")
-    if (
-        "needs: [prepare-plan, audit-downstream-authority]" not in main
-        or "uses: ./.github/actions/release-downstream-audit" not in main
-    ):
+    if "needs: [prepare-plan, verify-downstream-authority]" not in main:
         raise ValueError(
             "downstream payloads do not depend on the live authority audit"
         )
@@ -333,7 +377,13 @@ def validate_downstream_workflows(root: Path) -> None:
         _validate_retry(path)
     _validate_retry_dispatch(_retry_dispatch_path(root))
     _validate_retry_prepare(_retry_prepare_path(root))
-    _validate_live_audit(_audit_path(root), _audit_action_path(root), main)
+    _validate_live_audit(
+        _audit_path(root),
+        _audit_action_path(root),
+        _audit_proof_action_path(root),
+        _receipt_path(root),
+        main,
+    )
     verifier = root / "scripts/release/verify-receipt-attestation.py"
     if "--deny-self-hosted-runners" not in verifier.read_text(encoding="utf-8"):
         raise ValueError("receipt verifier lost its GitHub-hosted runner gate")

--- a/tests/release_downstream_workflows_spec.rs
+++ b/tests/release_downstream_workflows_spec.rs
@@ -8,6 +8,8 @@ const DOWNSTREAM: &str = include_str!("../.github/workflows/release-downstream.y
 const DOWNSTREAM_AUDIT: &str = include_str!("../.github/workflows/release-downstream-audit.yml");
 const DOWNSTREAM_AUDIT_ACTION: &str =
     include_str!("../.github/actions/release-downstream-audit/action.yml");
+const DOWNSTREAM_AUTHORITY_PROOF: &str =
+    include_str!("../.github/actions/release-downstream-authority-proof/action.yml");
 const RECEIPT: &str = include_str!("../.github/workflows/release-receipt.yml");
 const CI: &str = include_str!("../.github/workflows/ci.yml");
 const RECEIPT_REFERENCE_BUILDER: &str =
@@ -97,9 +99,9 @@ fn downstream_workflow_is_receipt_gated_read_only_and_active() {
         DOWNSTREAM
             .matches("environment: release-publication")
             .count(),
-        1
+        0
     );
-    assert_eq!(DOWNSTREAM.matches("environment:").count(), 1);
+    assert_eq!(DOWNSTREAM.matches("environment:").count(), 0);
     assert!(!DOWNSTREAM.contains("self-hosted"));
     assert!(!DOWNSTREAM.contains("larger-runner"));
 
@@ -202,26 +204,45 @@ fn downstream_authority_is_rechecked_live_before_payload_staging() {
             .count(),
         1
     );
+    assert!(DOWNSTREAM_AUDIT_ACTION.contains("artifact-id:"));
+    assert!(DOWNSTREAM_AUDIT_ACTION.contains("artifact-digest:"));
     assert!(!DOWNSTREAM.contains("uses: ./.github/workflows/release-downstream-audit.yml"));
-    assert_eq!(
-        DOWNSTREAM
-            .matches("uses: ./.github/actions/release-downstream-audit")
-            .count(),
-        1
-    );
-    let audit = job(
-        DOWNSTREAM,
-        "audit-downstream-authority",
-        Some("prepare-payloads"),
-    );
+    assert!(!DOWNSTREAM.contains("uses: ./.github/actions/release-downstream-audit"));
+    assert!(!DOWNSTREAM.contains("RMUX_DOWNSTREAM_APP_PRIVATE_KEY"));
+    assert!(!DOWNSTREAM.contains("environment: release-publication"));
+    let audit = job(RECEIPT, "audit-downstream-authority", Some("downstream"));
     assert!(audit.contains("environment: release-publication"));
     assert!(audit.contains("app-private-key: ${{ secrets.RMUX_DOWNSTREAM_APP_PRIVATE_KEY }}"));
+    assert!(audit.contains("uses: ./.github/actions/release-downstream-audit"));
+    assert!(audit.contains("artifact_id: ${{ steps.audit.outputs.artifact-id }}"));
+    assert!(audit.contains("artifact_digest: ${{ steps.audit.outputs.artifact-digest }}"));
+    let downstream = job(RECEIPT, "downstream", None);
+    assert!(downstream.contains("needs: [receipt-only, audit-downstream-authority]"));
+    assert!(downstream.contains("downstream_audit_artifact_id:"));
+    assert!(downstream.contains("downstream_audit_artifact_digest:"));
+    let verification = job(
+        DOWNSTREAM,
+        "verify-downstream-authority",
+        Some("prepare-payloads"),
+    );
+    assert!(verification.contains("uses: ./.github/actions/release-downstream-authority-proof"));
+    assert!(verification.contains(
+        "test \"${{ inputs.downstream_audit_run_id }}\" = \"${{ inputs.receipt_run_id }}\""
+    ));
+    assert!(DOWNSTREAM_AUTHORITY_PROOF.contains("actions-artifact.py verify"));
+    assert!(DOWNSTREAM_AUTHORITY_PROOF
+        .contains("--expected-workflow-path .github/workflows/release-receipt.yml"));
+    assert!(DOWNSTREAM_AUTHORITY_PROOF
+        .contains("test \"$RMUX_DOWNSTREAM_AUDIT_WORKFLOW_ID\" = 316435347"));
+    assert!(DOWNSTREAM_AUTHORITY_PROOF.contains("verify-exact-file-set.py"));
+    assert!(DOWNSTREAM_AUTHORITY_PROOF.contains("verify-downstream-repository.py fixtures"));
+    assert!(DOWNSTREAM_AUTHORITY_PROOF.contains("--allow-running-current-run"));
     let payloads = job(
         DOWNSTREAM,
         "prepare-payloads",
         Some("build-linux-repository"),
     );
-    assert!(payloads.contains("needs: [prepare-plan, audit-downstream-authority]"));
+    assert!(payloads.contains("needs: [prepare-plan, verify-downstream-authority]"));
 }
 
 #[test]
@@ -266,6 +287,10 @@ fn exact_receipt_ids_digests_origin_and_documents_are_bound() {
         "receipt_envelope_artifact_digest:",
         "receipt_predicate_sha256:",
         "receipt_envelope_sha256:",
+        "downstream_audit_run_id:",
+        "downstream_audit_workflow_id:",
+        "downstream_audit_artifact_id:",
+        "downstream_audit_artifact_digest:",
         "expected_source_sha:",
         "release_id:",
         "release_ref:",


### PR DESCRIPTION
Move the secret-bearing downstream App audit into the top-level receipt workflow, where GitHub environment secrets are available. Pass only the exact audit artifact ID and digest across the reusable-workflow boundary, then verify its producer identity, file set, and repository fixtures before payload staging.

Validation:
- 73 focused release tests
- release contracts
- cargo fmt and Clippy with warnings denied
- Ruff lint and format
- release static gate
- YAML parse