### PR TITLE
fix(release): accept active GitHub run transitions

### DIFF
--- a/scripts/release/actions-artifact.py
+++ b/scripts/release/actions-artifact.py
@@ -18,6 +18,9 @@ DIGEST = re.compile(r"sha256:[0-9a-f]{64}")
 SHA = re.compile(r"[0-9a-f]{40}")
 REPOSITORY = "Helvesec/rmux"
 REPOSITORY_ID = 1239918790
+ACTIVE_RUN_STATUSES = frozenset(
+    {"queued", "in_progress", "requested", "waiting", "pending"}
+)
 
 
 def artifact_timestamp(value: Any, label: str) -> str:
@@ -120,7 +123,7 @@ def verify_run_identity(args: argparse.Namespace) -> None:
                 "running artifact verification differs from the current context"
             )
         if (
-            run.get("status") not in {"in_progress", "waiting"}
+            run.get("status") not in ACTIVE_RUN_STATUSES
             or run.get("conclusion") is not None
         ):
             raise ValueError("current workflow run is not actively in progress")

--- a/scripts/release/github_release_api.py
+++ b/scripts/release/github_release_api.py
@@ -16,6 +16,9 @@ API_ROOT = "https://api.github.com"
 UPLOAD_ROOT = "https://uploads.github.com"
 API_VERSION = "2026-03-10"
 MAX_RESPONSE_BYTES = 8 * 1024 * 1024
+ACTIVE_RUN_STATUSES = frozenset(
+    {"queued", "in_progress", "requested", "waiting", "pending"}
+)
 
 
 class NoRedirect(HTTPRedirectHandler):
@@ -343,7 +346,7 @@ def verify_live_evidence(client: ApiClient, evidence: Any, now: datetime) -> Non
         or run.get("workflow_id") != authorization["workflow_id"]
         or run.get("path") != authorization["workflow_path"]
         or run.get("head_sha") != evidence.source_sha
-        or run.get("status") != "in_progress"
+        or run.get("status") not in ACTIVE_RUN_STATUSES
         or run.get("conclusion") is not None
         or run.get("repository", {}).get("id") != REPOSITORY_ID
     ):

--- a/tests/release_canonical_build_spec.rs
+++ b/tests/release_canonical_build_spec.rs
@@ -740,9 +740,30 @@ fn actions_artifact_binding_rejects_digest_or_run_drift() {
         "{}",
         String::from_utf8_lossy(&running.stderr)
     );
-    running_run["status"] = serde_json::json!("waiting");
-    fs::write(&run_path, running_run.to_string()).expect("write waiting fixture");
-    let waiting = Command::new(python())
+    for status in ["waiting", "queued", "requested", "pending"] {
+        running_run["status"] = serde_json::json!(status);
+        fs::write(&run_path, running_run.to_string()).expect("write active fixture");
+        let active = Command::new(python())
+            .arg(&script)
+            .args(strict_args)
+            .arg("--allow-running-current-run")
+            .env("GITHUB_RUN_ID", "77")
+            .env("GITHUB_RUN_ATTEMPT", "1")
+            .env("GITHUB_SHA", source)
+            .env("GITHUB_REF_NAME", "main")
+            .env("GITHUB_EVENT_NAME", "workflow_dispatch")
+            .current_dir(repo_root())
+            .output()
+            .expect("verify current active artifact");
+        assert!(
+            active.status.success(),
+            "status={status}: {}",
+            String::from_utf8_lossy(&active.stderr)
+        );
+    }
+    running_run["status"] = serde_json::json!("completed");
+    fs::write(&run_path, running_run.to_string()).expect("write completed fixture");
+    let completed = Command::new(python())
         .arg(&script)
         .args(strict_args)
         .arg("--allow-running-current-run")
@@ -753,27 +774,8 @@ fn actions_artifact_binding_rejects_digest_or_run_drift() {
         .env("GITHUB_EVENT_NAME", "workflow_dispatch")
         .current_dir(repo_root())
         .output()
-        .expect("verify current waiting artifact");
-    assert!(
-        waiting.status.success(),
-        "{}",
-        String::from_utf8_lossy(&waiting.stderr)
-    );
-    running_run["status"] = serde_json::json!("queued");
-    fs::write(&run_path, running_run.to_string()).expect("write queued fixture");
-    let queued = Command::new(python())
-        .arg(&script)
-        .args(strict_args)
-        .arg("--allow-running-current-run")
-        .env("GITHUB_RUN_ID", "77")
-        .env("GITHUB_RUN_ATTEMPT", "1")
-        .env("GITHUB_SHA", source)
-        .env("GITHUB_REF_NAME", "main")
-        .env("GITHUB_EVENT_NAME", "workflow_dispatch")
-        .current_dir(repo_root())
-        .output()
-        .expect("reject queued current artifact");
-    assert!(!queued.status.success());
+        .expect("reject completed current artifact");
+    assert!(!completed.status.success());
     running_run["status"] = serde_json::json!("waiting");
     fs::write(&run_path, running_run.to_string()).expect("restore waiting fixture");
     let wrong_current_run = Command::new(python())

--- a/tests/release_github_publisher_spec.rs
+++ b/tests/release_github_publisher_spec.rs
@@ -67,6 +67,7 @@ struct ServerState {
     assets: BTreeMap<String, Value>,
     requests: Vec<RequestRecord>,
     expected_assets: BTreeMap<String, AssetSpec>,
+    audit_run_status: String,
 }
 
 struct FakeServer {
@@ -121,6 +122,7 @@ impl FakeServer {
             assets,
             requests: Vec::new(),
             expected_assets,
+            audit_run_status: "in_progress".to_owned(),
         }));
         let stop = Arc::new(AtomicBool::new(false));
         let thread_state = Arc::clone(&state);
@@ -159,6 +161,10 @@ impl FakeServer {
 
     fn is_public(&self) -> bool {
         self.state.lock().expect("fake API state").draft == Some(false)
+    }
+
+    fn set_audit_run_status(&self, status: &str) {
+        self.state.lock().expect("fake API state").audit_run_status = status.to_owned();
     }
 }
 
@@ -606,7 +612,7 @@ fn handle_request(mut stream: TcpStream, shared: &Arc<Mutex<ServerState>>) {
         ),
         ("GET", "/repos/Helvesec/rmux/actions/runs/501") => (
             200,
-            json!({"id": 501, "run_attempt": 1, "workflow_id": 316435346, "path": ".github/workflows/release-promote.yml", "head_sha": SOURCE, "status": "in_progress", "conclusion": null, "repository": {"id": 1239918790}}),
+            json!({"id": 501, "run_attempt": 1, "workflow_id": 316435346, "path": ".github/workflows/release-promote.yml", "head_sha": SOURCE, "status": state.audit_run_status.clone(), "conclusion": null, "repository": {"id": 1239918790}}),
         ),
         ("GET", "/repos/Helvesec/rmux/actions/artifacts/503") => (
             200,
@@ -786,6 +792,17 @@ fn creates_exact_draft_uploads_exact_bytes_then_publishes_once() {
         .map(|item| item.method.as_str())
         .collect();
     assert_eq!(tail, ["PATCH", "GET", "GET"]);
+}
+
+#[test]
+fn publisher_accepts_nonterminal_policy_audit_run_states() {
+    for status in ["queued", "requested", "waiting", "pending"] {
+        let fixture = fixture(true);
+        let server = FakeServer::start(&fixture, InitialRelease::ExactDraft(fixture.assets.len()));
+        server.set_audit_run_status(status);
+        let result = assert_success(invoke(&fixture, &server, true));
+        assert_eq!(result["published"], true, "status={status}");
+    }
 }
 
 #[test]


### PR DESCRIPTION
GitHub can report an attempt-1 workflow run as queued, requested, waiting, or pending while reusable jobs cross environment and scheduler boundaries. Treat those documented nonterminal states like in_progress when the exact current run identity, workflow, source SHA, repository, and null conclusion all match.

This keeps completed and forged runs fail-closed and applies the same invariant to artifact and GitHub Release verification.

Validation:
- all release_* integration suites (201 tests)
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --locked -- -D warnings
- Ruff check and format
- release contract validation
- git diff --check