### PR TITLE
fix(release): normalize channel result artifacts

### DIFF
--- a/scripts/release/channel-result.py
+++ b/scripts/release/channel-result.py
@@ -16,7 +16,6 @@ from downstream_channels import (
     file_hash,
     read_object,
     timestamp,
-    validate_artifact,
     validate_request,
     write_object,
 )
@@ -27,6 +26,7 @@ from downstream_result import (
     validate_producer,
     validate_target_evidence,
 )
+from downstream_result_reference import artifact_reference
 
 
 def expected_predicate(args: argparse.Namespace) -> dict[str, Any]:
@@ -95,14 +95,16 @@ def expected_envelope(args: argparse.Namespace) -> dict[str, Any]:
     bundle_path = args.attestation_bundle.resolve(strict=True)
     if bundle_path.name != "downstream-channel-result.sigstore.json":
         raise ValueError("result attestation bundle name changed")
-    result_bundle = read_object(args.bundle_artifact, "result bundle artifact")
-    validate_artifact(result_bundle, "result bundle")
     expected_name = (
         f"rmux-downstream-{predicate['channel']}-result-"
         f"{predicate['source_git_sha']}-{predicate['release']['id']}"
     )
-    if result_bundle["name"] != expected_name:
-        raise ValueError("result bundle name differs from its exact release")
+    result_bundle = artifact_reference(
+        read_object(args.bundle_artifact, "result bundle artifact"),
+        expected_name=expected_name,
+        source_sha=predicate["source_git_sha"],
+        run_id=predicate["producer"]["run_id"],
+    )
     created = timestamp(args.created_at, "result envelope created_at")
     if created < timestamp(predicate["observed_at"], "result observed_at"):
         raise ValueError("result envelope predates its predicate")

--- a/scripts/release/downstream_result_reference.py
+++ b/scripts/release/downstream_result_reference.py
@@ -63,7 +63,7 @@ REFERENCE_KEYS = {
 }
 
 
-def _artifact_reference(
+def artifact_reference(
     value: dict[str, Any], *, expected_name: str, source_sha: str, run_id: int
 ) -> dict[str, Any]:
     exact_keys(
@@ -207,13 +207,13 @@ def create_reference(
     channel = predicate["channel"]
     release = predicate["release"]
     run_id = predicate["producer"]["run_id"]
-    predicate_artifact = _artifact_reference(
+    predicate_artifact = artifact_reference(
         read_object(predicate_artifact_path, "predicate artifact metadata"),
         expected_name=f"rmux-downstream-{channel}-result-{source_sha}-{release['id']}",
         source_sha=source_sha,
         run_id=run_id,
     )
-    envelope_artifact = _artifact_reference(
+    envelope_artifact = artifact_reference(
         read_object(envelope_artifact_path, "envelope artifact metadata"),
         expected_name=(
             f"rmux-downstream-{channel}-result-envelope-{source_sha}-{release['id']}"

--- a/tests/release_downstream_result_evidence_spec.rs
+++ b/tests/release_downstream_result_evidence_spec.rs
@@ -340,6 +340,40 @@ with tempfile.TemporaryDirectory(dir=pathlib.Path.cwd()) as root:
 }
 
 #[test]
+fn result_envelope_normalizes_exact_github_artifact_metadata() {
+    assert_fixture(&format!(
+        "{FIXTURE}\n{}",
+        r#"
+with tempfile.TemporaryDirectory(dir=pathlib.Path.cwd()) as root:
+    root = pathlib.Path(root)
+    paths = write_fixture(root)
+    bundle = root / 'downstream-channel-result.sigstore.json'
+    bundle.write_text('{}\n', encoding='utf-8')
+    spec = importlib.util.spec_from_file_location(
+        'channel_result',
+        'scripts/release/channel-result.py',
+    )
+    channel_result = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(channel_result)
+    envelope = channel_result.expected_envelope(argparse.Namespace(
+        request=paths['request'],
+        predicate=paths['predicate'],
+        attestation_id='result-attestation-7',
+        attestation_bundle=bundle,
+        bundle_artifact=paths['predicate_meta'],
+        created_at='2026-07-20T00:00:30Z',
+    ))
+    expected = artifact(
+        53,
+        f'rmux-downstream-homebrew_tap-result-{SOURCE}-7',
+    )
+    if envelope['result_bundle'] != expected:
+        raise SystemExit('GitHub artifact metadata was not normalized exactly')
+"#
+    ));
+}
+
+#[test]
 fn exact_reference_rejects_changed_envelope_and_symlinked_request() {
     assert_fixture(&format!(
         "{FIXTURE}\n{}",


### PR DESCRIPTION
## Summary

- normalize exact GitHub artifact metadata before embedding it in channel result envelopes
- share one strict artifact-reference conversion between envelopes and final references
- replay the production metadata shape in focused regression coverage

## Validation

- exact rc.16 Scoop result replay: envelope create and verify
- downstream release test suites
- python3 scripts/release/validate-contracts.py
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --locked -- -D warnings
- scripts/release-review-gate.sh --section static --evidence-mode candidate-delta --skip-package