### PR TITLE
fix(release): recover protected downstream workers

### DIFF
--- a/.github/workflows/release-chocolatey-channel.yml
+++ b/.github/workflows/release-chocolatey-channel.yml
@@ -11,10 +11,6 @@ on:
       expected_source_sha: {required: true, type: string}
       release_id: {required: true, type: string}
       release_ref: {required: true, type: string}
-    secrets:
-      CHOCOLATEY_API_KEY:
-        required: false
-
 permissions: {}
 
 jobs:

--- a/.github/workflows/release-linux-repository-build.yml
+++ b/.github/workflows/release-linux-repository-build.yml
@@ -11,21 +11,6 @@ on:
       expected_source_sha: {required: true, type: string}
       release_id: {required: true, type: string}
       release_ref: {required: true, type: string}
-    secrets:
-      RMUX_APT_GPG_PRIVATE_KEY:
-        required: false
-      RMUX_APT_GPG_KEY:
-        required: false
-      RMUX_RPM_GPG_PRIVATE_KEY:
-        required: false
-      RMUX_RPM_GPG_KEY:
-        required: false
-      RMUX_RPM_REPO_GPG_PRIVATE_KEY:
-        required: false
-      RMUX_RPM_REPO_GPG_KEY:
-        required: false
-      RMUX_DOWNSTREAM_APP_PRIVATE_KEY:
-        required: false
     outputs:
       repository_artifact_id:
         value: ${{ jobs.build.outputs.repository_artifact_id }}
@@ -271,8 +256,6 @@ jobs:
       attestations: write
       contents: read
       id-token: write
-    secrets:
-      RMUX_DOWNSTREAM_APP_PRIVATE_KEY: ${{ secrets.RMUX_DOWNSTREAM_APP_PRIVATE_KEY }}
     with:
       receipt_run_id: ${{ inputs.receipt_run_id }}
       plan_artifact_id: ${{ inputs.plan_artifact_id }}

--- a/.github/workflows/release-linux-repository-publish.yml
+++ b/.github/workflows/release-linux-repository-publish.yml
@@ -16,10 +16,6 @@ on:
       release_id: {required: true, type: string}
       release_ref: {required: true, type: string}
       recovery_mode: {required: false, type: boolean, default: false}
-    secrets:
-      RMUX_DOWNSTREAM_APP_PRIVATE_KEY:
-        required: false
-
 permissions: {}
 
 jobs:

--- a/.github/workflows/release-owned-repository-channel.yml
+++ b/.github/workflows/release-owned-repository-channel.yml
@@ -12,10 +12,6 @@ on:
       expected_source_sha: {required: true, type: string}
       release_id: {required: true, type: string}
       release_ref: {required: true, type: string}
-    secrets:
-      RMUX_DOWNSTREAM_APP_PRIVATE_KEY:
-        required: false
-
 permissions: {}
 
 jobs:

--- a/.github/workflows/release-snap-channel.yml
+++ b/.github/workflows/release-snap-channel.yml
@@ -11,10 +11,6 @@ on:
       expected_source_sha: {required: true, type: string}
       release_id: {required: true, type: string}
       release_ref: {required: true, type: string}
-    secrets:
-      SNAPCRAFT_STORE_CREDENTIALS:
-        required: false
-
 permissions: {}
 
 jobs:

--- a/scripts/release/downstream_workflow_contract.py
+++ b/scripts/release/downstream_workflow_contract.py
@@ -115,7 +115,7 @@ def _validate_reusable_workflow(path: Path, *, require_repository_guard: bool) -
         raise ValueError(f"{path.name} does not reject external callers")
 
 
-def _validate_worker_secret_declarations(root: Path) -> None:
+def _validate_worker_environment_secrets(root: Path) -> None:
     workflows = root / ".github/workflows"
     expected = {
         "release-chocolatey-channel.yml": ("CHOCOLATEY_API_KEY",),
@@ -134,12 +134,11 @@ def _validate_worker_secret_declarations(root: Path) -> None:
     for name, secret_names in expected.items():
         text = (workflows / name).read_text(encoding="utf-8")
         call = text.split("\n  workflow_dispatch:", 1)[0]
-        if "\n    secrets:\n" not in call:
-            raise ValueError(f"{name} does not declare protected environment secrets")
+        if "\n    secrets:\n" in call:
+            raise ValueError(
+                f"{name} shadows its protected environment secrets with workflow_call secrets"
+            )
         for secret_name in secret_names:
-            declaration = f"      {secret_name}:\n        required: false"
-            if call.count(declaration) != 1:
-                raise ValueError(f"{name} lost secret declaration {secret_name}")
             if text.count(f"secrets.{secret_name}") < 1:
                 raise ValueError(f"{name} no longer consumes secret {secret_name}")
 
@@ -355,7 +354,6 @@ def _validate_linux_repository_recovery(root: Path) -> None:
         "linux_repository_recovery.py create-manifest",
         "attestations: write",
         "id-token: write",
-        "RMUX_DOWNSTREAM_APP_PRIVATE_KEY: ${{ secrets.RMUX_DOWNSTREAM_APP_PRIVATE_KEY }}",
     )
     if any(build.count(value) != 1 for value in build_required):
         raise ValueError("Linux repository recovery lost its same-run artifact route")
@@ -368,6 +366,13 @@ def _validate_linux_repository_recovery(root: Path) -> None:
         )
     if "secrets: inherit" in build or "secrets: inherit" in publish:
         raise ValueError("Linux repository recovery exposes inherited secrets")
+    if (
+        "RMUX_DOWNSTREAM_APP_PRIVATE_KEY: ${{ secrets.RMUX_DOWNSTREAM_APP_PRIVATE_KEY }}"
+        in build
+    ):
+        raise ValueError(
+            "Linux repository build shadows the publisher environment secret"
+        )
     construction_gate = build.find(
         "uses: ./.github/actions/release-linux-repository-recovery-authorize"
     )
@@ -639,7 +644,7 @@ def validate_downstream_workflows(root: Path) -> None:
         )
     for path in _worker_paths(root):
         _validate_reusable_workflow(path, require_repository_guard=False)
-    _validate_worker_secret_declarations(root)
+    _validate_worker_environment_secrets(root)
     _validate_callers(root, paths)
     main = paths[0].read_text(encoding="utf-8")
     _validate_receipt_origin(main)

--- a/scripts/release/receipt-recovery.py
+++ b/scripts/release/receipt-recovery.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Authorize one receipt replay from protected main after a startup failure."""
+"""Authorize one fail-closed receipt replay from protected main."""
 
 from __future__ import annotations
 
@@ -18,6 +18,55 @@ CI_WORKFLOW_ID = 277622540
 SHA40 = re.compile(r"[0-9a-f]{40}")
 RELEASE_REF = re.compile(r"v[0-9]+\.[0-9]+\.[0-9]+(?:-rc\.[0-9]+)?")
 ACTIVE = frozenset({"queued", "in_progress", "requested", "waiting", "pending"})
+EARLY_SUCCESS_JOBS = frozenset(
+    {
+        "Verify immutable Release and create receipt",
+        "Audit live downstream repository authority",
+        "Receipt-gated downstream publication / Prepare non-authoritative downstream plan",
+        "Receipt-gated downstream publication / Verify exact downstream repository authority audit",
+        "Receipt-gated downstream publication / Prepare exact downstream payloads / Materialize exact channel payloads",
+    }
+)
+LINUX_SIGNING_JOB = (
+    "Receipt-gated downstream publication / Build exact signed Linux repository trees / "
+    "Sign retained APT and RPM repository trees"
+)
+OWNED_WRITER_JOBS = frozenset(
+    {
+        "Receipt-gated downstream publication / Publish exact Homebrew tap formula / Publish owned channel homebrew_tap",
+        "Receipt-gated downstream publication / Publish exact Scoop manifest / Publish owned channel scoop",
+        "Receipt-gated downstream publication / Publish exact Web Share WASM bytes / Publish owned channel web_share",
+    }
+)
+SKIPPED_AFTER_FAILURE = frozenset(
+    {
+        "Receipt-gated downstream publication / Build exact signed Linux repository trees / Publish only this run's authorized recovery artifact",
+        "Receipt-gated downstream publication / Publish exact signed APT and RPM repositories",
+        "Receipt-gated downstream publication / Publish exact crates.io package set",
+        "Receipt-gated downstream publication / Record denied RC Linux repository channel",
+        "Receipt-gated downstream publication / Submit exact Chocolatey package",
+        "Receipt-gated downstream publication / Record disabled Snap stable channel",
+        "Receipt-gated downstream publication / Record manual Homebrew Core submission",
+        "Receipt-gated downstream publication / Record manual WinGet submission",
+        "Receipt-gated downstream publication / Publish exact Snap candidate revisions",
+        "Receipt-gated downstream publication / Aggregate ten exact pre-site results",
+        "Receipt-gated downstream publication / Record blocked automated rmux.io update",
+        "Receipt-gated downstream publication / Prepare manual rmux.io handoff",
+        "Receipt-gated downstream publication / Aggregate all eleven exact channel results",
+    }
+)
+PAYLOAD_CHANNELS = (
+    "apt_rpm",
+    "chocolatey",
+    "crates_io",
+    "homebrew_core",
+    "homebrew_tap",
+    "scoop",
+    "snap_candidate",
+    "snap_stable",
+    "web_share",
+    "winget",
+)
 
 
 def object_fixture(path: Path | None, endpoint: str) -> dict[str, Any]:
@@ -48,6 +97,215 @@ def empty_collection(value: dict[str, Any], field: str, label: str) -> None:
         raise ValueError(f"{label} is not empty")
 
 
+def verified_commit(value: dict[str, Any], sha: str, label: str) -> None:
+    verification = value.get("commit", {}).get("verification", {})
+    if (
+        value.get("sha") != sha
+        or verification.get("verified") is not True
+        or verification.get("reason") != "valid"
+    ):
+        raise ValueError(f"{label} is not GitHub-verified")
+
+
+def job_steps(job: dict[str, Any], label: str) -> dict[str, str]:
+    steps = job.get("steps")
+    if not isinstance(steps, list):
+        raise ValueError(f"{label} has no step list")
+    result: dict[str, str] = {}
+    for step in steps:
+        if not isinstance(step, dict):
+            raise ValueError(f"{label} has a malformed step")
+        name = step.get("name")
+        conclusion = step.get("conclusion")
+        if not isinstance(name, str) or not isinstance(conclusion, str):
+            raise ValueError(f"{label} step identity is malformed")
+        if name in result and result[name] != conclusion:
+            raise ValueError(f"{label} duplicate step conclusions differ")
+        result[name] = conclusion
+    return result
+
+
+def exact_step(steps: dict[str, str], name: str, conclusion: str, label: str) -> None:
+    if steps.get(name) != conclusion:
+        raise ValueError(f"{label} step {name} did not conclude {conclusion}")
+
+
+def verify_failed_downstream_jobs(value: dict[str, Any]) -> None:
+    jobs = value.get("jobs")
+    if not isinstance(jobs, list) or value.get("total_count") != len(jobs):
+        raise ValueError("failed downstream job set is malformed")
+    by_name: dict[str, dict[str, Any]] = {}
+    for job in jobs:
+        if not isinstance(job, dict) or not isinstance(job.get("name"), str):
+            raise ValueError("failed downstream job identity is malformed")
+        name = job["name"]
+        if name in by_name:
+            raise ValueError("failed downstream job names are not unique")
+        by_name[name] = job
+    expected_names = (
+        EARLY_SUCCESS_JOBS
+        | {LINUX_SIGNING_JOB}
+        | OWNED_WRITER_JOBS
+        | SKIPPED_AFTER_FAILURE
+    )
+    if set(by_name) != expected_names:
+        raise ValueError("failed downstream job topology differs")
+    for name in EARLY_SUCCESS_JOBS:
+        if by_name[name].get("conclusion") != "success":
+            raise ValueError(f"failed downstream prerequisite {name} is not successful")
+    for name in SKIPPED_AFTER_FAILURE:
+        if (
+            by_name[name].get("conclusion") != "skipped"
+            or by_name[name].get("steps") != []
+        ):
+            raise ValueError(f"post-failure downstream job {name} was not untouched")
+
+    linux = by_name[LINUX_SIGNING_JOB]
+    if linux.get("conclusion") != "failure":
+        raise ValueError("Linux repository signing did not fail closed")
+    linux_steps = job_steps(linux, LINUX_SIGNING_JOB)
+    exact_step(
+        linux_steps,
+        "Import distinct repository signing keys",
+        "failure",
+        LINUX_SIGNING_JOB,
+    )
+    for name in (
+        "Authenticate retained history and generate signed repositories",
+        "Add static package host files and exact checksum inventory",
+        "Upload the exact signed repository tree",
+    ):
+        exact_step(linux_steps, name, "skipped", LINUX_SIGNING_JOB)
+
+    for name in OWNED_WRITER_JOBS:
+        job = by_name[name]
+        if job.get("conclusion") != "failure":
+            raise ValueError(f"owned repository job {name} did not fail closed")
+        steps = job_steps(job, name)
+        exact_step(
+            steps,
+            "Mint a repository-scoped downstream writer token",
+            "failure",
+            name,
+        )
+        exact_step(
+            steps,
+            "Publish and reread exact repository bytes",
+            "skipped",
+            name,
+        )
+        exact_step(
+            steps,
+            "Seal exact owned repository result evidence",
+            "skipped",
+            name,
+        )
+
+
+def verify_failed_downstream_artifacts(
+    value: dict[str, Any], args: argparse.Namespace, failed_control_sha: str
+) -> int:
+    artifacts = value.get("artifacts")
+    if not isinstance(artifacts, list) or value.get("total_count") != len(artifacts):
+        raise ValueError("failed downstream artifact set is malformed")
+    expected_names = {
+        f"rmux-publication-receipt-{args.source_sha}-{args.release_id}",
+        f"rmux-publication-receipt-envelope-{args.source_sha}-{args.release_id}",
+        f"rmux-downstream-authority-{args.source_sha}-{args.failed_run_id}",
+        f"rmux-downstream-plan-{args.source_sha}-{args.release_id}",
+        *(
+            f"rmux-downstream-{channel}-payload-{args.source_sha}-{args.release_id}"
+            for channel in PAYLOAD_CHANNELS
+        ),
+    }
+    by_name: dict[str, dict[str, Any]] = {}
+    for artifact in artifacts:
+        if not isinstance(artifact, dict) or not isinstance(artifact.get("name"), str):
+            raise ValueError("failed downstream artifact identity is malformed")
+        name = artifact["name"]
+        if name in by_name:
+            raise ValueError("failed downstream artifact names are not unique")
+        by_name[name] = artifact
+    if set(by_name) != expected_names:
+        raise ValueError("failed downstream artifact topology differs")
+    for name, artifact in by_name.items():
+        workflow_run = artifact.get("workflow_run", {})
+        if (
+            type(artifact.get("id")) is not int
+            or artifact["id"] <= 0
+            or artifact.get("expired") is not False
+            or not isinstance(artifact.get("digest"), str)
+            or re.fullmatch(r"sha256:[0-9a-f]{64}", artifact["digest"]) is None
+            or workflow_run.get("id") != args.failed_run_id
+            or workflow_run.get("head_sha") != failed_control_sha
+            or workflow_run.get("head_branch") != "main"
+            or workflow_run.get("repository_id") != REPOSITORY_ID
+            or workflow_run.get("head_repository_id") != REPOSITORY_ID
+        ):
+            raise ValueError(f"failed downstream artifact {name} identity differs")
+    return by_name[f"rmux-publication-receipt-{args.source_sha}-{args.release_id}"][
+        "id"
+    ]
+
+
+def verify_failed_attempt(
+    args: argparse.Namespace,
+    failed: dict[str, Any],
+    jobs: dict[str, Any],
+    artifacts: dict[str, Any],
+) -> int | None:
+    common = {
+        "id": args.failed_run_id,
+        "workflow_id": RECEIPT_WORKFLOW_ID,
+        "path": ".github/workflows/release-receipt.yml",
+        "event": "workflow_dispatch",
+        "run_attempt": 1,
+        "status": "completed",
+    }
+    if failed.get("conclusion") == "startup_failure":
+        exact_run(
+            failed,
+            common
+            | {
+                "head_sha": args.source_sha,
+                "head_branch": args.release_ref,
+                "conclusion": "startup_failure",
+            },
+            "failed receipt run",
+        )
+        empty_collection(jobs, "jobs", "failed receipt job set")
+        empty_collection(artifacts, "artifacts", "failed receipt artifact set")
+        return None
+    if failed.get("conclusion") != "failure":
+        raise ValueError("failed receipt conclusion is not recoverable")
+    failed_control_sha = failed.get("head_sha")
+    if (
+        not isinstance(failed_control_sha, str)
+        or SHA40.fullmatch(failed_control_sha) is None
+        or failed_control_sha == args.source_sha
+    ):
+        raise ValueError("failed downstream control SHA is invalid")
+    exact_run(
+        failed,
+        common
+        | {
+            "head_sha": failed_control_sha,
+            "head_branch": "main",
+            "conclusion": "failure",
+        },
+        "failed downstream receipt run",
+    )
+    failed_commit = object_fixture(
+        args.failed_control_commit_json,
+        f"repos/{REPOSITORY}/commits/{failed_control_sha}",
+    )
+    verified_commit(
+        failed_commit, failed_control_sha, "failed downstream control commit"
+    )
+    verify_failed_downstream_jobs(jobs)
+    return verify_failed_downstream_artifacts(artifacts, args, failed_control_sha)
+
+
 def verify(args: argparse.Namespace) -> None:
     if args.failed_run_id <= 0 or args.current_run_id <= 0 or args.release_id <= 0:
         raise ValueError("run and release IDs must be positive")
@@ -64,31 +322,15 @@ def verify(args: argparse.Namespace) -> None:
         args.failed_run_json,
         f"repos/{REPOSITORY}/actions/runs/{args.failed_run_id}",
     )
-    exact_run(
-        failed,
-        {
-            "id": args.failed_run_id,
-            "workflow_id": RECEIPT_WORKFLOW_ID,
-            "path": ".github/workflows/release-receipt.yml",
-            "event": "workflow_dispatch",
-            "run_attempt": 1,
-            "head_sha": args.source_sha,
-            "head_branch": args.release_ref,
-            "status": "completed",
-            "conclusion": "startup_failure",
-        },
-        "failed receipt run",
-    )
     jobs = object_fixture(
         args.failed_jobs_json,
         f"repos/{REPOSITORY}/actions/runs/{args.failed_run_id}/jobs?filter=all&per_page=100",
     )
-    empty_collection(jobs, "jobs", "failed receipt job set")
     artifacts = object_fixture(
         args.failed_artifacts_json,
         f"repos/{REPOSITORY}/actions/runs/{args.failed_run_id}/artifacts?per_page=100",
     )
-    empty_collection(artifacts, "artifacts", "failed receipt artifact set")
+    failed_receipt_artifact_id = verify_failed_attempt(args, failed, jobs, artifacts)
 
     current = object_fixture(
         args.current_run_json,
@@ -124,13 +366,7 @@ def verify(args: argparse.Namespace) -> None:
         args.control_commit_json,
         f"repos/{REPOSITORY}/commits/{args.control_sha}",
     )
-    verification = commit.get("commit", {}).get("verification", {})
-    if (
-        commit.get("sha") != args.control_sha
-        or verification.get("verified") is not True
-        or verification.get("reason") != "valid"
-    ):
-        raise ValueError("recovery control commit is not GitHub-verified")
+    verified_commit(commit, args.control_sha, "recovery control commit")
 
     ci_runs = object_fixture(
         args.ci_runs_json,
@@ -164,10 +400,21 @@ def verify(args: argparse.Namespace) -> None:
     receipts = existing.get("artifacts")
     if not isinstance(receipts, list) or existing.get("total_count") != len(receipts):
         raise ValueError("existing receipt artifact query is malformed")
-    if any(
-        isinstance(item, dict) and item.get("expired") is False for item in receipts
+    live = [
+        item
+        for item in receipts
+        if isinstance(item, dict) and item.get("expired") is False
+    ]
+    if failed_receipt_artifact_id is None:
+        if live:
+            raise ValueError("a live receipt artifact already exists for this release")
+    elif (
+        len(live) != 1
+        or live[0].get("id") != failed_receipt_artifact_id
+        or live[0].get("name") != name
+        or live[0].get("workflow_run", {}).get("id") != args.failed_run_id
     ):
-        raise ValueError("a live receipt artifact already exists for this release")
+        raise ValueError("the recoverable failed run is not the sole live receipt")
 
 
 def parse_args() -> argparse.Namespace:
@@ -181,6 +428,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--failed-run-json", type=Path)
     parser.add_argument("--failed-jobs-json", type=Path)
     parser.add_argument("--failed-artifacts-json", type=Path)
+    parser.add_argument("--failed-control-commit-json", type=Path)
     parser.add_argument("--current-run-json", type=Path)
     parser.add_argument("--main-ref-json", type=Path)
     parser.add_argument("--control-commit-json", type=Path)

--- a/tests/release_downstream_workflows_spec.rs
+++ b/tests/release_downstream_workflows_spec.rs
@@ -163,6 +163,53 @@ fn downstream_caller_guard_rejects_relative_and_absolute_targets() {
     ));
 }
 
+#[test]
+fn protected_environment_secrets_are_not_shadowed_by_reusable_inputs() {
+    let workflows = repo_root().join(".github/workflows");
+    for (filename, secret) in [
+        ("release-chocolatey-channel.yml", "CHOCOLATEY_API_KEY"),
+        (
+            "release-linux-repository-publish.yml",
+            "RMUX_DOWNSTREAM_APP_PRIVATE_KEY",
+        ),
+        (
+            "release-owned-repository-channel.yml",
+            "RMUX_DOWNSTREAM_APP_PRIVATE_KEY",
+        ),
+        ("release-snap-channel.yml", "SNAPCRAFT_STORE_CREDENTIALS"),
+    ] {
+        let text = fs::read_to_string(workflows.join(filename)).expect("read workflow");
+        let workflow_call = text
+            .split("\npermissions: {}\n")
+            .next()
+            .expect("workflow_call boundary");
+        assert!(text.contains("environment: release"));
+        assert!(!workflow_call.contains("\n    secrets:\n"));
+        assert!(text.contains(&format!("secrets.{secret}")));
+    }
+
+    let build = fs::read_to_string(workflows.join("release-linux-repository-build.yml"))
+        .expect("read Linux repository build");
+    let workflow_call = build
+        .split("\n  workflow_dispatch:\n")
+        .next()
+        .expect("Linux workflow_call boundary");
+    assert!(!workflow_call.contains("\n    secrets:\n"));
+    assert!(!build.contains(
+        "RMUX_DOWNSTREAM_APP_PRIVATE_KEY: ${{ secrets.RMUX_DOWNSTREAM_APP_PRIVATE_KEY }}"
+    ));
+    for secret in [
+        "RMUX_APT_GPG_PRIVATE_KEY",
+        "RMUX_APT_GPG_KEY",
+        "RMUX_RPM_GPG_PRIVATE_KEY",
+        "RMUX_RPM_GPG_KEY",
+        "RMUX_RPM_REPO_GPG_PRIVATE_KEY",
+        "RMUX_RPM_REPO_GPG_KEY",
+    ] {
+        assert!(build.contains(&format!("secrets.{secret}")));
+    }
+}
+
 #[cfg(unix)]
 #[test]
 fn downstream_workflow_entry_points_are_executable() {

--- a/tests/release_linux_repository_recovery_spec.rs
+++ b/tests/release_linux_repository_recovery_spec.rs
@@ -130,9 +130,11 @@ fn manual_recovery_is_same_run_revalidated_and_canonically_sealed() {
     assert!(BUILD.contains("environment: release"));
     assert!(BUILD.contains("attestations: write"));
     assert!(BUILD.contains("id-token: write"));
-    assert!(BUILD.contains(
+    assert!(!BUILD.contains(
         "RMUX_DOWNSTREAM_APP_PRIVATE_KEY: ${{ secrets.RMUX_DOWNSTREAM_APP_PRIVATE_KEY }}"
     ));
+    assert!(PUBLISH.contains("environment: release-publication"));
+    assert!(PUBLISH.contains("private-key: ${{ secrets.RMUX_DOWNSTREAM_APP_PRIVATE_KEY }}"));
 
     assert_eq!(
         PUBLISH

--- a/tests/release_receipt_recovery_spec.rs
+++ b/tests/release_receipt_recovery_spec.rs
@@ -9,6 +9,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 const SOURCE: &str = "1111111111111111111111111111111111111111";
 const CONTROL: &str = "2222222222222222222222222222222222222222";
+const FAILED_CONTROL: &str = "3333333333333333333333333333333333333333";
 const FAILED_RUN: u64 = 30_926_195_244;
 const CURRENT_RUN: u64 = 30_930_000_001;
 const RELEASE_ID: u64 = 364_986_297;
@@ -45,24 +46,14 @@ fn repository() -> Value {
     json!({"id": 1_239_918_790})
 }
 
-fn run_recovery(root: &Path, failed_conclusion: &str, existing: Value) -> Output {
-    let failed = write(
-        root,
-        "failed.json",
-        &json!({
-            "id": FAILED_RUN,
-            "workflow_id": 316_435_347,
-            "path": ".github/workflows/release-receipt.yml",
-            "event": "workflow_dispatch",
-            "run_attempt": 1,
-            "head_sha": SOURCE,
-            "head_branch": "v0.10.0",
-            "status": "completed",
-            "conclusion": failed_conclusion,
-            "repository": repository(),
-            "head_repository": repository(),
-        }),
-    );
+fn run_recovery(
+    root: &Path,
+    failed: Value,
+    jobs: Value,
+    artifacts: Value,
+    existing: Value,
+) -> Output {
+    let failed = write(root, "failed.json", &failed);
     let current = write(
         root,
         "current.json",
@@ -80,11 +71,12 @@ fn run_recovery(root: &Path, failed_conclusion: &str, existing: Value) -> Output
             "head_repository": repository(),
         }),
     );
-    let empty_jobs = write(root, "jobs.json", &json!({"total_count": 0, "jobs": []}));
-    let empty_artifacts = write(
+    let jobs = write(root, "jobs.json", &jobs);
+    let artifacts = write(root, "artifacts.json", &artifacts);
+    let failed_commit = write(
         root,
-        "artifacts.json",
-        &json!({"total_count": 0, "artifacts": []}),
+        "failed-commit.json",
+        &json!({"sha": FAILED_CONTROL, "commit": {"verification": {"verified": true, "reason": "valid"}}}),
     );
     let main_ref = write(
         root,
@@ -131,9 +123,11 @@ fn run_recovery(root: &Path, failed_conclusion: &str, existing: Value) -> Output
         ])
         .arg(failed)
         .arg("--failed-jobs-json")
-        .arg(empty_jobs)
+        .arg(jobs)
         .arg("--failed-artifacts-json")
-        .arg(empty_artifacts)
+        .arg(artifacts)
+        .arg("--failed-control-commit-json")
+        .arg(failed_commit)
         .arg("--current-run-json")
         .arg(current)
         .arg("--main-ref-json")
@@ -149,10 +143,148 @@ fn run_recovery(root: &Path, failed_conclusion: &str, existing: Value) -> Output
         .expect("run receipt recovery verifier")
 }
 
+fn failed_run(head_sha: &str, head_branch: &str, conclusion: &str) -> Value {
+    json!({
+        "id": FAILED_RUN,
+        "workflow_id": 316_435_347,
+        "path": ".github/workflows/release-receipt.yml",
+        "event": "workflow_dispatch",
+        "run_attempt": 1,
+        "head_sha": head_sha,
+        "head_branch": head_branch,
+        "status": "completed",
+        "conclusion": conclusion,
+        "repository": repository(),
+        "head_repository": repository(),
+    })
+}
+
+fn startup_recovery(root: &Path, conclusion: &str, existing: Value) -> Output {
+    run_recovery(
+        root,
+        failed_run(SOURCE, "v0.10.0", conclusion),
+        json!({"total_count": 0, "jobs": []}),
+        json!({"total_count": 0, "artifacts": []}),
+        existing,
+    )
+}
+
+fn step(name: &str, conclusion: &str) -> Value {
+    json!({"name": name, "status": "completed", "conclusion": conclusion})
+}
+
+fn downstream_failure_jobs() -> Value {
+    let successes = [
+        "Verify immutable Release and create receipt",
+        "Audit live downstream repository authority",
+        "Receipt-gated downstream publication / Prepare non-authoritative downstream plan",
+        "Receipt-gated downstream publication / Verify exact downstream repository authority audit",
+        "Receipt-gated downstream publication / Prepare exact downstream payloads / Materialize exact channel payloads",
+    ];
+    let owned = [
+        "Receipt-gated downstream publication / Publish exact Homebrew tap formula / Publish owned channel homebrew_tap",
+        "Receipt-gated downstream publication / Publish exact Scoop manifest / Publish owned channel scoop",
+        "Receipt-gated downstream publication / Publish exact Web Share WASM bytes / Publish owned channel web_share",
+    ];
+    let skipped = [
+        "Receipt-gated downstream publication / Build exact signed Linux repository trees / Publish only this run's authorized recovery artifact",
+        "Receipt-gated downstream publication / Publish exact signed APT and RPM repositories",
+        "Receipt-gated downstream publication / Publish exact crates.io package set",
+        "Receipt-gated downstream publication / Record denied RC Linux repository channel",
+        "Receipt-gated downstream publication / Submit exact Chocolatey package",
+        "Receipt-gated downstream publication / Record disabled Snap stable channel",
+        "Receipt-gated downstream publication / Record manual Homebrew Core submission",
+        "Receipt-gated downstream publication / Record manual WinGet submission",
+        "Receipt-gated downstream publication / Publish exact Snap candidate revisions",
+        "Receipt-gated downstream publication / Aggregate ten exact pre-site results",
+        "Receipt-gated downstream publication / Record blocked automated rmux.io update",
+        "Receipt-gated downstream publication / Prepare manual rmux.io handoff",
+        "Receipt-gated downstream publication / Aggregate all eleven exact channel results",
+    ];
+    let mut jobs = Vec::new();
+    for name in successes {
+        jobs.push(json!({"name": name, "conclusion": "success", "steps": []}));
+    }
+    jobs.push(json!({
+        "name": "Receipt-gated downstream publication / Build exact signed Linux repository trees / Sign retained APT and RPM repository trees",
+        "conclusion": "failure",
+        "steps": [
+            step("Import distinct repository signing keys", "failure"),
+            step("Authenticate retained history and generate signed repositories", "skipped"),
+            step("Add static package host files and exact checksum inventory", "skipped"),
+            step("Upload the exact signed repository tree", "skipped"),
+        ],
+    }));
+    for name in owned {
+        jobs.push(json!({
+            "name": name,
+            "conclusion": "failure",
+            "steps": [
+                step("Mint a repository-scoped downstream writer token", "failure"),
+                step("Publish and reread exact repository bytes", "skipped"),
+                step("Seal exact owned repository result evidence", "skipped"),
+            ],
+        }));
+    }
+    for name in skipped {
+        jobs.push(json!({"name": name, "conclusion": "skipped", "steps": []}));
+    }
+    json!({"total_count": jobs.len(), "jobs": jobs})
+}
+
+fn downstream_failure_artifacts() -> (Value, u64) {
+    let receipt_id = 81_u64;
+    let mut names = vec![
+        format!("rmux-publication-receipt-{SOURCE}-{RELEASE_ID}"),
+        format!("rmux-publication-receipt-envelope-{SOURCE}-{RELEASE_ID}"),
+        format!("rmux-downstream-authority-{SOURCE}-{FAILED_RUN}"),
+        format!("rmux-downstream-plan-{SOURCE}-{RELEASE_ID}"),
+    ];
+    for channel in [
+        "apt_rpm",
+        "chocolatey",
+        "crates_io",
+        "homebrew_core",
+        "homebrew_tap",
+        "scoop",
+        "snap_candidate",
+        "snap_stable",
+        "web_share",
+        "winget",
+    ] {
+        names.push(format!(
+            "rmux-downstream-{channel}-payload-{SOURCE}-{RELEASE_ID}"
+        ));
+    }
+    let artifacts: Vec<Value> = names
+        .into_iter()
+        .enumerate()
+        .map(|(index, name)| {
+            json!({
+                "id": receipt_id + index as u64,
+                "name": name,
+                "expired": false,
+                "digest": format!("sha256:{}", "a".repeat(64)),
+                "workflow_run": {
+                    "id": FAILED_RUN,
+                    "head_sha": FAILED_CONTROL,
+                    "head_branch": "main",
+                    "repository_id": 1_239_918_790,
+                    "head_repository_id": 1_239_918_790,
+                },
+            })
+        })
+        .collect();
+    (
+        json!({"total_count": artifacts.len(), "artifacts": artifacts}),
+        receipt_id,
+    )
+}
+
 #[test]
 fn protected_main_recovery_accepts_only_one_empty_startup_failure() {
     let root = fixture_root("success");
-    let output = run_recovery(
+    let output = startup_recovery(
         &root,
         "startup_failure",
         json!({"total_count": 0, "artifacts": []}),
@@ -169,15 +301,83 @@ fn protected_main_recovery_accepts_only_one_empty_startup_failure() {
 #[test]
 fn protected_main_recovery_rejects_job_failures_and_existing_receipts() {
     let root = fixture_root("wrong-conclusion");
-    let output = run_recovery(&root, "failure", json!({"total_count": 0, "artifacts": []}));
+    let output = startup_recovery(&root, "failure", json!({"total_count": 0, "artifacts": []}));
     fs::remove_dir_all(&root).expect("remove fixture root");
     assert!(!output.status.success());
 
     let root = fixture_root("existing-receipt");
-    let output = run_recovery(
+    let output = startup_recovery(
         &root,
         "startup_failure",
         json!({"total_count": 1, "artifacts": [{"expired": false}]}),
+    );
+    fs::remove_dir_all(&root).expect("remove fixture root");
+    assert!(!output.status.success());
+}
+
+#[test]
+fn protected_main_recovery_accepts_only_the_exact_pre_mutation_failure() {
+    let root = fixture_root("pre-mutation");
+    let jobs = downstream_failure_jobs();
+    let (artifacts, receipt_id) = downstream_failure_artifacts();
+    let output = run_recovery(
+        &root,
+        failed_run(FAILED_CONTROL, "main", "failure"),
+        jobs,
+        artifacts,
+        json!({
+            "total_count": 1,
+            "artifacts": [{
+                "id": receipt_id,
+                "name": format!("rmux-publication-receipt-{SOURCE}-{RELEASE_ID}"),
+                "expired": false,
+                "workflow_run": {"id": FAILED_RUN},
+            }],
+        }),
+    );
+    fs::remove_dir_all(&root).expect("remove fixture root");
+    assert!(
+        output.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn protected_main_recovery_rejects_any_owned_writer_mutation() {
+    let root = fixture_root("writer-mutation");
+    let mut jobs = downstream_failure_jobs();
+    let entries = jobs["jobs"].as_array_mut().expect("jobs array");
+    let owned = entries
+        .iter_mut()
+        .find(|job| {
+            job["name"]
+                .as_str()
+                .is_some_and(|name| name.contains("Publish exact Scoop manifest"))
+        })
+        .expect("owned writer job");
+    let steps = owned["steps"].as_array_mut().expect("step array");
+    let writer = steps
+        .iter_mut()
+        .find(|step| step["name"] == "Publish and reread exact repository bytes")
+        .expect("writer step");
+    writer["conclusion"] = json!("success");
+    let (artifacts, receipt_id) = downstream_failure_artifacts();
+    let output = run_recovery(
+        &root,
+        failed_run(FAILED_CONTROL, "main", "failure"),
+        jobs,
+        artifacts,
+        json!({
+            "total_count": 1,
+            "artifacts": [{
+                "id": receipt_id,
+                "name": format!("rmux-publication-receipt-{SOURCE}-{RELEASE_ID}"),
+                "expired": false,
+                "workflow_run": {"id": FAILED_RUN},
+            }],
+        }),
     );
     fs::remove_dir_all(&root).expect("remove fixture root");
     assert!(!output.status.success());


### PR DESCRIPTION
Fix the protected environment secret boundary exposed by the first v0.10.0 downstream run.

The replay verifier accepts only the exact failed-before-mutation topology from run 30933937932 and rejects any executed writer step or extra result artifact.

Validation: all release_* test targets, workspace Clippy, Rustfmt, Ruff, release contracts, and the live failed-run fixture.