### PR TITLE
fix(release): accept current waiting workflow runs

### DIFF
--- a/scripts/release/actions-artifact.py
+++ b/scripts/release/actions-artifact.py
@@ -119,7 +119,10 @@ def verify_run_identity(args: argparse.Namespace) -> None:
             raise ValueError(
                 "running artifact verification differs from the current context"
             )
-        if run.get("status") != "in_progress" or run.get("conclusion") is not None:
+        if (
+            run.get("status") not in {"in_progress", "waiting"}
+            or run.get("conclusion") is not None
+        ):
             raise ValueError("current workflow run is not actively in progress")
     elif run.get("status") != "completed" or run.get("conclusion") != "success":
         raise ValueError("workflow run is not completed successfully")

--- a/tests/release_canonical_build_spec.rs
+++ b/tests/release_canonical_build_spec.rs
@@ -740,6 +740,42 @@ fn actions_artifact_binding_rejects_digest_or_run_drift() {
         "{}",
         String::from_utf8_lossy(&running.stderr)
     );
+    running_run["status"] = serde_json::json!("waiting");
+    fs::write(&run_path, running_run.to_string()).expect("write waiting fixture");
+    let waiting = Command::new(python())
+        .arg(&script)
+        .args(strict_args)
+        .arg("--allow-running-current-run")
+        .env("GITHUB_RUN_ID", "77")
+        .env("GITHUB_RUN_ATTEMPT", "1")
+        .env("GITHUB_SHA", source)
+        .env("GITHUB_REF_NAME", "main")
+        .env("GITHUB_EVENT_NAME", "workflow_dispatch")
+        .current_dir(repo_root())
+        .output()
+        .expect("verify current waiting artifact");
+    assert!(
+        waiting.status.success(),
+        "{}",
+        String::from_utf8_lossy(&waiting.stderr)
+    );
+    running_run["status"] = serde_json::json!("queued");
+    fs::write(&run_path, running_run.to_string()).expect("write queued fixture");
+    let queued = Command::new(python())
+        .arg(&script)
+        .args(strict_args)
+        .arg("--allow-running-current-run")
+        .env("GITHUB_RUN_ID", "77")
+        .env("GITHUB_RUN_ATTEMPT", "1")
+        .env("GITHUB_SHA", source)
+        .env("GITHUB_REF_NAME", "main")
+        .env("GITHUB_EVENT_NAME", "workflow_dispatch")
+        .current_dir(repo_root())
+        .output()
+        .expect("reject queued current artifact");
+    assert!(!queued.status.success());
+    running_run["status"] = serde_json::json!("waiting");
+    fs::write(&run_path, running_run.to_string()).expect("restore waiting fixture");
     let wrong_current_run = Command::new(python())
         .arg(&script)
         .args(strict_args)


### PR DESCRIPTION
Allow exact-current-run artifact verification while GitHub reports the workflow as waiting because a sibling job is pending protected-environment approval. The verifier remains bound to the exact run, attempt, SHA, ref, event, workflow, and repository, and continues to reject queued and completed runs.\n\nRegression coverage exercises the waiting state and preserves rejection of queued and wrong-run evidence.