### PR TITLE
ci: tolerate offline Windows revocation services

### DIFF
--- a/.github/actions/canonical-smoke/action.yml
+++ b/.github/actions/canonical-smoke/action.yml
@@ -193,6 +193,16 @@ runs:
         test -f windows-nextest.tar.zst.sha256
         sha256sum --check windows-nextest.tar.zst.sha256
 
+    - name: Tolerate unavailable Windows revocation servers
+      if: runner.os == 'Windows' && inputs.smoke-kind != 'runtime'
+      shell: pwsh
+      run: |
+        $curlHome = Join-Path $env:RUNNER_TEMP "rmux-curl"
+        New-Item -ItemType Directory -Force -Path $curlHome | Out-Null
+        "ssl-revoke-best-effort" |
+          Set-Content -LiteralPath (Join-Path $curlHome ".curlrc") -Encoding ascii
+        "CURL_HOME=$curlHome" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
     - name: Install cargo-nextest for persisted Windows test drivers
       if: runner.os == 'Windows' && inputs.smoke-kind != 'runtime'
       uses: taiki-e/install-action@c7eb1735f09259a5035e8e5d44b1406b1cddc0fb # v2.83.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -911,6 +911,16 @@ jobs:
         with:
           toolchain: "1.96.1"
 
+      - name: Tolerate unavailable Windows revocation servers
+        if: steps.archive-cache.outputs.cache-hit != 'true'
+        shell: pwsh
+        run: |
+          $curlHome = Join-Path $env:RUNNER_TEMP "rmux-curl"
+          New-Item -ItemType Directory -Force -Path $curlHome | Out-Null
+          "ssl-revoke-best-effort" |
+            Set-Content -LiteralPath (Join-Path $curlHome ".curlrc") -Encoding ascii
+          "CURL_HOME=$curlHome" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
       - name: Install cargo-nextest
         if: steps.archive-cache.outputs.cache-hit != 'true'
         uses: taiki-e/install-action@c7eb1735f09259a5035e8e5d44b1406b1cddc0fb # v2.83.0
@@ -1041,6 +1051,15 @@ jobs:
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
         with:
           toolchain: "1.96.1"
+
+      - name: Tolerate unavailable Windows revocation servers
+        shell: pwsh
+        run: |
+          $curlHome = Join-Path $env:RUNNER_TEMP "rmux-curl"
+          New-Item -ItemType Directory -Force -Path $curlHome | Out-Null
+          "ssl-revoke-best-effort" |
+            Set-Content -LiteralPath (Join-Path $curlHome ".curlrc") -Encoding ascii
+          "CURL_HOME=$curlHome" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@c7eb1735f09259a5035e8e5d44b1406b1cddc0fb # v2.83.0
@@ -1238,6 +1257,15 @@ jobs:
       CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_RUSTFLAGS: "-C target-feature=+crt-static"
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Tolerate unavailable Windows revocation servers
+        shell: pwsh
+        run: |
+          $curlHome = Join-Path $env:RUNNER_TEMP "rmux-curl"
+          New-Item -ItemType Directory -Force -Path $curlHome | Out-Null
+          "ssl-revoke-best-effort" |
+            Set-Content -LiteralPath (Join-Path $curlHome ".curlrc") -Encoding ascii
+          "CURL_HOME=$curlHome" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@c7eb1735f09259a5035e8e5d44b1406b1cddc0fb # v2.83.0

--- a/tests/windows_package_nextest_spec.rs
+++ b/tests/windows_package_nextest_spec.rs
@@ -1,5 +1,7 @@
 const VERIFIER: &str = include_str!("../scripts/verify-package-windows.ps1");
 const NEXTEST_SMOKE: &str = include_str!("../scripts/run-nextest-package-smoke.ps1");
+const CI: &str = include_str!("../.github/workflows/ci.yml");
+const CANONICAL_SMOKE: &str = include_str!("../.github/actions/canonical-smoke/action.yml");
 
 fn function_body<'a>(source: &'a str, name: &str, next_name: &str) -> &'a str {
     source
@@ -128,6 +130,30 @@ fn release_package_metadata_is_bound_to_the_expected_commit() {
         assert!(
             release_gate.contains(required),
             "release metadata binding lost {required:?}"
+        );
+    }
+}
+
+#[test]
+fn windows_nextest_downloads_tolerate_only_offline_revocation_services() {
+    assert_eq!(
+        CI.matches("Tolerate unavailable Windows revocation servers")
+            .count(),
+        3
+    );
+    assert_eq!(
+        CANONICAL_SMOKE
+            .matches("Tolerate unavailable Windows revocation servers")
+            .count(),
+        1
+    );
+
+    for source in [CI, CANONICAL_SMOKE] {
+        assert!(source.contains("\"ssl-revoke-best-effort\""));
+        assert!(source.contains("\"CURL_HOME=$curlHome\""));
+        assert!(
+            !source.contains("ssl-no-revoke"),
+            "known certificate revocations must remain enforced"
         );
     }
 }


### PR DESCRIPTION
GitHub-hosted Windows runners can fail `cargo-nextest` downloads when the certificate revocation service is temporarily unreachable. Configure curl’s `ssl-revoke-best-effort` mode only around the pinned, checksum-verified nextest installs. Known certificate revocations remain enforced; `ssl-no-revoke` is explicitly forbidden by regression coverage.