### PR TITLE
fix(release): delegate repository attestation permissions

### DIFF
--- a/.github/workflows/release-downstream.yml
+++ b/.github/workflows/release-downstream.yml
@@ -265,7 +265,9 @@ jobs:
     uses: ./.github/workflows/release-linux-repository-build.yml
     permissions:
       actions: read
+      attestations: write
       contents: read
+      id-token: write
     with:
       receipt_run_id: ${{ inputs.receipt_run_id }}
       payload_artifact_id: ${{ fromJSON(needs.prepare-payloads.outputs.payload_artifact_ids).apt_rpm }}

--- a/tests/release_downstream_workflows_spec.rs
+++ b/tests/release_downstream_workflows_spec.rs
@@ -253,6 +253,13 @@ fn downstream_authority_is_rechecked_live_before_payload_staging() {
         Some("build-linux-repository"),
     );
     assert!(payloads.contains("needs: [prepare-plan, verify-downstream-authority]"));
+    let linux_repository = job(
+        DOWNSTREAM,
+        "build-linux-repository",
+        Some("publish-homebrew-tap"),
+    );
+    assert!(linux_repository.contains("attestations: write"));
+    assert!(linux_repository.contains("id-token: write"));
 }
 
 #[test]


### PR DESCRIPTION
The receipt workflow could not compile because the reusable Linux repository builder requests OIDC and attestation permissions that its caller did not delegate.

This change grants only those two permissions at the existing reusable-workflow boundary and adds a regression assertion to the release workflow contract test.

Validation:
- `cargo test --locked --test release_downstream_workflows_spec`
- `python3 scripts/release/validate-contracts.py`
- `git diff --check`