### PR TITLE
fix(release): bind complete shadow run identity

### DIFF
--- a/.github/workflows/release-downstream-prepare.yml
+++ b/.github/workflows/release-downstream-prepare.yml
@@ -141,7 +141,9 @@ jobs:
             --name "rmux-candidate-manifest-${{ steps.candidate.outputs.candidate_run_id }}" \
             --expected-source-sha "$RMUX_EXPECTED_SOURCE_SHA" \
             --expected-digest "${{ steps.candidate.outputs.manifest_artifact_digest }}" \
+            --expected-workflow-id 316223904 \
             --expected-workflow-path .github/workflows/release-shadow.yml \
+            --expected-event workflow_dispatch --expected-head-branch main \
             --max-attempts 1
 
       - name: Download only the exact candidate manifest artifact ID

--- a/scripts/release/downstream_workflow_contract.py
+++ b/scripts/release/downstream_workflow_contract.py
@@ -141,6 +141,25 @@ def _validate_receipt_origin(main: str) -> None:
         raise ValueError("downstream plan artifact must flatten its receipt predicate")
 
 
+def _validate_payload_prepare(path: Path) -> None:
+    text = path.read_text(encoding="utf-8")
+    marker = "- name: Verify exact candidate manifest artifact identity"
+    next_marker = "- name: Download only the exact candidate manifest artifact ID"
+    if text.count(marker) != 1 or text.count(next_marker) != 1:
+        raise ValueError("downstream payload preparer lost candidate manifest binding")
+    verification = text.split(marker, 1)[1].split(next_marker, 1)[0]
+    required = (
+        "--expected-workflow-id 316223904",
+        "--expected-workflow-path .github/workflows/release-shadow.yml",
+        "--expected-event workflow_dispatch",
+        "--expected-head-branch main",
+    )
+    if any(verification.count(value) != 1 for value in required):
+        raise ValueError(
+            "downstream payload preparer lost the exact shadow run identity"
+        )
+
+
 def _validate_retry(path: Path) -> None:
     retry = path.read_text(encoding="utf-8")
     channel = "chocolatey" if "chocolatey" in path.name else "snap_candidate"
@@ -382,6 +401,9 @@ def validate_downstream_workflows(root: Path) -> None:
     main = paths[0].read_text(encoding="utf-8")
     _validate_receipt_origin(main)
     _validate_channel_orchestration(main)
+    _validate_payload_prepare(
+        root / ".github/workflows/release-downstream-prepare.yml"
+    )
     for path in paths[1:]:
         _validate_retry(path)
     _validate_retry_dispatch(_retry_dispatch_path(root))

--- a/tests/release_downstream_workflows_spec.rs
+++ b/tests/release_downstream_workflows_spec.rs
@@ -10,6 +10,8 @@ const DOWNSTREAM_AUDIT_ACTION: &str =
     include_str!("../.github/actions/release-downstream-audit/action.yml");
 const DOWNSTREAM_AUTHORITY_PROOF: &str =
     include_str!("../.github/actions/release-downstream-authority-proof/action.yml");
+const DOWNSTREAM_PREPARE: &str =
+    include_str!("../.github/workflows/release-downstream-prepare.yml");
 const RECEIPT: &str = include_str!("../.github/workflows/release-receipt.yml");
 const CI: &str = include_str!("../.github/workflows/ci.yml");
 const RECEIPT_REFERENCE_BUILDER: &str =
@@ -272,6 +274,30 @@ fn downstream_rc_payloads_keep_stable_package_names() {
     assert!(staging.contains("version = manifest[\"package_version\"]"));
     assert!(!staging.contains("version = release_ref.removeprefix(\"v\")"));
     assert!(snap.contains("version = package_version(args.release_ref)"));
+}
+
+#[test]
+fn downstream_payloads_bind_the_complete_shadow_run_identity() {
+    let marker = "- name: Verify exact candidate manifest artifact identity";
+    let next_marker = "- name: Download only the exact candidate manifest artifact ID";
+    let verification = DOWNSTREAM_PREPARE
+        .split(marker)
+        .nth(1)
+        .expect("candidate manifest verification")
+        .split(next_marker)
+        .next()
+        .expect("candidate manifest verification boundary");
+    for expected in [
+        "--expected-workflow-id 316223904",
+        "--expected-workflow-path .github/workflows/release-shadow.yml",
+        "--expected-event workflow_dispatch",
+        "--expected-head-branch main",
+    ] {
+        assert!(
+            verification.contains(expected),
+            "missing shadow run identity {expected}"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
Bind the downstream payload preparer to the exact shadow workflow ID, path, event, and branch. Add static and Rust regression gates for the complete run identity group.