### PR TITLE
fix(release): permit exact failed-run recovery

### DIFF
--- a/.github/workflows/release-linux-repository-build.yml
+++ b/.github/workflows/release-linux-repository-build.yml
@@ -71,27 +71,39 @@ jobs:
           [[ "$RMUX_PAYLOAD_ARTIFACT_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]
           [[ "$RMUX_SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]
           [[ "$RMUX_RELEASE_REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
+          if test "$GITHUB_RUN_ID" != "$RMUX_RECEIPT_RUN_ID"; then
+            test "$GITHUB_REF" = "refs/heads/main"
+          fi
+
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
+
+      - name: Verify exact APT/RPM payload artifact identity
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mode=(--allow-completed-failed-run)
+          if test "$GITHUB_RUN_ID" = "$RMUX_RECEIPT_RUN_ID"; then
+            mode=(--allow-running-current-run)
+          fi
+          scripts/release/actions-artifact.py verify \
+            --repository "$GITHUB_REPOSITORY" --run-id "$RMUX_RECEIPT_RUN_ID" \
+            --artifact-id "$RMUX_PAYLOAD_ARTIFACT_ID" \
+            --name "rmux-downstream-apt_rpm-payload-$RMUX_SOURCE_SHA-$RMUX_RELEASE_ID" \
+            --expected-source-sha "$RMUX_SOURCE_SHA" \
+            --expected-digest "$RMUX_PAYLOAD_ARTIFACT_DIGEST" \
+            --expected-workflow-id 316435347 \
+            --expected-workflow-path .github/workflows/release-receipt.yml \
+            --expected-event workflow_dispatch --expected-head-branch "$RMUX_RELEASE_REF" \
+            "${mode[@]}" --max-attempts 1
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           ref: ${{ inputs.expected_source_sha }}
           persist-credentials: false
-
-      - name: Verify exact APT/RPM payload artifact identity
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: >-
-          scripts/release/actions-artifact.py verify
-          --repository "$GITHUB_REPOSITORY" --run-id "$RMUX_RECEIPT_RUN_ID"
-          --artifact-id "$RMUX_PAYLOAD_ARTIFACT_ID"
-          --name "rmux-downstream-apt_rpm-payload-$RMUX_SOURCE_SHA-$RMUX_RELEASE_ID"
-          --expected-source-sha "$RMUX_SOURCE_SHA"
-          --expected-digest "$RMUX_PAYLOAD_ARTIFACT_DIGEST"
-          --expected-workflow-id 316435347
-          --expected-workflow-path .github/workflows/release-receipt.yml
-          --expected-event workflow_dispatch --expected-head-branch "$RMUX_RELEASE_REF"
-          --allow-running-current-run
-          --max-attempts 1
 
       - name: Download only the exact APT/RPM payload artifact ID
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093

--- a/scripts/release/actions-artifact.py
+++ b/scripts/release/actions-artifact.py
@@ -77,8 +77,13 @@ def verify_run_identity(args: argparse.Namespace) -> None:
         args.expected_event,
         args.expected_head_branch,
     )
-    if args.allow_running_current_run and all(value is None for value in expected):
-        raise ValueError("running artifact verification requires exact run identity")
+    allows_non_success = (
+        args.allow_running_current_run or args.allow_completed_failed_run
+    )
+    if allows_non_success and all(value is None for value in expected):
+        raise ValueError(
+            "non-success artifact verification requires exact run identity"
+        )
     if all(value is None for value in expected):
         return
     if any(value is None for value in expected):
@@ -127,6 +132,9 @@ def verify_run_identity(args: argparse.Namespace) -> None:
             or run.get("conclusion") is not None
         ):
             raise ValueError("current workflow run is not actively in progress")
+    elif args.allow_completed_failed_run:
+        if run.get("status") != "completed" or run.get("conclusion") != "failure":
+            raise ValueError("workflow run is not a completed failed run")
     elif run.get("status") != "completed" or run.get("conclusion") != "success":
         raise ValueError("workflow run is not completed successfully")
 
@@ -242,7 +250,9 @@ def parse_args() -> argparse.Namespace:
             "--expected-event", choices=("workflow_call", "workflow_dispatch")
         )
         command.add_argument("--expected-head-branch")
-        command.add_argument("--allow-running-current-run", action="store_true")
+        run_mode = command.add_mutually_exclusive_group()
+        run_mode.add_argument("--allow-running-current-run", action="store_true")
+        run_mode.add_argument("--allow-completed-failed-run", action="store_true")
         command.add_argument("--include-retention", action="store_true")
         if name in {"resolve-id", "verify"}:
             command.add_argument("--artifact-id", type=int, required=True)

--- a/scripts/release/downstream_workflow_contract.py
+++ b/scripts/release/downstream_workflow_contract.py
@@ -85,6 +85,14 @@ def _validate_reusable_workflow(path: Path, *, require_repository_guard: bool) -
         ):
             if f"      {name}:" not in dispatch[1]:
                 raise ValueError(f"Linux repository recovery lost input {name}")
+        for mode in (
+            "--allow-completed-failed-run",
+            "--allow-running-current-run",
+        ):
+            if text.count(mode) != 1:
+                raise ValueError(f"Linux repository recovery lost run mode {mode}")
+        if text.count('test "$GITHUB_REF" = "refs/heads/main"') != 1:
+            raise ValueError("Linux repository recovery is not bound to protected main")
     elif "\n  workflow_dispatch:" in text:
         raise ValueError(f"{path.name} gained a mutation-capable dispatch trigger")
     if "runs-on: self-hosted" in text or "\n      - self-hosted" in text:

--- a/tests/release_canonical_build_spec.rs
+++ b/tests/release_canonical_build_spec.rs
@@ -776,7 +776,37 @@ fn actions_artifact_binding_rejects_digest_or_run_drift() {
         .output()
         .expect("reject completed current artifact");
     assert!(!completed.status.success());
+    running_run["conclusion"] = serde_json::json!("failure");
+    fs::write(&run_path, running_run.to_string()).expect("write failed fixture");
+    let failed_recovery = Command::new(python())
+        .arg(&script)
+        .args(strict_args)
+        .arg("--allow-completed-failed-run")
+        .current_dir(repo_root())
+        .output()
+        .expect("verify retained artifact from failed run");
+    assert!(
+        failed_recovery.status.success(),
+        "{}",
+        String::from_utf8_lossy(&failed_recovery.stderr)
+    );
+    for conclusion in ["cancelled", "success"] {
+        running_run["conclusion"] = serde_json::json!(conclusion);
+        fs::write(&run_path, running_run.to_string()).expect("write rejected fixture");
+        let rejected_recovery = Command::new(python())
+            .arg(&script)
+            .args(strict_args)
+            .arg("--allow-completed-failed-run")
+            .current_dir(repo_root())
+            .output()
+            .expect("reject non-failed retained artifact");
+        assert!(
+            !rejected_recovery.status.success(),
+            "conclusion={conclusion}"
+        );
+    }
     running_run["status"] = serde_json::json!("waiting");
+    running_run["conclusion"] = serde_json::Value::Null;
     fs::write(&run_path, running_run.to_string()).expect("restore waiting fixture");
     let wrong_current_run = Command::new(python())
         .arg(&script)


### PR DESCRIPTION
Allow the APT/RPM recovery signer to consume an exact retained payload from a completed failed receipt run.

The exception remains bound to attempt 1 and the exact repository, workflow, event, ref, source SHA, artifact ID, name, and digest. Cancelled and successful runs are rejected under recovery mode.

Validation:
- 12 release canonical-build tests
- 15 downstream workflow tests
- release contracts
- Ruff, rustfmt, and diff checks