### PR TITLE
fix(release): preserve canonical JSON on Windows

### DIFF
--- a/scripts/release/downstream_channels.py
+++ b/scripts/release/downstream_channels.py
@@ -91,11 +91,13 @@ def read_object(path: Path, label: str) -> dict[str, Any]:
     return read_json_object(path, label)
 
 
+def canonical_file_bytes(value: Any) -> bytes:
+    return (json.dumps(value, indent=2, sort_keys=True) + "\n").encode("utf-8")
+
+
 def write_object(path: Path, value: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(
-        json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8"
-    )
+    path.write_bytes(canonical_file_bytes(value))
 
 
 def canonical_hash(value: Any) -> str:
@@ -106,8 +108,7 @@ def canonical_hash(value: Any) -> str:
 
 
 def canonical_file_hash(value: Any) -> str:
-    rendered = json.dumps(value, indent=2, sort_keys=True) + "\n"
-    return hashlib.sha256(rendered.encode("utf-8")).hexdigest()
+    return hashlib.sha256(canonical_file_bytes(value)).hexdigest()
 
 
 def file_hash(path: Path) -> str:

--- a/tests/release_downstream_workflows_spec.rs
+++ b/tests/release_downstream_workflows_spec.rs
@@ -268,6 +268,39 @@ fn downstream_writers_keep_the_python_310_runtime_contract() {
 }
 
 #[test]
+fn downstream_json_writer_uses_canonical_lf_bytes_on_every_platform() {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time")
+        .as_nanos();
+    let root = std::env::temp_dir().join(format!(
+        "rmux-downstream-json-{}-{nonce}",
+        std::process::id()
+    ));
+    fs::create_dir_all(&root).expect("create canonical JSON fixture directory");
+    let output_path = root.join("evidence.json");
+    let output = Command::new("python3")
+        .args([
+            "-c",
+            "import pathlib,sys; sys.path.insert(0,'scripts/release'); \
+             from downstream_channels import write_object; \
+             write_object(pathlib.Path(sys.argv[1]), {'z': 1, 'a': 2})",
+        ])
+        .arg(&output_path)
+        .current_dir(repo_root())
+        .output()
+        .expect("run canonical downstream JSON writer");
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let bytes = fs::read(&output_path).expect("read canonical downstream JSON");
+    fs::remove_dir_all(root).expect("remove canonical JSON fixture directory");
+    assert_eq!(bytes, b"{\n  \"a\": 2,\n  \"z\": 1\n}\n");
+}
+
+#[test]
 fn downstream_rc_payloads_keep_stable_package_names() {
     let staging = include_str!("../scripts/release/stage-downstream-payloads.py");
     let snap = include_str!("../scripts/release/snap-candidate-status.py");


### PR DESCRIPTION
## Summary

- write downstream JSON evidence as explicit UTF-8 bytes with LF line endings
- hash the exact canonical bytes written to disk
- add a cross-platform regression test that rejects CRLF or BOM output

## Root cause

Windows text-mode output converted canonical JSON newlines to CRLF. The release verifier correctly rejected the Chocolatey RC no-op channel result because the bytes no longer matched the canonical representation.

## Validation

- 183 targeted release tests
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo fmt --all -- --check
- Ruff check and format
- release contract validation
- git diff --check