### PR TITLE
fix(release): qualify channel attestation digest

### DIFF
--- a/.github/actions/release-channel-result/action.yml
+++ b/.github/actions/release-channel-result/action.yml
@@ -91,7 +91,7 @@ runs:
         scripts/release/channel-result.py verify-predicate "${common[@]}" \
           --document "$root/downstream-channel-result-predicate.json"
         digest="$(sha256sum "$RMUX_TARGET_EVIDENCE" | cut -d' ' -f1)"
-        echo "subject_digest=$digest" >> "$GITHUB_OUTPUT"
+        echo "subject_digest=sha256:$digest" >> "$GITHUB_OUTPUT"
         echo "observed_at=$observed_at" >> "$GITHUB_OUTPUT"
 
     - id: attestation

--- a/scripts/release/downstream_workflow_contract.py
+++ b/scripts/release/downstream_workflow_contract.py
@@ -52,6 +52,10 @@ def _audit_proof_action_path(root: Path) -> Path:
     return root / ".github/actions/release-downstream-authority-proof/action.yml"
 
 
+def _channel_result_action_path(root: Path) -> Path:
+    return root / ".github/actions/release-channel-result/action.yml"
+
+
 def _receipt_path(root: Path) -> Path:
     return root / ".github/workflows/release-receipt.yml"
 
@@ -158,6 +162,17 @@ def _validate_payload_prepare(path: Path) -> None:
         raise ValueError(
             "downstream payload preparer lost the exact shadow run identity"
         )
+
+
+def _validate_channel_result_action(path: Path) -> None:
+    text = path.read_text(encoding="utf-8")
+    qualified = 'echo "subject_digest=sha256:$digest" >> "$GITHUB_OUTPUT"'
+    unqualified = 'echo "subject_digest=$digest" >> "$GITHUB_OUTPUT"'
+    consumer = "subject-digest: ${{ steps.predicate.outputs.subject_digest }}"
+    if text.count(qualified) != 1 or text.count(consumer) != 1:
+        raise ValueError("channel result attestation lost its qualified subject digest")
+    if unqualified in text:
+        raise ValueError("channel result attestation regained an unqualified digest")
 
 
 def _validate_retry(path: Path) -> None:
@@ -404,6 +419,7 @@ def validate_downstream_workflows(root: Path) -> None:
     _validate_payload_prepare(
         root / ".github/workflows/release-downstream-prepare.yml"
     )
+    _validate_channel_result_action(_channel_result_action_path(root))
     for path in paths[1:]:
         _validate_retry(path)
     _validate_retry_dispatch(_retry_dispatch_path(root))

--- a/tests/release_downstream_result_evidence_spec.rs
+++ b/tests/release_downstream_result_evidence_spec.rs
@@ -26,6 +26,15 @@ fn assert_fixture(source: &str) {
     );
 }
 
+const RESULT_ACTION: &str = include_str!("../.github/actions/release-channel-result/action.yml");
+
+#[test]
+fn result_attestation_uses_algorithm_qualified_subject_digest() {
+    assert!(RESULT_ACTION.contains("echo \"subject_digest=sha256:$digest\" >> \"$GITHUB_OUTPUT\""));
+    assert!(!RESULT_ACTION.contains("echo \"subject_digest=$digest\" >> \"$GITHUB_OUTPUT\""));
+    assert!(RESULT_ACTION.contains("subject-digest: ${{ steps.predicate.outputs.subject_digest }}"));
+}
+
 const FIXTURE: &str = r#"
 import argparse
 import copy


### PR DESCRIPTION
## Summary

- qualify downstream attestation subject digests with the SHA-256 algorithm
- enforce the exact digest format in release workflow contracts
- add focused regression coverage for the shared channel result action

## Validation

- cargo test --locked --test release_downstream_result_evidence_spec
- downstream release test suites
- python3 scripts/release/validate-contracts.py
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --locked -- -D warnings
- scripts/release-review-gate.sh --section static --evidence-mode candidate-delta --skip-package