### PR TITLE
fix(release): hash Windows evidence without path escaping

### DIFF
--- a/.github/actions/release-channel-result/action.yml
+++ b/.github/actions/release-channel-result/action.yml
@@ -90,7 +90,7 @@ runs:
           --output "$root/downstream-channel-result-predicate.json"
         scripts/release/channel-result.py verify-predicate "${common[@]}" \
           --document "$root/downstream-channel-result-predicate.json"
-        digest="$(sha256sum "$RMUX_TARGET_EVIDENCE" | cut -d' ' -f1)"
+        digest="$(sha256sum < "$RMUX_TARGET_EVIDENCE" | cut -d' ' -f1)"
         echo "subject_digest=sha256:$digest" >> "$GITHUB_OUTPUT"
         echo "observed_at=$observed_at" >> "$GITHUB_OUTPUT"
 

--- a/scripts/release/downstream_workflow_contract.py
+++ b/scripts/release/downstream_workflow_contract.py
@@ -166,11 +166,18 @@ def _validate_payload_prepare(path: Path) -> None:
 
 def _validate_channel_result_action(path: Path) -> None:
     text = path.read_text(encoding="utf-8")
+    digest = 'digest="$(sha256sum < "$RMUX_TARGET_EVIDENCE" | cut -d\' \' -f1)"'
     qualified = 'echo "subject_digest=sha256:$digest" >> "$GITHUB_OUTPUT"'
     unqualified = 'echo "subject_digest=$digest" >> "$GITHUB_OUTPUT"'
     consumer = "subject-digest: ${{ steps.predicate.outputs.subject_digest }}"
-    if text.count(qualified) != 1 or text.count(consumer) != 1:
+    if (
+        text.count(digest) != 1
+        or text.count(qualified) != 1
+        or text.count(consumer) != 1
+    ):
         raise ValueError("channel result attestation lost its qualified subject digest")
+    if 'sha256sum "$RMUX_TARGET_EVIDENCE"' in text:
+        raise ValueError("channel result digest regained filename-dependent output")
     if unqualified in text:
         raise ValueError("channel result attestation regained an unqualified digest")
 

--- a/tests/release_downstream_result_evidence_spec.rs
+++ b/tests/release_downstream_result_evidence_spec.rs
@@ -30,6 +30,9 @@ const RESULT_ACTION: &str = include_str!("../.github/actions/release-channel-res
 
 #[test]
 fn result_attestation_uses_algorithm_qualified_subject_digest() {
+    assert!(RESULT_ACTION
+        .contains("digest=\"$(sha256sum < \"$RMUX_TARGET_EVIDENCE\" | cut -d' ' -f1)\""));
+    assert!(!RESULT_ACTION.contains("sha256sum \"$RMUX_TARGET_EVIDENCE\""));
     assert!(RESULT_ACTION.contains("echo \"subject_digest=sha256:$digest\" >> \"$GITHUB_OUTPUT\""));
     assert!(!RESULT_ACTION.contains("echo \"subject_digest=$digest\" >> \"$GITHUB_OUTPUT\""));
     assert!(RESULT_ACTION.contains("subject-digest: ${{ steps.predicate.outputs.subject_digest }}"));

--- a/tests/release_downstream_workflows_spec.rs
+++ b/tests/release_downstream_workflows_spec.rs
@@ -14,6 +14,8 @@ const DOWNSTREAM_PREPARE: &str =
     include_str!("../.github/workflows/release-downstream-prepare.yml");
 const RECEIPT: &str = include_str!("../.github/workflows/release-receipt.yml");
 const CI: &str = include_str!("../.github/workflows/ci.yml");
+const CHANNEL_RESULT_ACTION: &str =
+    include_str!("../.github/actions/release-channel-result/action.yml");
 const RECEIPT_REFERENCE_BUILDER: &str =
     include_str!("../scripts/release/build-downstream-receipt-reference.py");
 
@@ -298,6 +300,13 @@ fn downstream_json_writer_uses_canonical_lf_bytes_on_every_platform() {
     let bytes = fs::read(&output_path).expect("read canonical downstream JSON");
     fs::remove_dir_all(root).expect("remove canonical JSON fixture directory");
     assert_eq!(bytes, b"{\n  \"a\": 2,\n  \"z\": 1\n}\n");
+}
+
+#[test]
+fn downstream_result_digest_is_independent_of_windows_path_escaping() {
+    assert!(CHANNEL_RESULT_ACTION
+        .contains("digest=\"$(sha256sum < \"$RMUX_TARGET_EVIDENCE\" | cut -d' ' -f1)\""));
+    assert!(!CHANNEL_RESULT_ACTION.contains("sha256sum \"$RMUX_TARGET_EVIDENCE\""));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- hash downstream target evidence through stdin so GNU sha256sum never escapes a Windows filename
- require the filename-independent form in the release workflow contract
- add Unix reproduction and cross-platform regression coverage

## Root cause

GNU sha256sum prefixes its digest with a backslash when it escapes a filename containing backslashes. On Git Bash, the Chocolatey evidence path therefore produced `sha256:\...`, which actions/attest correctly rejected as non-hex. Hashing stdin preserves the exact bytes while removing the filename from the output format.

## Validation

- reproduced the old escaped digest and the new 64-hex digest
- 184 targeted release tests
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo fmt --all -- --check
- Ruff lint and Python compilation
- release contract validation
- git diff --check