### PR TITLE
fix(release): recover receipts from protected main

### DIFF
--- a/.github/actions/release-channel-prepare/action.yml
+++ b/.github/actions/release-channel-prepare/action.yml
@@ -98,29 +98,33 @@ runs:
         set -euo pipefail
         scripts/release/assert-release-capability.py downstream_channels
         mode=(--allow-running-current-run)
+        artifact_source_sha="$GITHUB_SHA"
+        artifact_head_branch="$GITHUB_REF_NAME"
         if [ "$RMUX_RECEIPT_RUN_LIFECYCLE" = completed-failure ]; then
           mode=(--allow-completed-failed-run)
+          artifact_source_sha="$RMUX_SOURCE_SHA"
+          artifact_head_branch="$RMUX_RELEASE_REF"
         fi
         scripts/release/actions-artifact.py verify \
           --repository "$GITHUB_REPOSITORY" --run-id "$RMUX_RECEIPT_RUN_ID" \
           --artifact-id "$RMUX_PLAN_ARTIFACT_ID" \
           --name "rmux-downstream-plan-$RMUX_SOURCE_SHA-$RMUX_RELEASE_ID" \
-          --expected-source-sha "$RMUX_SOURCE_SHA" \
+          --expected-source-sha "$artifact_source_sha" \
           --expected-digest "$RMUX_PLAN_ARTIFACT_DIGEST" \
           --expected-workflow-id 316435347 \
           --expected-workflow-path .github/workflows/release-receipt.yml \
-          --expected-event workflow_dispatch --expected-head-branch "$RMUX_RELEASE_REF" \
+          --expected-event workflow_dispatch --expected-head-branch "$artifact_head_branch" \
           "${mode[@]}" \
           --max-attempts 1
         scripts/release/actions-artifact.py verify \
           --repository "$GITHUB_REPOSITORY" --run-id "$RMUX_RECEIPT_RUN_ID" \
           --artifact-id "$RMUX_PAYLOAD_ARTIFACT_ID" \
           --name "rmux-downstream-$RMUX_CHANNEL-payload-$RMUX_SOURCE_SHA-$RMUX_RELEASE_ID" \
-          --expected-source-sha "$RMUX_SOURCE_SHA" \
+          --expected-source-sha "$artifact_source_sha" \
           --expected-digest "$RMUX_PAYLOAD_ARTIFACT_DIGEST" \
           --expected-workflow-id 316435347 \
           --expected-workflow-path .github/workflows/release-receipt.yml \
-          --expected-event workflow_dispatch --expected-head-branch "$RMUX_RELEASE_REF" \
+          --expected-event workflow_dispatch --expected-head-branch "$artifact_head_branch" \
           "${mode[@]}" \
           --max-attempts 1
 
@@ -134,11 +138,11 @@ runs:
         --repository "$GITHUB_REPOSITORY" --run-id "${{ inputs.receipt-run-id }}"
         --artifact-id "${{ inputs.pre-site-summary-artifact-id }}"
         --name "rmux-downstream-pre-site-summary-${{ inputs.source-sha }}-${{ inputs.release-id }}"
-        --expected-source-sha "${{ inputs.source-sha }}"
+        --expected-source-sha "$GITHUB_SHA"
         --expected-digest "${{ inputs.pre-site-summary-artifact-digest }}"
         --expected-workflow-id 316435347
         --expected-workflow-path .github/workflows/release-receipt.yml
-        --expected-event workflow_dispatch --expected-head-branch "${{ inputs.release-ref }}"
+        --expected-event workflow_dispatch --expected-head-branch "$GITHUB_REF_NAME"
         --allow-running-current-run --max-attempts 1
 
     - name: Download only the exact plan artifact ID
@@ -199,19 +203,26 @@ runs:
       run: |
         set -euo pipefail
         root="${{ steps.paths.outputs.root }}"
+        artifact_source_sha="$GITHUB_SHA"
+        artifact_source_ref="$GITHUB_REF"
+        if [ "$RMUX_RECEIPT_RUN_LIFECYCLE" = completed-failure ]; then
+          artifact_source_sha="$RMUX_SOURCE_SHA"
+          artifact_source_ref="refs/tags/${{ inputs.release-ref }}"
+        fi
         scripts/release/actions-artifact.py resolve-id \
           --repository "$GITHUB_REPOSITORY" --run-id "$RMUX_RECEIPT_RUN_ID" \
           --artifact-id "$RMUX_PAYLOAD_ARTIFACT_ID" \
           --name "rmux-downstream-$RMUX_CHANNEL-payload-$RMUX_SOURCE_SHA-${{ inputs.release-id }}" \
-          --expected-source-sha "$RMUX_SOURCE_SHA" --max-attempts 1 \
+          --expected-source-sha "$artifact_source_sha" --max-attempts 1 \
           --include-retention > "$root/payload-artifact.json"
         producer_run_id="$GITHUB_RUN_ID"
         if [ "$RMUX_RECEIPT_RUN_LIFECYCLE" = completed-failure ]; then
           producer_run_id="$RMUX_RECEIPT_RUN_ID"
         fi
-        python3 - "$producer_run_id" "$RMUX_CHANNEL" "$root/producer.json" <<'PY'
+        python3 - "$producer_run_id" "$RMUX_CHANNEL" "$artifact_source_sha" \
+          "$artifact_source_ref" "$root/producer.json" <<'PY'
         import json, pathlib, sys
-        run_id, channel, output_path = sys.argv[1:]
+        run_id, channel, head_sha, source_ref, output_path = sys.argv[1:]
         job_workflow_path = (
             ".github/workflows/release-rmux-io-payload.yml"
             if channel == "rmux_io"
@@ -223,6 +234,8 @@ runs:
             "workflow_id": 316435347,
             "workflow_path": ".github/workflows/release-receipt.yml",
             "job_workflow_path": job_workflow_path,
+            "head_sha": head_sha,
+            "source_ref": source_ref,
             "runner_group_id": 0,
             "runner_group_name": "GitHub Actions",
             "runner_image": "ubuntu-22.04",

--- a/.github/actions/release-channel-result/action.yml
+++ b/.github/actions/release-channel-result/action.yml
@@ -58,8 +58,8 @@ runs:
         test -f "$root/plan/receipt-reference.json"
         test -f "$RMUX_TARGET_EVIDENCE"
         [[ "$RMUX_PRODUCER_WORKFLOW_ID" =~ ^[1-9][0-9]*$ ]]
-        producer_head_sha="${RMUX_PRODUCER_HEAD_SHA:-${{ inputs.source-sha }}}"
-        producer_source_ref="${RMUX_PRODUCER_SOURCE_REF:-refs/tags/${{ inputs.release-ref }}}"
+        producer_head_sha="${RMUX_PRODUCER_HEAD_SHA:-$GITHUB_SHA}"
+        producer_source_ref="${RMUX_PRODUCER_SOURCE_REF:-$GITHUB_REF}"
         attestation_signer="${RMUX_ATTESTATION_SIGNER_WORKFLOW_PATH:-$RMUX_PRODUCER_WORKFLOW_PATH}"
         [[ "$producer_head_sha" =~ ^[0-9a-f]{40}$ ]]
         [[ "$producer_source_ref" =~ ^refs/(heads|tags)/[A-Za-z0-9._/-]+$ ]]
@@ -68,9 +68,9 @@ runs:
           test -n "$RMUX_PRODUCER_HEAD_SHA"
           test -n "$RMUX_PRODUCER_SOURCE_REF"
           test -n "$RMUX_ATTESTATION_SIGNER_WORKFLOW_PATH"
-          test "$GITHUB_SHA" = "$producer_head_sha"
-          test "$GITHUB_REF" = "$producer_source_ref"
         fi
+        test "$GITHUB_SHA" = "$producer_head_sha"
+        test "$GITHUB_REF" = "$producer_source_ref"
         python3 - "$GITHUB_RUN_ID" "$RMUX_PRODUCER_WORKFLOW_ID" \
           "$RMUX_PRODUCER_WORKFLOW_PATH" "$RMUX_RUNNER_IMAGE" \
           "$root/result-producer.json" <<'PY'

--- a/.github/actions/release-downstream-authority-proof/action.yml
+++ b/.github/actions/release-downstream-authority-proof/action.yml
@@ -38,7 +38,6 @@ runs:
         test "$GITHUB_REPOSITORY" = "Helvesec/rmux"
         test "$GITHUB_REPOSITORY_ID" = "1239918790"
         test "$GITHUB_RUN_ATTEMPT" = 1
-        test "$GITHUB_SHA" = "$RMUX_EXPECTED_SOURCE_SHA"
         for value in "$RMUX_DOWNSTREAM_AUDIT_RUN_ID" "$RMUX_DOWNSTREAM_AUDIT_WORKFLOW_ID" "$RMUX_DOWNSTREAM_AUDIT_ARTIFACT_ID"; do
           [[ "$value" =~ ^[1-9][0-9]*$ ]]
         done
@@ -46,7 +45,11 @@ runs:
         [[ "$RMUX_DOWNSTREAM_AUDIT_ARTIFACT_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]
         [[ "$RMUX_EXPECTED_SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]
         [[ "$RMUX_RELEASE_REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$ ]]
-        test "$GITHUB_REF" = "refs/tags/$RMUX_RELEASE_REF"
+        if [ "$GITHUB_SHA" = "$RMUX_EXPECTED_SOURCE_SHA" ]; then
+          test "$GITHUB_REF" = "refs/tags/$RMUX_RELEASE_REF"
+        else
+          test "$GITHUB_REF" = refs/heads/main
+        fi
 
     - name: Verify exact downstream authority artifact identity
       shell: bash
@@ -59,12 +62,12 @@ runs:
           --run-id "${{ inputs.audit-run-id }}" \
           --artifact-id "${{ inputs.audit-artifact-id }}" \
           --name "rmux-downstream-authority-${{ inputs.expected-source-sha }}-${{ inputs.audit-run-id }}" \
-          --expected-source-sha "${{ inputs.expected-source-sha }}" \
+          --expected-source-sha "$GITHUB_SHA" \
           --expected-digest "${{ inputs.audit-artifact-digest }}" \
           --expected-workflow-id "${{ inputs.audit-workflow-id }}" \
           --expected-workflow-path .github/workflows/release-receipt.yml \
           --expected-event workflow_dispatch \
-          --expected-head-branch "${{ inputs.release-ref }}" \
+          --expected-head-branch "$GITHUB_REF_NAME" \
           --allow-running-current-run --max-attempts 1
 
     - name: Download only the exact downstream authority artifact ID

--- a/.github/release/candidate-contract.json
+++ b/.github/release/candidate-contract.json
@@ -517,6 +517,7 @@
     "scripts/release/publish-github-release.py",
     "scripts/release/publish-linux-repository.py",
     "scripts/release/publish-owned-repository.py",
+    "scripts/release/receipt-recovery.py",
     "scripts/release/release-tag-message.py",
     "scripts/release/release_authority.py",
     "scripts/release/release_evidence.py",

--- a/.github/release/schemas/downstream-channel-payload.schema.json
+++ b/.github/release/schemas/downstream-channel-payload.schema.json
@@ -99,6 +99,8 @@
         "workflow_id": {"const": 316435347},
         "workflow_path": {"const": ".github/workflows/release-receipt.yml"},
         "job_workflow_path": {"const": ".github/workflows/release-downstream-prepare.yml"},
+        "head_sha": {"$ref": "#/$defs/sha40"},
+        "source_ref": {"type": "string", "pattern": "^refs/(?:heads|tags)/[A-Za-z0-9._/-]+$"},
         "runner_group_id": {"const": 0},
         "runner_group_name": {"const": "GitHub Actions"},
         "runner_image": {"enum": ["ubuntu-22.04", "windows-latest"]}

--- a/.github/release/schemas/downstream-channel-plan.schema.json
+++ b/.github/release/schemas/downstream-channel-plan.schema.json
@@ -188,6 +188,7 @@
         "run_attempt": {"const": 1},
         "workflow_id": {"$ref": "#/$defs/positive"},
         "workflow_path": {"const": ".github/workflows/release-receipt.yml"},
+        "recovery": {"type": "object", "additionalProperties": false, "required": ["failed_run_id", "failed_conclusion", "control_sha", "control_ref"], "properties": {"failed_run_id": {"$ref": "#/$defs/positive"}, "failed_conclusion": {"const": "startup_failure"}, "control_sha": {"$ref": "#/$defs/sha40"}, "control_ref": {"const": "refs/heads/main"}}},
         "predicate_bundle": {"$ref": "#/$defs/receipt_predicate_artifact"},
         "predicate_sha256": {"$ref": "#/$defs/sha256"},
         "envelope_bundle": {"$ref": "#/$defs/receipt_envelope_artifact"},

--- a/.github/release/schemas/downstream-channel-request.schema.json
+++ b/.github/release/schemas/downstream-channel-request.schema.json
@@ -213,6 +213,7 @@
         "run_attempt": {"const": 1},
         "workflow_id": {"$ref": "#/$defs/positive"},
         "workflow_path": {"const": ".github/workflows/release-receipt.yml"},
+        "recovery": {"type": "object", "additionalProperties": false, "required": ["failed_run_id", "failed_conclusion", "control_sha", "control_ref"], "properties": {"failed_run_id": {"$ref": "#/$defs/positive"}, "failed_conclusion": {"const": "startup_failure"}, "control_sha": {"$ref": "#/$defs/sha40"}, "control_ref": {"const": "refs/heads/main"}}},
         "predicate_bundle": {"$ref": "#/$defs/receipt_predicate_artifact"},
         "predicate_sha256": {"$ref": "#/$defs/sha256"},
         "envelope_bundle": {"$ref": "#/$defs/receipt_envelope_artifact"},

--- a/.github/release/schemas/downstream-channel-result-predicate.schema.json
+++ b/.github/release/schemas/downstream-channel-result-predicate.schema.json
@@ -137,6 +137,7 @@
         "run_attempt": {"const": 1},
         "workflow_id": {"$ref": "#/$defs/positive"},
         "workflow_path": {"const": ".github/workflows/release-receipt.yml"},
+        "recovery": {"type": "object", "additionalProperties": false, "required": ["failed_run_id", "failed_conclusion", "control_sha", "control_ref"], "properties": {"failed_run_id": {"$ref": "#/$defs/positive"}, "failed_conclusion": {"const": "startup_failure"}, "control_sha": {"$ref": "#/$defs/sha40"}, "control_ref": {"const": "refs/heads/main"}}},
         "predicate_bundle": {"$ref": "#/$defs/receipt_predicate_artifact"},
         "predicate_sha256": {"$ref": "#/$defs/sha256"},
         "envelope_bundle": {"$ref": "#/$defs/receipt_envelope_artifact"},

--- a/.github/release/schemas/downstream-channel-result-reference.schema.json
+++ b/.github/release/schemas/downstream-channel-result-reference.schema.json
@@ -141,6 +141,7 @@
         "run_attempt": {"const": 1},
         "workflow_id": {"$ref": "#/$defs/positive"},
         "workflow_path": {"const": ".github/workflows/release-receipt.yml"},
+        "recovery": {"type": "object", "additionalProperties": false, "required": ["failed_run_id", "failed_conclusion", "control_sha", "control_ref"], "properties": {"failed_run_id": {"$ref": "#/$defs/positive"}, "failed_conclusion": {"const": "startup_failure"}, "control_sha": {"$ref": "#/$defs/sha40"}, "control_ref": {"const": "refs/heads/main"}}},
         "predicate_bundle": {"$ref": "#/$defs/receipt_predicate_artifact"},
         "predicate_sha256": {"$ref": "#/$defs/sha256"},
         "envelope_bundle": {"$ref": "#/$defs/receipt_envelope_artifact"},

--- a/.github/release/schemas/downstream-channel-summary.schema.json
+++ b/.github/release/schemas/downstream-channel-summary.schema.json
@@ -186,6 +186,7 @@
         "run_attempt": {"const": 1},
         "workflow_id": {"$ref": "#/$defs/positive"},
         "workflow_path": {"const": ".github/workflows/release-receipt.yml"},
+        "recovery": {"type": "object", "additionalProperties": false, "required": ["failed_run_id", "failed_conclusion", "control_sha", "control_ref"], "properties": {"failed_run_id": {"$ref": "#/$defs/positive"}, "failed_conclusion": {"const": "startup_failure"}, "control_sha": {"$ref": "#/$defs/sha40"}, "control_ref": {"const": "refs/heads/main"}}},
         "predicate_bundle": {"$ref": "#/$defs/receipt_predicate_artifact"},
         "predicate_sha256": {"$ref": "#/$defs/sha256"},
         "envelope_bundle": {"$ref": "#/$defs/receipt_envelope_artifact"},

--- a/.github/release/schemas/publication-receipt-envelope.schema.json
+++ b/.github/release/schemas/publication-receipt-envelope.schema.json
@@ -40,7 +40,18 @@
         "run_id": {"type": "integer", "minimum": 1},
         "run_attempt": {"const": 1},
         "workflow_id": {"type": "integer", "minimum": 1},
-        "workflow_path": {"const": ".github/workflows/release-receipt.yml"}
+        "workflow_path": {"const": ".github/workflows/release-receipt.yml"},
+        "recovery": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["failed_run_id", "failed_conclusion", "control_sha", "control_ref"],
+          "properties": {
+            "failed_run_id": {"type": "integer", "minimum": 1},
+            "failed_conclusion": {"const": "startup_failure"},
+            "control_sha": {"$ref": "#/$defs/sha40"},
+            "control_ref": {"const": "refs/heads/main"}
+          }
+        }
       }
     },
     "predicate_sha256": {"$ref": "#/$defs/sha256"},

--- a/.github/release/schemas/publication-receipt-predicate.schema.json
+++ b/.github/release/schemas/publication-receipt-predicate.schema.json
@@ -190,7 +190,19 @@
         "run_id": {"$ref": "#/$defs/positive"},
         "run_attempt": {"const": 1},
         "workflow_id": {"$ref": "#/$defs/positive"},
-        "workflow_path": {"const": ".github/workflows/release-receipt.yml"}
+        "workflow_path": {"const": ".github/workflows/release-receipt.yml"},
+        "recovery": {"$ref": "#/$defs/receipt_recovery"}
+      }
+    },
+    "receipt_recovery": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["failed_run_id", "failed_conclusion", "control_sha", "control_ref"],
+      "properties": {
+        "failed_run_id": {"$ref": "#/$defs/positive"},
+        "failed_conclusion": {"const": "startup_failure"},
+        "control_sha": {"$ref": "#/$defs/sha40"},
+        "control_ref": {"const": "refs/heads/main"}
       }
     }
   }

--- a/.github/workflows/release-channel-summary.yml
+++ b/.github/workflows/release-channel-summary.yml
@@ -37,7 +37,6 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ inputs.expected_source_sha }}
           persist-credentials: false
 
       - id: paths
@@ -87,11 +86,11 @@ jobs:
             --repository "$GITHUB_REPOSITORY" --run-id "${{ inputs.receipt_run_id }}" \
             --artifact-id "${{ inputs.plan_artifact_id }}" \
             --name "rmux-downstream-plan-${{ inputs.expected_source_sha }}-${{ inputs.release_id }}" \
-            --expected-source-sha "${{ inputs.expected_source_sha }}" \
+            --expected-source-sha "$GITHUB_SHA" \
             --expected-digest "${{ inputs.plan_artifact_digest }}" \
             --expected-workflow-id 316435347 \
             --expected-workflow-path .github/workflows/release-receipt.yml \
-            --expected-event workflow_dispatch --expected-head-branch "${{ inputs.release_ref }}" \
+            --expected-event workflow_dispatch --expected-head-branch "$GITHUB_REF_NAME" \
             --allow-running-current-run --max-attempts 1
 
       - name: Download only the exact plan artifact ID
@@ -125,7 +124,7 @@ jobs:
             for attempt in 1 2 3 4 5 6; do
               if scripts/release/actions-artifact.py resolve \
                 --repository "$GITHUB_REPOSITORY" --run-id "${{ inputs.receipt_run_id }}" \
-                --name "$name" --expected-source-sha "${{ inputs.expected_source_sha }}" \
+                --name "$name" --expected-source-sha "$GITHUB_SHA" \
                 > "$metadata"; then
                 break
               fi
@@ -155,11 +154,11 @@ jobs:
           --repository "$GITHUB_REPOSITORY" --run-id "${{ inputs.receipt_run_id }}"
           --artifact-id "${{ inputs.pre_site_artifact_id }}"
           --name "rmux-downstream-pre-site-summary-${{ inputs.expected_source_sha }}-${{ inputs.release_id }}"
-          --expected-source-sha "${{ inputs.expected_source_sha }}"
+          --expected-source-sha "$GITHUB_SHA"
           --expected-digest "${{ inputs.pre_site_artifact_digest }}"
           --expected-workflow-id 316435347
           --expected-workflow-path .github/workflows/release-receipt.yml
-          --expected-event workflow_dispatch --expected-head-branch "${{ inputs.release_ref }}"
+          --expected-event workflow_dispatch --expected-head-branch "$GITHUB_REF_NAME"
           --allow-running-current-run --max-attempts 1
 
       - name: Download only the exact pre-site summary artifact ID

--- a/.github/workflows/release-chocolatey-channel.yml
+++ b/.github/workflows/release-chocolatey-channel.yml
@@ -34,7 +34,6 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ inputs.expected_source_sha }}
           persist-credentials: false
 
       - id: prepare

--- a/.github/workflows/release-crates-channel.yml
+++ b/.github/workflows/release-crates-channel.yml
@@ -31,7 +31,6 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ inputs.expected_source_sha }}
           persist-credentials: false
 
       - id: prepare

--- a/.github/workflows/release-downstream-prepare.yml
+++ b/.github/workflows/release-downstream-prepare.yml
@@ -55,7 +55,6 @@ jobs:
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ inputs.expected_source_sha }}
           persist-credentials: false
 
       - name: Verify exact plan artifact identity
@@ -67,11 +66,11 @@ jobs:
             --repository "$GITHUB_REPOSITORY" --run-id "$RMUX_RECEIPT_RUN_ID" \
             --artifact-id "$RMUX_PLAN_ARTIFACT_ID" \
             --name "rmux-downstream-plan-$RMUX_EXPECTED_SOURCE_SHA-$RMUX_RELEASE_ID" \
-            --expected-source-sha "$RMUX_EXPECTED_SOURCE_SHA" \
+            --expected-source-sha "$GITHUB_SHA" \
             --expected-digest "$RMUX_PLAN_ARTIFACT_DIGEST" \
             --expected-workflow-id 316435347 \
             --expected-workflow-path .github/workflows/release-receipt.yml \
-            --expected-event workflow_dispatch --expected-head-branch "$RMUX_RELEASE_REF" \
+            --expected-event workflow_dispatch --expected-head-branch "$GITHUB_REF_NAME" \
             --allow-running-current-run \
             --max-attempts 1
 

--- a/.github/workflows/release-downstream.yml
+++ b/.github/workflows/release-downstream.yml
@@ -82,7 +82,6 @@ jobs:
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ inputs.expected_source_sha }}
           persist-credentials: false
 
       - name: Verify exact receipt artifacts and producer run
@@ -96,21 +95,21 @@ jobs:
             --repository "$GITHUB_REPOSITORY" --run-id "$RMUX_RECEIPT_RUN_ID" \
             --artifact-id "$RMUX_RECEIPT_ARTIFACT_ID" \
             --name "rmux-publication-receipt-$RMUX_EXPECTED_SOURCE_SHA-$RMUX_RELEASE_ID" \
-            --expected-source-sha "$RMUX_EXPECTED_SOURCE_SHA" \
+            --expected-source-sha "$GITHUB_SHA" \
             --expected-digest "$RMUX_RECEIPT_ARTIFACT_DIGEST" \
             --expected-workflow-id "$RMUX_RECEIPT_RUN_WORKFLOW_ID" \
             --expected-workflow-path .github/workflows/release-receipt.yml \
-            --expected-event workflow_dispatch --expected-head-branch "$RMUX_RELEASE_REF" \
+            --expected-event workflow_dispatch --expected-head-branch "$GITHUB_REF_NAME" \
             --allow-running-current-run --max-attempts 1 > "$root/receipt-artifact.json"
           python3 scripts/release/actions-artifact.py verify \
             --repository "$GITHUB_REPOSITORY" --run-id "$RMUX_RECEIPT_RUN_ID" \
             --artifact-id "$RMUX_RECEIPT_ENVELOPE_ARTIFACT_ID" \
             --name "rmux-publication-receipt-envelope-$RMUX_EXPECTED_SOURCE_SHA-$RMUX_RELEASE_ID" \
-            --expected-source-sha "$RMUX_EXPECTED_SOURCE_SHA" \
+            --expected-source-sha "$GITHUB_SHA" \
             --expected-digest "$RMUX_RECEIPT_ENVELOPE_ARTIFACT_DIGEST" \
             --expected-workflow-id "$RMUX_RECEIPT_RUN_WORKFLOW_ID" \
             --expected-workflow-path .github/workflows/release-receipt.yml \
-            --expected-event workflow_dispatch --expected-head-branch "$RMUX_RELEASE_REF" \
+            --expected-event workflow_dispatch --expected-head-branch "$GITHUB_REF_NAME" \
             --allow-running-current-run --max-attempts 1 > "$root/envelope-artifact.json"
 
       - name: Download only the exact receipt predicate bundle ID
@@ -154,6 +153,8 @@ jobs:
           --predicate "$RUNNER_TEMP/rmux-downstream/receipt/publication-receipt-predicate.json"
           --source-sha "$RMUX_EXPECTED_SOURCE_SHA"
           --release-ref "$RMUX_RELEASE_REF"
+          --producer-source-sha "$GITHUB_SHA"
+          --producer-source-ref "$GITHUB_REF"
 
       - name: Assert active downstream authority
         run: scripts/release/assert-release-capability.py downstream_channels
@@ -229,7 +230,6 @@ jobs:
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ inputs.expected_source_sha }}
           persist-credentials: false
 
       - name: Verify exact downstream repository authority proof

--- a/.github/workflows/release-linux-repository-build.yml
+++ b/.github/workflows/release-linux-repository-build.yml
@@ -103,11 +103,11 @@ jobs:
             --repository "$GITHUB_REPOSITORY" --run-id "$RMUX_RECEIPT_RUN_ID" \
             --artifact-id "$RMUX_PAYLOAD_ARTIFACT_ID" \
             --name "rmux-downstream-apt_rpm-payload-$RMUX_SOURCE_SHA-$RMUX_RELEASE_ID" \
-            --expected-source-sha "$RMUX_SOURCE_SHA" \
+            --expected-source-sha "$GITHUB_SHA" \
             --expected-digest "$RMUX_PAYLOAD_ARTIFACT_DIGEST" \
             --expected-workflow-id 316435347 \
             --expected-workflow-path .github/workflows/release-receipt.yml \
-            --expected-event workflow_dispatch --expected-head-branch "$RMUX_RELEASE_REF" \
+            --expected-event workflow_dispatch --expected-head-branch "$GITHUB_REF_NAME" \
             --allow-running-current-run --max-attempts 1
 
       - id: recovery
@@ -127,7 +127,6 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         if: github.run_id == inputs.receipt_run_id
         with:
-          ref: ${{ inputs.expected_source_sha }}
           persist-credentials: false
 
       - name: Download only the exact APT/RPM payload artifact ID

--- a/.github/workflows/release-linux-repository-publish.yml
+++ b/.github/workflows/release-linux-repository-publish.yml
@@ -82,7 +82,6 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         if: inputs.recovery_mode == false
         with:
-          ref: ${{ inputs.expected_source_sha }}
           persist-credentials: false
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -131,11 +130,11 @@ jobs:
           --repository "$GITHUB_REPOSITORY" --run-id "${{ inputs.receipt_run_id }}"
           --artifact-id "${{ inputs.repository_artifact_id }}"
           --name "rmux-downstream-apt_rpm-signed-${{ inputs.expected_source_sha }}-${{ inputs.release_id }}"
-          --expected-source-sha "${{ inputs.expected_source_sha }}"
+          --expected-source-sha "$GITHUB_SHA"
           --expected-digest "${{ inputs.repository_artifact_digest }}"
           --expected-workflow-id 316435347
           --expected-workflow-path .github/workflows/release-receipt.yml
-          --expected-event workflow_dispatch --expected-head-branch "${{ inputs.release_ref }}"
+          --expected-event workflow_dispatch --expected-head-branch "$GITHUB_REF_NAME"
           --allow-running-current-run --max-attempts 1
 
       - id: signer

--- a/.github/workflows/release-owned-repository-channel.yml
+++ b/.github/workflows/release-owned-repository-channel.yml
@@ -35,7 +35,6 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ inputs.expected_source_sha }}
           persist-credentials: false
 
       - id: prepare

--- a/.github/workflows/release-policy-channel.yml
+++ b/.github/workflows/release-policy-channel.yml
@@ -31,7 +31,6 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ inputs.expected_source_sha }}
           persist-credentials: false
 
       - id: prepare

--- a/.github/workflows/release-receipt.yml
+++ b/.github/workflows/release-receipt.yml
@@ -17,6 +17,10 @@ on:
         type: choice
         options: [rc, stable]
       receipt_workflow_id: {required: true, type: string}
+      failed_receipt_run_id:
+        required: false
+        type: string
+        default: ""
       snap_candidate_opt_in:
         required: false
         type: boolean
@@ -57,6 +61,7 @@ jobs:
       RMUX_RELEASE_REF: ${{ inputs.release_ref }}
       RMUX_RELEASE_KIND: ${{ inputs.release_kind }}
       RMUX_RECEIPT_WORKFLOW_ID: ${{ inputs.receipt_workflow_id }}
+      RMUX_FAILED_RECEIPT_RUN_ID: ${{ inputs.failed_receipt_run_id }}
     steps:
       - name: Reject malformed receipt inputs
         shell: bash
@@ -76,11 +81,31 @@ jobs:
             [[ "$RMUX_RELEASE_REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
           fi
           test "$GITHUB_RUN_ATTEMPT" = 1
+          if [ -n "$RMUX_FAILED_RECEIPT_RUN_ID" ]; then
+            [[ "$RMUX_FAILED_RECEIPT_RUN_ID" =~ ^[1-9][0-9]*$ ]]
+            test "$GITHUB_REF" = refs/heads/main
+            test "$GITHUB_SHA" != "$RMUX_EXPECTED_SOURCE_SHA"
+          else
+            test "$GITHUB_SHA" = "$RMUX_EXPECTED_SOURCE_SHA"
+            test "$GITHUB_REF" = "refs/tags/$RMUX_RELEASE_REF"
+          fi
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ inputs.expected_source_sha }}
           persist-credentials: false
+
+      - name: Verify exact failed receipt before protected-main recovery
+        if: inputs.failed_receipt_run_id != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          scripts/release/receipt-recovery.py
+          --failed-run-id "$RMUX_FAILED_RECEIPT_RUN_ID"
+          --current-run-id "$GITHUB_RUN_ID"
+          --control-sha "$GITHUB_SHA"
+          --source-sha "$RMUX_EXPECTED_SOURCE_SHA"
+          --release-id "$RMUX_RELEASE_ID"
+          --release-ref "$RMUX_RELEASE_REF"
 
       - name: Fail closed before receipt attestation
         run: scripts/release/assert-release-capability.py publication_receipt
@@ -311,6 +336,13 @@ jobs:
             --receipt-workflow-id "$RMUX_RECEIPT_WORKFLOW_ID"
             --verified-at "${{ steps.identity.outputs.verified_at }}"
           )
+          if [ -n "$RMUX_FAILED_RECEIPT_RUN_ID" ]; then
+            common+=(
+              --recovered-from-run-id "$RMUX_FAILED_RECEIPT_RUN_ID"
+              --recovery-control-sha "$GITHUB_SHA"
+              --recovery-control-ref "$GITHUB_REF"
+            )
+          fi
           python3 scripts/release/publication-receipt.py create-predicate \
             "${common[@]}" --output "$root/publication-receipt-predicate.json"
           python3 scripts/release/publication-receipt.py verify-predicate \
@@ -353,7 +385,7 @@ jobs:
             --repository "$GITHUB_REPOSITORY" --run-id "$GITHUB_RUN_ID" \
             --artifact-id "${{ steps.receipt-upload.outputs.artifact-id }}" \
             --name "rmux-publication-receipt-${{ inputs.expected_source_sha }}-${{ inputs.release_id }}" \
-            --expected-source-sha "$RMUX_EXPECTED_SOURCE_SHA" --max-attempts 6 \
+            --expected-source-sha "$GITHUB_SHA" --max-attempts 6 \
             --retry-delay-seconds 2 > "$RUNNER_TEMP/rmux-receipt/artifact.json"
           python3 - "$RUNNER_TEMP/rmux-receipt/artifact.json" "$GITHUB_OUTPUT" <<'PY'
           import json, pathlib, sys
@@ -428,6 +460,7 @@ jobs:
       artifact_digest: ${{ steps.audit.outputs.artifact-digest }}
     env:
       RMUX_EXPECTED_SOURCE_SHA: ${{ inputs.expected_source_sha }}
+      RMUX_FAILED_RECEIPT_RUN_ID: ${{ inputs.failed_receipt_run_id }}
     steps:
       - name: Reject malformed or stale audit identity
         shell: bash
@@ -436,13 +469,16 @@ jobs:
           test "$GITHUB_REPOSITORY" = "Helvesec/rmux"
           test "$GITHUB_REPOSITORY_ID" = "1239918790"
           test "$GITHUB_RUN_ATTEMPT" = 1
-          test "$GITHUB_SHA" = "$RMUX_EXPECTED_SOURCE_SHA"
           [[ "$RMUX_EXPECTED_SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]
-          [[ "$GITHUB_REF" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$ ]]
+          if [ -n "$RMUX_FAILED_RECEIPT_RUN_ID" ]; then
+            test "$GITHUB_REF" = refs/heads/main
+          else
+            test "$GITHUB_SHA" = "$RMUX_EXPECTED_SOURCE_SHA"
+            [[ "$GITHUB_REF" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$ ]]
+          fi
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ inputs.expected_source_sha }}
           persist-credentials: false
 
       - id: audit

--- a/.github/workflows/release-rmux-io-channel.yml
+++ b/.github/workflows/release-rmux-io-channel.yml
@@ -32,7 +32,6 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ inputs.expected_source_sha }}
           persist-credentials: false
 
       - id: prepare

--- a/.github/workflows/release-rmux-io-payload.yml
+++ b/.github/workflows/release-rmux-io-payload.yml
@@ -33,7 +33,6 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ inputs.expected_source_sha }}
           persist-credentials: false
 
       - name: Verify exact plan and pre-site summary artifacts
@@ -50,21 +49,21 @@ jobs:
             --repository "$GITHUB_REPOSITORY" --run-id "${{ inputs.receipt_run_id }}" \
             --artifact-id "${{ inputs.plan_artifact_id }}" \
             --name "rmux-downstream-plan-${{ inputs.expected_source_sha }}-${{ inputs.release_id }}" \
-            --expected-source-sha "${{ inputs.expected_source_sha }}" \
+            --expected-source-sha "$GITHUB_SHA" \
             --expected-digest "${{ inputs.plan_artifact_digest }}" \
             --expected-workflow-id 316435347 \
             --expected-workflow-path .github/workflows/release-receipt.yml \
-            --expected-event workflow_dispatch --expected-head-branch "${{ inputs.release_ref }}" \
+            --expected-event workflow_dispatch --expected-head-branch "$GITHUB_REF_NAME" \
             --allow-running-current-run --max-attempts 1
           scripts/release/actions-artifact.py verify \
             --repository "$GITHUB_REPOSITORY" --run-id "${{ inputs.receipt_run_id }}" \
             --artifact-id "${{ inputs.pre_site_artifact_id }}" \
             --name "rmux-downstream-pre-site-summary-${{ inputs.expected_source_sha }}-${{ inputs.release_id }}" \
-            --expected-source-sha "${{ inputs.expected_source_sha }}" \
+            --expected-source-sha "$GITHUB_SHA" \
             --expected-digest "${{ inputs.pre_site_artifact_digest }}" \
             --expected-workflow-id 316435347 \
             --expected-workflow-path .github/workflows/release-receipt.yml \
-            --expected-event workflow_dispatch --expected-head-branch "${{ inputs.release_ref }}" \
+            --expected-event workflow_dispatch --expected-head-branch "$GITHUB_REF_NAME" \
             --allow-running-current-run --max-attempts 1
 
       - name: Download only the exact plan artifact ID

--- a/.github/workflows/release-snap-channel.yml
+++ b/.github/workflows/release-snap-channel.yml
@@ -34,7 +34,6 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ inputs.expected_source_sha }}
           persist-credentials: false
 
       - id: prepare

--- a/scripts/release/build-downstream-receipt-reference.py
+++ b/scripts/release/build-downstream-receipt-reference.py
@@ -116,7 +116,11 @@ def build(args: argparse.Namespace) -> None:
         or predicate.get("downstream_authority") is not True
         or predicate.get("repository_id") != REPOSITORY_ID
         or predicate.get("source_git_sha") != args.source_sha
-        or receipt != expected_receipt
+        or not isinstance(receipt, dict)
+        or any(
+            receipt.get(field) != wanted for field, wanted in expected_receipt.items()
+        )
+        or set(receipt) - set(expected_receipt) - {"recovery"}
         or not isinstance(release, dict)
     ):
         raise ValueError("publication receipt predicate identity differs")

--- a/scripts/release/downstream_channels.py
+++ b/scripts/release/downstream_channels.py
@@ -192,28 +192,38 @@ def validate_embedded_receipt(
 ) -> dict[str, Any]:
     if not isinstance(value, dict):
         raise ValueError("embedded receipt must be an object")
-    exact_keys(
-        value,
-        {
-            "run_id",
-            "run_attempt",
-            "workflow_id",
-            "workflow_path",
-            "predicate_bundle",
-            "predicate_sha256",
-            "envelope_bundle",
-            "envelope_sha256",
-            "attestation",
-            "verified_at",
-        },
-        "embedded receipt",
+    required = set(
+        "run_id run_attempt workflow_id workflow_path predicate_bundle predicate_sha256 "
+        "envelope_bundle envelope_sha256 attestation verified_at".split()
     )
+    optional = {"recovery"}
+    actual = set(value)
+    if not required <= actual or actual - required - optional:
+        raise ValueError("embedded receipt keys differ")
     positive(value["run_id"], "receipt run ID")
     positive(value["workflow_id"], "receipt workflow ID")
     if value["run_attempt"] != 1 or value["workflow_path"] != (
         ".github/workflows/release-receipt.yml"
     ):
         raise ValueError("receipt must be an attempt-1 release-receipt run")
+    recovery = value.get("recovery")
+    if recovery is not None:
+        if not isinstance(recovery, dict):
+            raise ValueError("receipt recovery identity must be an object")
+        exact_keys(
+            recovery,
+            {"failed_run_id", "failed_conclusion", "control_sha", "control_ref"},
+            "receipt recovery identity",
+        )
+        positive(recovery["failed_run_id"], "failed receipt run ID")
+        if (
+            recovery["failed_run_id"] == value["run_id"]
+            or recovery["failed_conclusion"] != "startup_failure"
+            or match(recovery["control_sha"], SHA40, "recovery control SHA")
+            != recovery["control_sha"]
+            or recovery["control_ref"] != "refs/heads/main"
+        ):
+            raise ValueError("receipt recovery identity changed")
     predicate = validate_artifact(value["predicate_bundle"], "receipt bundle")
     envelope = validate_artifact(value["envelope_bundle"], "receipt envelope")
     expected = f"rmux-publication-receipt-{source_sha}-{release['id']}"

--- a/scripts/release/downstream_payload.py
+++ b/scripts/release/downstream_payload.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import re
 import sys
 from pathlib import Path
 from typing import Any
@@ -13,6 +14,7 @@ from downstream_channels import (
     REPOSITORY_ID,
     RUNNER_IMAGES,
     SAFE_NAME,
+    SHA40,
     SHA256,
     canonical_hash,
     contract_channels,
@@ -37,6 +39,7 @@ PRODUCER_WORKFLOW_ID = 316435347
 PRODUCER_WORKFLOW_PATH = ".github/workflows/release-receipt.yml"
 DEFAULT_PRODUCER_JOB_WORKFLOW_PATH = ".github/workflows/release-downstream-prepare.yml"
 RMUX_IO_PRODUCER_JOB_WORKFLOW_PATH = ".github/workflows/release-rmux-io-payload.yml"
+SOURCE_REF = re.compile(r"refs/(?:heads|tags)/[A-Za-z0-9._/-]+")
 
 
 def payload_contract() -> dict[str, Any]:
@@ -71,20 +74,22 @@ def payload_contract() -> dict[str, Any]:
 def validate_producer(value: Any, channel: str) -> dict[str, Any]:
     if not isinstance(value, dict):
         raise ValueError("payload producer must be an object")
-    exact_keys(
-        value,
-        {
-            "run_id",
-            "run_attempt",
-            "workflow_id",
-            "workflow_path",
-            "job_workflow_path",
-            "runner_group_id",
-            "runner_group_name",
-            "runner_image",
-        },
-        "payload producer",
-    )
+    required = {
+        "run_id",
+        "run_attempt",
+        "workflow_id",
+        "workflow_path",
+        "job_workflow_path",
+        "runner_group_id",
+        "runner_group_name",
+        "runner_image",
+    }
+    optional = {"head_sha", "source_ref"}
+    actual = set(value)
+    if actual - required - optional or not required <= actual:
+        raise ValueError("payload producer keys differ")
+    if ("head_sha" in value) != ("source_ref" in value):
+        raise ValueError("payload producer Git source identity is incomplete")
     positive(value["run_id"], "payload producer run ID")
     expected_image = "ubuntu-22.04"
     expected_job_workflow_path = (
@@ -105,6 +110,13 @@ def validate_producer(value: Any, channel: str) -> dict[str, Any]:
         or value["runner_image"] != expected_image
     ):
         raise ValueError("payload producer is not the allowlisted GitHub-hosted job")
+    if "head_sha" in value and (
+        match(value["head_sha"], SHA40, "payload producer head SHA")
+        != value["head_sha"]
+        or not isinstance(value["source_ref"], str)
+        or SOURCE_REF.fullmatch(value["source_ref"]) is None
+    ):
+        raise ValueError("payload producer Git source identity changed")
     return value
 
 
@@ -455,9 +467,10 @@ def expected_documents(
     ):
         raise ValueError("payload producer differs from the exact receipt run")
     metadata = load_artifact_metadata(args.artifact_metadata)
+    producer_head_sha = producer.get("head_sha", reference["source_git_sha"])
     if (
         metadata["run_id"] != producer["run_id"]
-        or metadata["source_git_sha"] != reference["source_git_sha"]
+        or metadata["source_git_sha"] != producer_head_sha
     ):
         raise ValueError("payload artifact API identity differs from its producer")
     release = reference["release"]

--- a/scripts/release/publication-receipt.py
+++ b/scripts/release/publication-receipt.py
@@ -244,12 +244,33 @@ def receipt_identity(args: argparse.Namespace) -> dict[str, Any]:
     )
     if args.receipt_workflow_id != expected_id:
         raise ValueError("publication receipt workflow ID changed")
-    return {
+    identity = {
         "run_id": args.receipt_run_id,
         "run_attempt": 1,
         "workflow_id": args.receipt_workflow_id,
         "workflow_path": expected_path,
     }
+    recovery_values = (
+        args.recovered_from_run_id,
+        args.recovery_control_sha,
+        args.recovery_control_ref,
+    )
+    if any(value is not None for value in recovery_values):
+        if args.simulation or any(value is None for value in recovery_values):
+            raise ValueError("receipt recovery identity is incomplete")
+        positive_integer(args.recovered_from_run_id, "failed receipt run ID")
+        require_match(args.recovery_control_sha, SHA40, "recovery control SHA")
+        if args.recovery_control_ref != "refs/heads/main":
+            raise ValueError("receipt recovery must execute from protected main")
+        if args.recovered_from_run_id == args.receipt_run_id:
+            raise ValueError("receipt recovery must use a fresh run")
+        identity["recovery"] = {
+            "failed_run_id": args.recovered_from_run_id,
+            "failed_conclusion": "startup_failure",
+            "control_sha": args.recovery_control_sha,
+            "control_ref": args.recovery_control_ref,
+        }
+    return identity
 
 
 def expected_predicate(args: argparse.Namespace) -> dict[str, Any]:
@@ -459,6 +480,9 @@ def predicate_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--receipt-run-attempt", type=int, default=1)
     parser.add_argument("--receipt-workflow-id", type=int, required=True)
     parser.add_argument("--verified-at", required=True)
+    parser.add_argument("--recovered-from-run-id", type=int)
+    parser.add_argument("--recovery-control-sha")
+    parser.add_argument("--recovery-control-ref")
 
 
 def envelope_arguments(parser: argparse.ArgumentParser) -> None:

--- a/scripts/release/receipt-recovery.py
+++ b/scripts/release/receipt-recovery.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Authorize one receipt replay from protected main after a startup failure."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+from github_actions import gh_api, read_json
+
+REPOSITORY = "Helvesec/rmux"
+REPOSITORY_ID = 1239918790
+RECEIPT_WORKFLOW_ID = 316435347
+CI_WORKFLOW_ID = 277622540
+SHA40 = re.compile(r"[0-9a-f]{40}")
+RELEASE_REF = re.compile(r"v[0-9]+\.[0-9]+\.[0-9]+(?:-rc\.[0-9]+)?")
+ACTIVE = frozenset({"queued", "in_progress", "requested", "waiting", "pending"})
+
+
+def object_fixture(path: Path | None, endpoint: str) -> dict[str, Any]:
+    value = read_json(path) if path else gh_api(endpoint)
+    if not isinstance(value, dict):
+        raise ValueError(f"{endpoint} did not return one object")
+    return value
+
+
+def exact_repository(value: dict[str, Any], label: str) -> None:
+    if (
+        value.get("repository", {}).get("id") != REPOSITORY_ID
+        or value.get("head_repository", {}).get("id") != REPOSITORY_ID
+    ):
+        raise ValueError(f"{label} repository identity differs")
+
+
+def exact_run(value: dict[str, Any], expected: dict[str, Any], label: str) -> None:
+    for field, wanted in expected.items():
+        if value.get(field) != wanted:
+            raise ValueError(f"{label} {field} differs")
+    exact_repository(value, label)
+
+
+def empty_collection(value: dict[str, Any], field: str, label: str) -> None:
+    items = value.get(field)
+    if value.get("total_count") != 0 or items != []:
+        raise ValueError(f"{label} is not empty")
+
+
+def verify(args: argparse.Namespace) -> None:
+    if args.failed_run_id <= 0 or args.current_run_id <= 0 or args.release_id <= 0:
+        raise ValueError("run and release IDs must be positive")
+    if args.failed_run_id == args.current_run_id:
+        raise ValueError("recovery and failed receipt run IDs must differ")
+    if SHA40.fullmatch(args.control_sha) is None:
+        raise ValueError("recovery control SHA is invalid")
+    if SHA40.fullmatch(args.source_sha) is None or args.source_sha == args.control_sha:
+        raise ValueError("release source SHA is invalid or not distinct")
+    if RELEASE_REF.fullmatch(args.release_ref) is None:
+        raise ValueError("release ref is invalid")
+
+    failed = object_fixture(
+        args.failed_run_json,
+        f"repos/{REPOSITORY}/actions/runs/{args.failed_run_id}",
+    )
+    exact_run(
+        failed,
+        {
+            "id": args.failed_run_id,
+            "workflow_id": RECEIPT_WORKFLOW_ID,
+            "path": ".github/workflows/release-receipt.yml",
+            "event": "workflow_dispatch",
+            "run_attempt": 1,
+            "head_sha": args.source_sha,
+            "head_branch": args.release_ref,
+            "status": "completed",
+            "conclusion": "startup_failure",
+        },
+        "failed receipt run",
+    )
+    jobs = object_fixture(
+        args.failed_jobs_json,
+        f"repos/{REPOSITORY}/actions/runs/{args.failed_run_id}/jobs?filter=all&per_page=100",
+    )
+    empty_collection(jobs, "jobs", "failed receipt job set")
+    artifacts = object_fixture(
+        args.failed_artifacts_json,
+        f"repos/{REPOSITORY}/actions/runs/{args.failed_run_id}/artifacts?per_page=100",
+    )
+    empty_collection(artifacts, "artifacts", "failed receipt artifact set")
+
+    current = object_fixture(
+        args.current_run_json,
+        f"repos/{REPOSITORY}/actions/runs/{args.current_run_id}",
+    )
+    exact_run(
+        current,
+        {
+            "id": args.current_run_id,
+            "workflow_id": RECEIPT_WORKFLOW_ID,
+            "path": ".github/workflows/release-receipt.yml",
+            "event": "workflow_dispatch",
+            "run_attempt": 1,
+            "head_sha": args.control_sha,
+            "head_branch": "main",
+        },
+        "recovery receipt run",
+    )
+    if current.get("status") not in ACTIVE or current.get("conclusion") is not None:
+        raise ValueError("recovery receipt run is not active")
+
+    main_ref = object_fixture(
+        args.main_ref_json,
+        f"repos/{REPOSITORY}/git/ref/heads/main",
+    )
+    if (
+        main_ref.get("ref") != "refs/heads/main"
+        or main_ref.get("object", {}).get("type") != "commit"
+        or main_ref.get("object", {}).get("sha") != args.control_sha
+    ):
+        raise ValueError("protected main no longer points at the recovery control SHA")
+    commit = object_fixture(
+        args.control_commit_json,
+        f"repos/{REPOSITORY}/commits/{args.control_sha}",
+    )
+    verification = commit.get("commit", {}).get("verification", {})
+    if (
+        commit.get("sha") != args.control_sha
+        or verification.get("verified") is not True
+        or verification.get("reason") != "valid"
+    ):
+        raise ValueError("recovery control commit is not GitHub-verified")
+
+    ci_runs = object_fixture(
+        args.ci_runs_json,
+        f"repos/{REPOSITORY}/actions/workflows/ci.yml/runs"
+        f"?branch=main&event=push&status=success&head_sha={args.control_sha}&per_page=100",
+    )
+    runs = ci_runs.get("workflow_runs")
+    if not isinstance(runs, list):
+        raise ValueError("CI run query has no workflow_runs array")
+    matches = [
+        run
+        for run in runs
+        if isinstance(run, dict)
+        and run.get("workflow_id") == CI_WORKFLOW_ID
+        and run.get("head_sha") == args.control_sha
+        and run.get("head_branch") == "main"
+        and run.get("event") == "push"
+        and run.get("run_attempt") == 1
+        and run.get("status") == "completed"
+        and run.get("conclusion") == "success"
+        and run.get("repository", {}).get("id") == REPOSITORY_ID
+    ]
+    if len(matches) != 1:
+        raise ValueError("recovery control SHA lacks one exact successful main CI run")
+
+    name = f"rmux-publication-receipt-{args.source_sha}-{args.release_id}"
+    existing = object_fixture(
+        args.existing_receipts_json,
+        f"repos/{REPOSITORY}/actions/artifacts?name={name}&per_page=100",
+    )
+    receipts = existing.get("artifacts")
+    if not isinstance(receipts, list) or existing.get("total_count") != len(receipts):
+        raise ValueError("existing receipt artifact query is malformed")
+    if any(
+        isinstance(item, dict) and item.get("expired") is False for item in receipts
+    ):
+        raise ValueError("a live receipt artifact already exists for this release")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--failed-run-id", type=int, required=True)
+    parser.add_argument("--current-run-id", type=int, required=True)
+    parser.add_argument("--control-sha", required=True)
+    parser.add_argument("--source-sha", required=True)
+    parser.add_argument("--release-id", type=int, required=True)
+    parser.add_argument("--release-ref", required=True)
+    parser.add_argument("--failed-run-json", type=Path)
+    parser.add_argument("--failed-jobs-json", type=Path)
+    parser.add_argument("--failed-artifacts-json", type=Path)
+    parser.add_argument("--current-run-json", type=Path)
+    parser.add_argument("--main-ref-json", type=Path)
+    parser.add_argument("--control-commit-json", type=Path)
+    parser.add_argument("--ci-runs-json", type=Path)
+    parser.add_argument("--existing-receipts-json", type=Path)
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    try:
+        verify(parse_args())
+        print("receipt-recovery-ok")
+    except (KeyError, OSError, ValueError) as error:
+        print(f"receipt-recovery: {error}", file=sys.stderr)
+        raise SystemExit(1) from error

--- a/scripts/release/verify-receipt-attestation.py
+++ b/scripts/release/verify-receipt-attestation.py
@@ -57,6 +57,10 @@ def verify(args: argparse.Namespace) -> None:
         raise ValueError("receipt source SHA is invalid")
     if RELEASE_REF.fullmatch(args.release_ref) is None:
         raise ValueError("receipt release ref is invalid")
+    producer_sha = args.producer_source_sha or args.source_sha
+    producer_ref = args.producer_source_ref or f"refs/tags/{args.release_ref}"
+    if SHA40.fullmatch(producer_sha) is None:
+        raise ValueError("receipt attestation producer SHA is invalid")
     predicate = read_object(predicate_path, "receipt predicate")
     validate_evidence_authority(
         predicate,
@@ -70,6 +74,21 @@ def verify(args: argparse.Namespace) -> None:
         or predicate.get("release", {}).get("ref") != args.release_ref
     ):
         raise ValueError("receipt predicate identity or authority changed")
+    recovery = predicate.get("receipt", {}).get("recovery")
+    if recovery is None:
+        if (
+            producer_sha != args.source_sha
+            or producer_ref != f"refs/tags/{args.release_ref}"
+        ):
+            raise ValueError("normal receipt attestation producer identity changed")
+    elif (
+        not isinstance(recovery, dict)
+        or recovery.get("control_sha") != producer_sha
+        or recovery.get("control_ref") != producer_ref
+        or producer_sha == args.source_sha
+        or producer_ref != "refs/heads/main"
+    ):
+        raise ValueError("recovery receipt attestation producer identity changed")
     command = [
         str(gh),
         "attestation",
@@ -82,11 +101,11 @@ def verify(args: argparse.Namespace) -> None:
         "--signer-workflow",
         SIGNER_WORKFLOW,
         "--signer-digest",
-        args.source_sha,
+        producer_sha,
         "--source-digest",
-        args.source_sha,
+        producer_sha,
         "--source-ref",
-        f"refs/tags/{args.release_ref}",
+        producer_ref,
         "--predicate-type",
         PREDICATE_TYPE,
         "--deny-self-hosted-runners",
@@ -144,6 +163,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--predicate", type=Path, required=True)
     parser.add_argument("--source-sha", required=True)
     parser.add_argument("--release-ref", required=True)
+    parser.add_argument("--producer-source-sha")
+    parser.add_argument("--producer-source-ref")
     return parser.parse_args()
 
 

--- a/tests/release_downstream_workflows_spec.rs
+++ b/tests/release_downstream_workflows_spec.rs
@@ -492,7 +492,8 @@ fn exact_receipt_ids_digests_origin_and_documents_are_bound() {
         prepare.contains("test \"$RMUX_RECEIPT_RUN_WORKFLOW_ID\" = \"$RMUX_RECEIPT_WORKFLOW_ID\"")
     );
     assert!(prepare.contains("--expected-event workflow_dispatch"));
-    assert!(prepare.contains("--expected-head-branch \"$RMUX_RELEASE_REF\""));
+    assert!(prepare.contains("--expected-source-sha \"$GITHUB_SHA\""));
+    assert!(prepare.contains("--expected-head-branch \"$GITHUB_REF_NAME\""));
     assert_eq!(prepare.matches("artifact-ids:").count(), 2);
     assert_eq!(
         prepare

--- a/tests/release_linux_repository_recovery_spec.rs
+++ b/tests/release_linux_repository_recovery_spec.rs
@@ -116,7 +116,9 @@ fn manual_recovery_is_same_run_revalidated_and_canonically_sealed() {
         .expect("signed repository construction");
     assert!(build_gate < construction);
     assert!(BUILD.contains("if: github.run_id == inputs.receipt_run_id"));
-    assert!(BUILD.contains("ref: ${{ inputs.expected_source_sha }}"));
+    assert!(!BUILD.contains("ref: ${{ inputs.expected_source_sha }}"));
+    assert!(BUILD.contains("test \"$GITHUB_REF\" = \"refs/heads/main\""));
+    assert!(BUILD.contains("--expected-source-sha \"$GITHUB_SHA\""));
     assert!(
         BUILD.contains("repository_artifact_id: ${{ needs.build.outputs.repository_artifact_id }}")
     );

--- a/tests/release_receipt_recovery_spec.rs
+++ b/tests/release_receipt_recovery_spec.rs
@@ -1,0 +1,193 @@
+#[path = "support/python3.rs"]
+mod python3;
+
+use serde_json::{json, Value};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Output;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const SOURCE: &str = "1111111111111111111111111111111111111111";
+const CONTROL: &str = "2222222222222222222222222222222222222222";
+const FAILED_RUN: u64 = 30_926_195_244;
+const CURRENT_RUN: u64 = 30_930_000_001;
+const RELEASE_ID: u64 = 364_986_297;
+const RECEIPT: &str = include_str!("../.github/workflows/release-receipt.yml");
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn fixture_root(label: &str) -> PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock")
+        .as_nanos();
+    let root = std::env::temp_dir().join(format!(
+        "rmux-receipt-recovery-{label}-{}-{nonce}",
+        std::process::id()
+    ));
+    fs::create_dir(&root).expect("create fixture root");
+    root
+}
+
+fn write(root: &Path, name: &str, value: &Value) -> PathBuf {
+    let path = root.join(name);
+    fs::write(
+        &path,
+        serde_json::to_vec_pretty(value).expect("serialize fixture"),
+    )
+    .expect("write fixture");
+    path
+}
+
+fn repository() -> Value {
+    json!({"id": 1_239_918_790})
+}
+
+fn run_recovery(root: &Path, failed_conclusion: &str, existing: Value) -> Output {
+    let failed = write(
+        root,
+        "failed.json",
+        &json!({
+            "id": FAILED_RUN,
+            "workflow_id": 316_435_347,
+            "path": ".github/workflows/release-receipt.yml",
+            "event": "workflow_dispatch",
+            "run_attempt": 1,
+            "head_sha": SOURCE,
+            "head_branch": "v0.10.0",
+            "status": "completed",
+            "conclusion": failed_conclusion,
+            "repository": repository(),
+            "head_repository": repository(),
+        }),
+    );
+    let current = write(
+        root,
+        "current.json",
+        &json!({
+            "id": CURRENT_RUN,
+            "workflow_id": 316_435_347,
+            "path": ".github/workflows/release-receipt.yml",
+            "event": "workflow_dispatch",
+            "run_attempt": 1,
+            "head_sha": CONTROL,
+            "head_branch": "main",
+            "status": "in_progress",
+            "conclusion": null,
+            "repository": repository(),
+            "head_repository": repository(),
+        }),
+    );
+    let empty_jobs = write(root, "jobs.json", &json!({"total_count": 0, "jobs": []}));
+    let empty_artifacts = write(
+        root,
+        "artifacts.json",
+        &json!({"total_count": 0, "artifacts": []}),
+    );
+    let main_ref = write(
+        root,
+        "main-ref.json",
+        &json!({"ref": "refs/heads/main", "object": {"type": "commit", "sha": CONTROL}}),
+    );
+    let commit = write(
+        root,
+        "commit.json",
+        &json!({"sha": CONTROL, "commit": {"verification": {"verified": true, "reason": "valid"}}}),
+    );
+    let ci = write(
+        root,
+        "ci.json",
+        &json!({"workflow_runs": [{
+            "workflow_id": 277_622_540,
+            "head_sha": CONTROL,
+            "head_branch": "main",
+            "event": "push",
+            "run_attempt": 1,
+            "status": "completed",
+            "conclusion": "success",
+            "repository": repository(),
+        }]}),
+    );
+    let existing = write(root, "existing.json", &existing);
+
+    python3::command()
+        .arg(repo_root().join("scripts/release/receipt-recovery.py"))
+        .args([
+            "--failed-run-id",
+            &FAILED_RUN.to_string(),
+            "--current-run-id",
+            &CURRENT_RUN.to_string(),
+            "--control-sha",
+            CONTROL,
+            "--source-sha",
+            SOURCE,
+            "--release-id",
+            &RELEASE_ID.to_string(),
+            "--release-ref",
+            "v0.10.0",
+            "--failed-run-json",
+        ])
+        .arg(failed)
+        .arg("--failed-jobs-json")
+        .arg(empty_jobs)
+        .arg("--failed-artifacts-json")
+        .arg(empty_artifacts)
+        .arg("--current-run-json")
+        .arg(current)
+        .arg("--main-ref-json")
+        .arg(main_ref)
+        .arg("--control-commit-json")
+        .arg(commit)
+        .arg("--ci-runs-json")
+        .arg(ci)
+        .arg("--existing-receipts-json")
+        .arg(existing)
+        .current_dir(repo_root())
+        .output()
+        .expect("run receipt recovery verifier")
+}
+
+#[test]
+fn protected_main_recovery_accepts_only_one_empty_startup_failure() {
+    let root = fixture_root("success");
+    let output = run_recovery(
+        &root,
+        "startup_failure",
+        json!({"total_count": 0, "artifacts": []}),
+    );
+    fs::remove_dir_all(&root).expect("remove fixture root");
+    assert!(
+        output.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn protected_main_recovery_rejects_job_failures_and_existing_receipts() {
+    let root = fixture_root("wrong-conclusion");
+    let output = run_recovery(&root, "failure", json!({"total_count": 0, "artifacts": []}));
+    fs::remove_dir_all(&root).expect("remove fixture root");
+    assert!(!output.status.success());
+
+    let root = fixture_root("existing-receipt");
+    let output = run_recovery(
+        &root,
+        "startup_failure",
+        json!({"total_count": 1, "artifacts": [{"expired": false}]}),
+    );
+    fs::remove_dir_all(&root).expect("remove fixture root");
+    assert!(!output.status.success());
+}
+
+#[test]
+fn receipt_recovery_is_explicit_and_normal_dispatch_remains_tag_bound() {
+    assert!(RECEIPT.contains("failed_receipt_run_id:"));
+    assert!(RECEIPT.contains("scripts/release/receipt-recovery.py"));
+    assert!(RECEIPT.contains("test \"$GITHUB_REF\" = refs/heads/main"));
+    assert!(RECEIPT.contains("test \"$GITHUB_REF\" = \"refs/tags/$RMUX_RELEASE_REF\""));
+    assert!(RECEIPT.contains("--recovered-from-run-id \"$RMUX_FAILED_RECEIPT_RUN_ID\""));
+}


### PR DESCRIPTION
Add a fail-closed recovery path for a receipt workflow that failed before creating any job or artifact. Product bytes remain bound to the immutable release tag; recovery control code must be a signed, CI-green protected-main commit.