### PR TITLE
fix(release): verify Linux toolchain provenance

### DIFF
--- a/scripts/release/verify-candidate-artifacts.py
+++ b/scripts/release/verify-candidate-artifacts.py
@@ -91,6 +91,21 @@ def run_verifier(script: str, arguments: list[str]) -> str:
     return completed.stdout.strip()
 
 
+def verify_linux_glibc_tools_receipt(path: Path) -> None:
+    requirements = ROOT / "scripts/release/linux-glibc-build-requirements.txt"
+    expected = (
+        "cargo_zigbuild=0.23.0\n"
+        "zig=0.15.2\n"
+        f"requirements_sha256={sha256_file(requirements)}\n"
+        "glibc_target=2.31\n"
+    )
+    try:
+        actual = path.read_text(encoding="ascii")
+    except (OSError, UnicodeDecodeError) as error:
+        raise ValueError("Linux glibc build-tools receipt is not ASCII") from error
+    require_equal(actual, expected, "Linux glibc build-tools receipt")
+
+
 def verify_fast_directory(
     directory: Path,
     source_sha: str,
@@ -182,16 +197,21 @@ def verify_platform_download(
     exact_entries(
         assets_dir, {"assets", "canonical-build-record.json"}, f"{platform} assets"
     )
+    provenance_entries = {
+        "build-provenance.sigstore.json",
+        "canonical-artifact-binding.json",
+        "canonical-build-record.json",
+        "rustc-vV.txt",
+    }
+    if platform in {"linux-aarch64", "linux-x86_64"}:
+        provenance_entries.add("linux-glibc-build-tools.txt")
     exact_entries(
         provenance_dir,
-        {
-            "build-provenance.sigstore.json",
-            "canonical-artifact-binding.json",
-            "canonical-build-record.json",
-            "rustc-vV.txt",
-        },
+        provenance_entries,
         f"{platform} provenance",
     )
+    if platform in {"linux-aarch64", "linux-x86_64"}:
+        verify_linux_glibc_tools_receipt(provenance_dir / "linux-glibc-build-tools.txt")
     record = assets_dir / "canonical-build-record.json"
     provenance_record = provenance_dir / "canonical-build-record.json"
     if record.read_bytes() != provenance_record.read_bytes():

--- a/tests/release_candidate_artifacts_spec.rs
+++ b/tests/release_candidate_artifacts_spec.rs
@@ -407,6 +407,17 @@ fn create_platform_download(root: &Path, resolution: &serde_json::Value, platfor
         ),
     )
     .expect("write rustc evidence");
+    if platform.key.starts_with("linux-") {
+        let requirements = repo_root().join("scripts/release/linux-glibc-build-requirements.txt");
+        fs::write(
+            provenance.join("linux-glibc-build-tools.txt"),
+            format!(
+                "cargo_zigbuild=0.23.0\nzig=0.15.2\nrequirements_sha256={}\nglibc_target=2.31\n",
+                sha256(&requirements)
+            ),
+        )
+        .expect("write Linux glibc build-tools receipt");
+    }
     let record = assets_root.join("canonical-build-record.json");
     let record_create = run(
         &repo_root().join("scripts/release/canonical-build-record.py"),
@@ -617,13 +628,31 @@ fn downloaded_candidate_records_bind_every_exact_byte() {
     );
 
     let linux_provenance = metadata(&resolution, "canonical-provenance", "linux-x86_64");
-    let binding_path = downloads
-        .join(
-            linux_provenance["name"]
-                .as_str()
-                .expect("Linux provenance artifact name"),
-        )
-        .join("canonical-artifact-binding.json");
+    let linux_provenance_root = downloads.join(
+        linux_provenance["name"]
+            .as_str()
+            .expect("Linux provenance artifact name"),
+    );
+    let glibc_receipt = linux_provenance_root.join("linux-glibc-build-tools.txt");
+    let original_glibc_receipt = fs::read(&glibc_receipt).expect("read glibc receipt");
+    fs::write(
+        &glibc_receipt,
+        "cargo_zigbuild=0.23.0\nzig=0.15.2\nrequirements_sha256=0000000000000000000000000000000000000000000000000000000000000000\nglibc_target=2.31\n",
+    )
+    .expect("tamper glibc receipt");
+    let mut glibc_args = args.clone();
+    glibc_args[18] = root
+        .join("tampered-glibc-receipt.json")
+        .display()
+        .to_string();
+    let rejected_glibc_receipt = run(
+        &repo_root().join("scripts/release/verify-candidate-artifacts.py"),
+        &glibc_args,
+    );
+    assert!(!rejected_glibc_receipt.status.success());
+    fs::write(&glibc_receipt, original_glibc_receipt).expect("restore glibc receipt");
+
+    let binding_path = linux_provenance_root.join("canonical-artifact-binding.json");
     let original_binding = fs::read(&binding_path).expect("read canonical binding");
     let mut substituted_binding: serde_json::Value =
         serde_json::from_slice(&original_binding).expect("parse canonical binding");


### PR DESCRIPTION
The canonical Linux builds persist the pinned glibc toolchain receipt, but the shadow verifier still required the older provenance file set.

This change contracts the Linux-only receipt, validates its exact versions, glibc target, and requirements digest, and adds tamper coverage.

Validation:
- exact v0.10.0 candidate artifact set verified locally
- cargo test --locked --test release_candidate_artifacts_spec
- cargo test --locked --test release_shadow_spec --test release_canonical_build_spec --test release_automation_spec
- Ruff, Python compile, Rustfmt, and git diff checks