### PR TITLE
fix(release): stabilize RC evidence recording

### DIFF
--- a/.github/release/downstream-channel-contract.json
+++ b/.github/release/downstream-channel-contract.json
@@ -101,7 +101,10 @@
     "final_result_count": 11,
     "rmux_io_pre_site_digest_field": "pre_site_summary_sha256",
     "producer_workflows": {
-      "apt_rpm": {".github/workflows/release-linux-repository-publish.yml": 316435347},
+      "apt_rpm": {
+        ".github/workflows/release-linux-repository-publish.yml": 316435347,
+        ".github/workflows/release-policy-channel.yml": 316435347
+      },
       "chocolatey": {
         ".github/workflows/release-chocolatey-channel.yml": 316435347,
         ".github/workflows/release-chocolatey-retry.yml": 316439352

--- a/scripts/release/downstream_contract.py
+++ b/scripts/release/downstream_contract.py
@@ -109,7 +109,10 @@ RESULT_STATES = {
     "submitted",
 }
 RESULT_PRODUCERS = {
-    "apt_rpm": {".github/workflows/release-linux-repository-publish.yml": 316435347},
+    "apt_rpm": {
+        ".github/workflows/release-linux-repository-publish.yml": 316435347,
+        ".github/workflows/release-policy-channel.yml": 316435347,
+    },
     "chocolatey": {
         ".github/workflows/release-chocolatey-channel.yml": 316435347,
         ".github/workflows/release-chocolatey-retry.yml": 316439352,

--- a/scripts/release/sign-and-push-release-tag.sh
+++ b/scripts/release/sign-and-push-release-tag.sh
@@ -238,7 +238,20 @@ push_status=$?
 set -e
 
 created_ref=$temporary/created-ref.json
-if ! api_get "repos/$repository/git/ref/tags/$release_ref" "$created_ref"; then
+created_ref_visible=false
+for delay in 0 1 2 4 8 10; do
+  if (( delay > 0 )); then
+    sleep "$delay"
+  fi
+  if api_get "repos/$repository/git/ref/tags/$release_ref" "$created_ref"; then
+    created_ref_visible=true
+    break
+  else
+    visibility_status=$?
+    [[ $visibility_status -eq 4 ]] || exit "$visibility_status"
+  fi
+done
+if [[ $created_ref_visible != true ]]; then
   echo 'release tag creation was not observable after the create-only request' >&2
   exit 1
 fi

--- a/tests/release_downstream_result_evidence_spec.rs
+++ b/tests/release_downstream_result_evidence_spec.rs
@@ -35,6 +35,43 @@ fn result_attestation_uses_algorithm_qualified_subject_digest() {
     assert!(RESULT_ACTION.contains("subject-digest: ${{ steps.predicate.outputs.subject_digest }}"));
 }
 
+#[test]
+fn rc_apt_policy_result_uses_an_exact_allowlisted_producer() {
+    assert_fixture(
+        r#"
+import sys
+sys.path.insert(0, 'scripts/release')
+
+from downstream_result import validate_producer
+
+base = {
+    'run_id': 51,
+    'run_attempt': 1,
+    'workflow_id': 316435347,
+    'runner_group_id': 0,
+    'runner_group_name': 'GitHub Actions',
+    'runner_image': 'ubuntu-22.04',
+}
+for workflow_path in (
+    '.github/workflows/release-linux-repository-publish.yml',
+    '.github/workflows/release-policy-channel.yml',
+):
+    producer = {**base, 'workflow_path': workflow_path}
+    if validate_producer(producer, 'apt_rpm') != producer:
+        raise SystemExit(f'APT/RPM producer was not preserved: {workflow_path}')
+
+forged = {**base, 'workflow_path': '.github/workflows/release-receipt.yml'}
+try:
+    validate_producer(forged, 'apt_rpm')
+except ValueError as error:
+    if 'not allowlisted' not in str(error):
+        raise
+else:
+    raise SystemExit('forged APT/RPM producer was accepted')
+"#,
+    );
+}
+
 const FIXTURE: &str = r#"
 import argparse
 import copy

--- a/tests/release_downstream_summary_spec.rs
+++ b/tests/release_downstream_summary_spec.rs
@@ -91,7 +91,15 @@ HOSTS = {
 
 PRODUCERS = {}
 for channel, workflows in load_contract()['result_evidence']['producer_workflows'].items():
-    initial = [(path, workflow_id) for path, workflow_id in workflows.items() if '-retry.yml' not in path]
+    initial = [
+        (path, workflow_id)
+        for path, workflow_id in workflows.items()
+        if '-retry.yml' not in path
+        and not (
+            path == '.github/workflows/release-policy-channel.yml'
+            and len(workflows) > 1
+        )
+    ]
     if len(initial) != 1:
         raise RuntimeError(f'channel {channel} lacks one exact initial producer')
     PRODUCERS[channel] = initial[0]

--- a/tests/release_signed_tag_spec.rs
+++ b/tests/release_signed_tag_spec.rs
@@ -619,6 +619,17 @@ if [[ ! -f $body ]]; then
   printf 'HTTP/2.0 404 Not Found\nContent-Type: application/json\n\n{}\n'
   exit 1
 fi
+if [[ $endpoint == */git/ref/tags/v0.9.1 && ${FAKE_REF_VISIBILITY_MISSES:-0} -gt 0 ]]; then
+  seen=0
+  if [[ -f $FAKE_VISIBILITY_STATE ]]; then
+    read -r seen < "$FAKE_VISIBILITY_STATE"
+  fi
+  if (( seen < FAKE_REF_VISIBILITY_MISSES )); then
+    printf '%s\n' "$((seen + 1))" > "$FAKE_VISIBILITY_STATE"
+    printf 'HTTP/2.0 404 Not Found\nContent-Type: application/json\n\n{}\n'
+    exit 1
+  fi
+fi
 printf 'HTTP/2.0 200 OK\nContent-Type: application/json\n\n'
 cat "$body"
 "#,
@@ -677,7 +688,8 @@ exec "$REAL_GIT" "$@"
         .expect("git path UTF-8")
         .trim()
         .to_owned();
-    let invoke_created = |verified: &str| {
+    let visibility_state = fixture.root.join("ref-visibility-count");
+    let invoke_created = |verified: &str, visibility_misses: &str| {
         run(Command::new(&driver)
             .args(&args)
             .env("PATH", &path)
@@ -685,15 +697,17 @@ exec "$REAL_GIT" "$@"
             .env("FAKE_REF_JSON", &ref_json)
             .env("FAKE_TAG_JSON", &tag_json)
             .env("FAKE_GITHUB_VERIFIED", verified)
+            .env("FAKE_REF_VISIBILITY_MISSES", visibility_misses)
+            .env("FAKE_VISIBILITY_STATE", &visibility_state)
             .env("RMUX_RELEASE_APP_ID", "4339867")
             .env("RMUX_RELEASE_APP_TOKEN", "fixture-installation-token"))
     };
-    let unverified = invoke_created("false");
+    let unverified = invoke_created("false", "0");
     assert!(!unverified.status.success());
     assert!(stderr(&unverified).contains("GitHub did not verify the tag signature"));
     fs::remove_file(&ref_json).expect("reset fake ref");
     fs::remove_file(&tag_json).expect("reset fake tag");
-    let created = invoke_created("true");
+    let created = invoke_created("true", "1");
     assert!(created.status.success(), "{}", stderr(&created));
     let created_json: serde_json::Value =
         serde_json::from_slice(&created.stdout).expect("created JSON");


### PR DESCRIPTION
## Summary
- allow the exact policy workflow to attest an intentionally denied RC APT/RPM channel
- keep the stable Linux repository publisher and forged producers strictly rejected
- poll boundedly for GitHub tag-ref visibility after a successful create-only push

## Validation
- cargo test --locked --test release_downstream_result_evidence_spec --test release_downstream_summary_spec --test release_downstream_workflows_spec --test release_signed_tag_spec
- cargo test --locked --test release_automation_spec --test release_tag_contract_spec --test release_promoter_workflows_spec
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo fmt --all -- --check
- python3 scripts/release/validate-contracts.py
- bash -n scripts/release/sign-and-push-release-tag.sh
- git diff --check