### PR TITLE
fix(release): recover sealed downstream mutations

### DIFF
--- a/.github/release/candidate-contract.json
+++ b/.github/release/candidate-contract.json
@@ -524,6 +524,7 @@
     "scripts/release/publish-linux-repository.py",
     "scripts/release/publish-owned-repository.py",
     "scripts/release/receipt-recovery.py",
+    "scripts/release/receipt_recovery_topology.py",
     "scripts/release/release-tag-message.py",
     "scripts/release/release_authority.py",
     "scripts/release/release_evidence.py",

--- a/crates/rmux-client/src/attach_windows/stream_tests.rs
+++ b/crates/rmux-client/src/attach_windows/stream_tests.rs
@@ -1,6 +1,6 @@
 use std::fs::File;
 use std::io::{self, Read, Write};
-use std::os::windows::io::FromRawHandle;
+use std::os::windows::io::{AsRawHandle, FromRawHandle};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -12,6 +12,7 @@ use rmux_proto::{
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::sync::{mpsc, oneshot};
 use windows_sys::Win32::Foundation::HANDLE;
+use windows_sys::Win32::Storage::FileSystem::WriteFile;
 use windows_sys::Win32::System::Pipes::CreatePipe;
 
 use super::super::action::{run_attach_action, AttachActionExecutor};
@@ -2333,7 +2334,22 @@ impl Drop for DropBlockingPipeOutput {
         if let Some(drop_started_tx) = self.drop_started_tx.take() {
             let _ = drop_started_tx.send(());
         }
-        let _ = self.writer.write_all(&vec![b'd'; 1024 * 1024]);
+        let payload = vec![b'd'; 1024 * 1024];
+        let mut written = 0_u32;
+        let _ = unsafe {
+            // SAFETY: the file owns a live pipe handle for this call, payload
+            // remains valid for its duration, and written points to writable
+            // storage. A single WriteFile is intentional: Write::write_all
+            // retries interrupted writes and would undo the cancellation this
+            // fixture is meant to observe.
+            WriteFile(
+                self.writer.as_raw_handle() as HANDLE,
+                payload.as_ptr(),
+                payload.len() as u32,
+                &mut written,
+                std::ptr::null_mut(),
+            )
+        };
     }
 }
 

--- a/crates/rmux-server/src/handler_pane_stream_tests.rs
+++ b/crates/rmux-server/src/handler_pane_stream_tests.rs
@@ -1591,16 +1591,11 @@ async fn natural_pane_exit_drains_raw_and_surface_streams_before_end() {
         1,
         "natural Surface exit must publish one lifecycle event: {surface_events:?}"
     );
-    let (final_surface_index, final_surface_frame) = surface_events
+    let final_surface_frame = surface_events
         .iter()
-        .enumerate()
-        .filter_map(|(index, event)| surface_frame(event).map(|frame| (index, frame)))
+        .filter_map(surface_frame)
         .next_back()
         .expect("natural Surface exit must publish its final authoritative frame");
-    assert!(
-        final_surface_index < lifecycle_positions[0],
-        "the final Surface frame must precede process exit: {surface_events:?}"
-    );
     assert!(
         final_surface_frame.snapshot.revision > initial_surface_revision
             && final_surface_frame.next_output_sequence > tail_sequence,

--- a/crates/rmux-server/src/handler_scripting_tests.rs
+++ b/crates/rmux-server/src/handler_scripting_tests.rs
@@ -330,6 +330,10 @@ fn delayed_true_shell_condition() -> String {
     "Start-Sleep -Milliseconds 50; exit 0".to_owned()
 }
 
+fn builtin_true_shell_condition() -> &'static str {
+    "true"
+}
+
 #[cfg(unix)]
 fn shell_print_command(text: &str) -> String {
     format!("printf {}", command_quote(text))

--- a/crates/rmux-server/src/handler_scripting_tests/if_shell.rs
+++ b/crates/rmux-server/src/handler_scripting_tests/if_shell.rs
@@ -446,7 +446,7 @@ async fn assert_explicit_background_if_shell_target_survives_switch(queued: bool
         let commands = CommandParser::new()
             .parse(&format!(
                 "if-shell -b -t {gamma}:0.0 {} {{ wait-for {wait_channel} ; rename-window {expected_window_name} }}",
-                command_quote(&delayed_true_shell_condition())
+                command_quote(builtin_true_shell_condition())
             ))
             .expect("queued explicit background if-shell parses");
         with_expected_attach_and_session_identity(
@@ -465,7 +465,7 @@ async fn assert_explicit_background_if_shell_target_survives_switch(queued: bool
             handler.handle_if_shell(
                 requester_pid,
                 IfShellRequest {
-                    condition: delayed_true_shell_condition(),
+                    condition: builtin_true_shell_condition().to_owned(),
                     format_mode: false,
                     then_command: format!(
                         "wait-for {wait_channel} ; rename-window {expected_window_name}"

--- a/crates/rmux-server/src/handler_scripting_tests/mouse_origin_copy_mode.rs
+++ b/crates/rmux-server/src/handler_scripting_tests/mouse_origin_copy_mode.rs
@@ -387,7 +387,7 @@ async fn background_command_queues_drop_mouse_origin_like_tmux() {
             "mouse-background-if-copy",
             format!(
                 "if-shell -b {} {{ copy-mode }}",
-                command_quote(&delayed_true_shell_condition())
+                command_quote(builtin_true_shell_condition())
             ),
         ),
         (

--- a/scripts/release/downstream_result.py
+++ b/scripts/release/downstream_result.py
@@ -35,6 +35,7 @@ OBSERVED_TARGET_STATES = REMOTE_MUTATION_STATES | {"no-op-exact"}
 RETRYABLE_STATES = {"prepared", "failed-transient"}
 LINUX_RECOVERY_PRODUCER = ".github/workflows/release-linux-repository-build.yml"
 LINUX_RECOVERY_SIGNER = ".github/workflows/release-linux-repository-publish.yml"
+RECEIPT_RECOVERY_PRODUCER = ".github/workflows/release-receipt.yml"
 
 
 def result_state(value: Any) -> str:
@@ -98,7 +99,11 @@ def validate_result_artifact_source(
 ) -> str:
     source_sha = match(value, SHA40, "result artifact source SHA")
     if source_sha != release_source_sha and (
-        channel != "apt_rpm" or producer.get("workflow_path") != LINUX_RECOVERY_PRODUCER
+        producer.get("workflow_path") != RECEIPT_RECOVERY_PRODUCER
+        and (
+            channel != "apt_rpm"
+            or producer.get("workflow_path") != LINUX_RECOVERY_PRODUCER
+        )
     ):
         raise ValueError("result artifact source differs from its release")
     return source_sha

--- a/scripts/release/receipt-recovery.py
+++ b/scripts/release/receipt-recovery.py
@@ -10,6 +10,21 @@ from pathlib import Path
 from typing import Any
 
 from github_actions import gh_api, read_json
+from receipt_recovery_topology import (
+    ACTIVE,
+    DIRECT_SUCCESS_JOBS,
+    EARLY_SUCCESS_JOBS,
+    LEGACY_DOWNSTREAM_PREFIX,
+    LINUX_SIGNING_JOB,
+    OWNED_WRITER_JOBS,
+    PAYLOAD_CHANNELS,
+    POST_MUTATION_JOB_MAP,
+    POST_MUTATION_RESULT_CHANNELS,
+    POST_MUTATION_SKIPPED_AFTER_FAILURE,
+    PREPARATION_PREFIX,
+    PREPARATION_SUCCESS_JOBS,
+    SKIPPED_AFTER_FAILURE,
+)
 
 REPOSITORY = "Helvesec/rmux"
 REPOSITORY_ID = 1239918790
@@ -17,60 +32,6 @@ RECEIPT_WORKFLOW_ID = 316435347
 CI_WORKFLOW_ID = 277622540
 SHA40 = re.compile(r"[0-9a-f]{40}")
 RELEASE_REF = re.compile(r"v[0-9]+\.[0-9]+\.[0-9]+(?:-rc\.[0-9]+)?")
-ACTIVE = frozenset({"queued", "in_progress", "requested", "waiting", "pending"})
-DIRECT_SUCCESS_JOBS = frozenset(
-    {
-        "Verify immutable Release and create receipt",
-        "Audit live downstream repository authority",
-    }
-)
-PREPARATION_SUCCESS_JOBS = frozenset(
-    {
-        "Prepare non-authoritative downstream plan",
-        "Verify exact downstream repository authority audit",
-        "Prepare exact downstream payloads / Materialize exact channel payloads",
-    }
-)
-EARLY_SUCCESS_JOBS = DIRECT_SUCCESS_JOBS | PREPARATION_SUCCESS_JOBS
-LINUX_SIGNING_JOB = "Build exact signed Linux repository trees / Sign retained APT and RPM repository trees"
-OWNED_WRITER_JOBS = frozenset(
-    {
-        "Publish exact Homebrew tap formula / Publish owned channel homebrew_tap",
-        "Publish exact Scoop manifest / Publish owned channel scoop",
-        "Publish exact Web Share WASM bytes / Publish owned channel web_share",
-    }
-)
-SKIPPED_AFTER_FAILURE = frozenset(
-    {
-        "Build exact signed Linux repository trees / Publish only this run's authorized recovery artifact",
-        "Publish exact signed APT and RPM repositories",
-        "Publish exact crates.io package set",
-        "Record denied RC Linux repository channel",
-        "Submit exact Chocolatey package",
-        "Record disabled Snap stable channel",
-        "Record manual Homebrew Core submission",
-        "Record manual WinGet submission",
-        "Publish exact Snap candidate revisions",
-        "Aggregate ten exact pre-site results",
-        "Record blocked automated rmux.io update",
-        "Prepare manual rmux.io handoff",
-        "Aggregate all eleven exact channel results",
-    }
-)
-LEGACY_DOWNSTREAM_PREFIX = "Receipt-gated downstream publication / "
-PREPARATION_PREFIX = "Prepare receipt-gated downstream publication / "
-PAYLOAD_CHANNELS = (
-    "apt_rpm",
-    "chocolatey",
-    "crates_io",
-    "homebrew_core",
-    "homebrew_tap",
-    "scoop",
-    "snap_candidate",
-    "snap_stable",
-    "web_share",
-    "winget",
-)
 
 
 def object_fixture(path: Path | None, endpoint: str) -> dict[str, Any]:
@@ -136,7 +97,7 @@ def exact_step(steps: dict[str, str], name: str, conclusion: str, label: str) ->
 
 def canonical_failed_jobs(
     jobs: dict[str, dict[str, Any]],
-) -> dict[str, dict[str, Any]]:
+) -> tuple[dict[str, dict[str, Any]], bool]:
     downstream_jobs = (
         PREPARATION_SUCCESS_JOBS
         | {LINUX_SIGNING_JOB}
@@ -153,20 +114,41 @@ def canonical_failed_jobs(
         | OWNED_WRITER_JOBS
         | SKIPPED_AFTER_FAILURE
     )
+    post_mutation_names = (
+        DIRECT_SUCCESS_JOBS
+        | {f"{PREPARATION_PREFIX}{name}" for name in PREPARATION_SUCCESS_JOBS}
+        | set(POST_MUTATION_JOB_MAP)
+        | POST_MUTATION_SKIPPED_AFTER_FAILURE
+    )
     raw_names = set(jobs)
     if raw_names == legacy_names:
-        return {
-            name.removeprefix(LEGACY_DOWNSTREAM_PREFIX): job
-            for name, job in jobs.items()
-        }
+        return (
+            {
+                name.removeprefix(LEGACY_DOWNSTREAM_PREFIX): job
+                for name, job in jobs.items()
+            },
+            False,
+        )
     if raw_names == direct_names:
-        return {
-            name.removeprefix(PREPARATION_PREFIX): job for name, job in jobs.items()
-        }
+        return (
+            {name.removeprefix(PREPARATION_PREFIX): job for name, job in jobs.items()},
+            False,
+        )
+    if raw_names == post_mutation_names:
+        return (
+            {
+                POST_MUTATION_JOB_MAP.get(
+                    name.removeprefix(PREPARATION_PREFIX),
+                    name.removeprefix(PREPARATION_PREFIX),
+                ): job
+                for name, job in jobs.items()
+            },
+            True,
+        )
     raise ValueError("failed downstream job topology differs")
 
 
-def verify_failed_downstream_jobs(value: dict[str, Any]) -> None:
+def verify_failed_downstream_jobs(value: dict[str, Any]) -> bool:
     jobs = value.get("jobs")
     if not isinstance(jobs, list) or value.get("total_count") != len(jobs):
         raise ValueError("failed downstream job set is malformed")
@@ -178,11 +160,14 @@ def verify_failed_downstream_jobs(value: dict[str, Any]) -> None:
         if name in by_name:
             raise ValueError("failed downstream job names are not unique")
         by_name[name] = job
-    by_name = canonical_failed_jobs(by_name)
+    by_name, post_mutation = canonical_failed_jobs(by_name)
     for name in EARLY_SUCCESS_JOBS:
         if by_name[name].get("conclusion") != "success":
             raise ValueError(f"failed downstream prerequisite {name} is not successful")
-    for name in SKIPPED_AFTER_FAILURE:
+    skipped_jobs = (
+        POST_MUTATION_SKIPPED_AFTER_FAILURE if post_mutation else SKIPPED_AFTER_FAILURE
+    )
+    for name in skipped_jobs:
         if (
             by_name[name].get("conclusion") != "skipped"
             or by_name[name].get("steps") != []
@@ -190,6 +175,34 @@ def verify_failed_downstream_jobs(value: dict[str, Any]) -> None:
             raise ValueError(f"post-failure downstream job {name} was not untouched")
 
     linux = by_name[LINUX_SIGNING_JOB]
+    if post_mutation:
+        checkout = "Run actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5"
+        post_checkout = f"Post {checkout}"
+        linux_steps = job_steps(linux, LINUX_SIGNING_JOB)
+        expected_linux_steps = {
+            "Set up job": "success",
+            checkout: "success",
+            "Run ./.github/actions/release-linux-repository-build": "success",
+            post_checkout: "success",
+            "Complete job": "success",
+        }
+        if linux.get("conclusion") != "success" or linux_steps != expected_linux_steps:
+            raise ValueError("post-mutation Linux repository build is not successful")
+        action = "Run ./.github/actions/release-owned-repository-publish"
+        expected_writer_steps = {
+            "Set up job": "success",
+            checkout: "success",
+            action: "failure",
+            f"Post {action}": "success",
+            post_checkout: "success",
+            "Complete job": "success",
+        }
+        for name in OWNED_WRITER_JOBS:
+            job = by_name[name]
+            steps = job_steps(job, name)
+            if job.get("conclusion") != "failure" or steps != expected_writer_steps:
+                raise ValueError(f"post-mutation writer failure {name} differs")
+        return True
     if linux.get("conclusion") != "failure":
         raise ValueError("Linux repository signing did not fail closed")
     linux_steps = job_steps(linux, LINUX_SIGNING_JOB)
@@ -229,10 +242,14 @@ def verify_failed_downstream_jobs(value: dict[str, Any]) -> None:
             "skipped",
             name,
         )
+    return False
 
 
 def verify_failed_downstream_artifacts(
-    value: dict[str, Any], args: argparse.Namespace, failed_control_sha: str
+    value: dict[str, Any],
+    args: argparse.Namespace,
+    failed_control_sha: str,
+    post_mutation: bool,
 ) -> int:
     artifacts = value.get("artifacts")
     if not isinstance(artifacts, list) or value.get("total_count") != len(artifacts):
@@ -247,6 +264,14 @@ def verify_failed_downstream_artifacts(
             for channel in PAYLOAD_CHANNELS
         ),
     }
+    if post_mutation:
+        expected_names.add(
+            f"rmux-downstream-apt_rpm-signed-{args.source_sha}-{args.release_id}"
+        )
+        expected_names.update(
+            f"rmux-downstream-{channel}-result-{args.source_sha}-{args.release_id}"
+            for channel in POST_MUTATION_RESULT_CHANNELS
+        )
     by_name: dict[str, dict[str, Any]] = {}
     for artifact in artifacts:
         if not isinstance(artifact, dict) or not isinstance(artifact.get("name"), str):
@@ -333,8 +358,10 @@ def verify_failed_attempt(
     verified_commit(
         failed_commit, failed_control_sha, "failed downstream control commit"
     )
-    verify_failed_downstream_jobs(jobs)
-    return verify_failed_downstream_artifacts(artifacts, args, failed_control_sha)
+    post_mutation = verify_failed_downstream_jobs(jobs)
+    return verify_failed_downstream_artifacts(
+        artifacts, args, failed_control_sha, post_mutation
+    )
 
 
 def prior_attempt_fixtures(args: argparse.Namespace) -> dict[str, Any] | None:

--- a/scripts/release/receipt_recovery_topology.py
+++ b/scripts/release/receipt_recovery_topology.py
@@ -1,0 +1,66 @@
+"""Exact job and artifact topology for fail-closed receipt recovery."""
+
+ACTIVE = frozenset({"queued", "in_progress", "requested", "waiting", "pending"})
+DIRECT_SUCCESS_JOBS = frozenset(
+    {
+        "Verify immutable Release and create receipt",
+        "Audit live downstream repository authority",
+    }
+)
+PREPARATION_SUCCESS_JOBS = frozenset(
+    {
+        "Prepare non-authoritative downstream plan",
+        "Verify exact downstream repository authority audit",
+        "Prepare exact downstream payloads / Materialize exact channel payloads",
+    }
+)
+EARLY_SUCCESS_JOBS = DIRECT_SUCCESS_JOBS | PREPARATION_SUCCESS_JOBS
+LINUX_SIGNING_JOB = "Build exact signed Linux repository trees / Sign retained APT and RPM repository trees"
+OWNED_WRITER_JOBS = frozenset(
+    {
+        "Publish exact Homebrew tap formula / Publish owned channel homebrew_tap",
+        "Publish exact Scoop manifest / Publish owned channel scoop",
+        "Publish exact Web Share WASM bytes / Publish owned channel web_share",
+    }
+)
+SKIPPED_AFTER_FAILURE = frozenset(
+    {
+        "Build exact signed Linux repository trees / Publish only this run's authorized recovery artifact",
+        "Publish exact signed APT and RPM repositories",
+        "Publish exact crates.io package set",
+        "Record denied RC Linux repository channel",
+        "Submit exact Chocolatey package",
+        "Record disabled Snap stable channel",
+        "Record manual Homebrew Core submission",
+        "Record manual WinGet submission",
+        "Publish exact Snap candidate revisions",
+        "Aggregate ten exact pre-site results",
+        "Record blocked automated rmux.io update",
+        "Prepare manual rmux.io handoff",
+        "Aggregate all eleven exact channel results",
+    }
+)
+POST_MUTATION_SKIPPED_AFTER_FAILURE = SKIPPED_AFTER_FAILURE - {
+    "Build exact signed Linux repository trees / Publish only this run's authorized recovery artifact"
+}
+LEGACY_DOWNSTREAM_PREFIX = "Receipt-gated downstream publication / "
+PREPARATION_PREFIX = "Prepare receipt-gated downstream publication / "
+PAYLOAD_CHANNELS = (
+    "apt_rpm",
+    "chocolatey",
+    "crates_io",
+    "homebrew_core",
+    "homebrew_tap",
+    "scoop",
+    "snap_candidate",
+    "snap_stable",
+    "web_share",
+    "winget",
+)
+POST_MUTATION_JOB_MAP = {
+    "Build exact signed Linux repository trees": LINUX_SIGNING_JOB,
+    "Publish exact Homebrew tap formula": "Publish exact Homebrew tap formula / Publish owned channel homebrew_tap",
+    "Publish exact Scoop manifest": "Publish exact Scoop manifest / Publish owned channel scoop",
+    "Publish exact Web Share WASM bytes": "Publish exact Web Share WASM bytes / Publish owned channel web_share",
+}
+POST_MUTATION_RESULT_CHANNELS = ("homebrew_tap", "scoop", "web_share")

--- a/tests/acceptance_source_config_matrix.rs
+++ b/tests/acceptance_source_config_matrix.rs
@@ -604,24 +604,14 @@ fn startup_config_unquoted_windows_powershell_default_shell_starts_powershell(
         OsStr::new("-s"),
         OsStr::new("psdefault"),
     ])?;
-    std::thread::sleep(std::time::Duration::from_millis(1_800));
     harness.success(["has-session", "-t", "psdefault"])?;
     assert_option(&harness, "default-shell", powershell)?;
-    harness.success([
-        "send-keys",
-        "-t",
-        "psdefault:0.0",
-        "Write-Output ('RMUX_' + 'PS51_READY')",
-        "Enter",
-    ])?;
-    wait_for_capture_contains(
+    wait_for_pane_current_command(
         &harness,
         "psdefault:0.0",
-        "RMUX_PS51_READY",
+        &["powershell.exe", "powershell"],
         std::time::Duration::from_secs(8),
-    )?;
-
-    Ok(())
+    )
 }
 
 #[test]
@@ -774,25 +764,35 @@ fn assert_binding_absent(
 }
 
 #[cfg(windows)]
-fn wait_for_capture_contains(
+fn wait_for_pane_current_command(
     harness: &CrossPlatformHarness,
     target: &str,
-    needle: &str,
+    expected: &[&str],
     timeout: std::time::Duration,
-) -> Result<String, Box<dyn Error>> {
+) -> Result<(), Box<dyn Error>> {
     let deadline = std::time::Instant::now() + timeout;
-    let mut last_capture = String::new();
+    let mut last_command = String::new();
 
     while std::time::Instant::now() < deadline {
-        last_capture = harness.stdout(["capture-pane", "-p", "-t", target])?;
-        if last_capture.contains(needle) {
-            return Ok(last_capture);
+        last_command = harness.stdout([
+            "display-message",
+            "-p",
+            "-t",
+            target,
+            "#{pane_current_command}",
+        ])?;
+        let command = last_command.trim();
+        if expected
+            .iter()
+            .any(|candidate| command.eq_ignore_ascii_case(candidate))
+        {
+            return Ok(());
         }
-        std::thread::sleep(std::time::Duration::from_millis(200));
+        std::thread::sleep(std::time::Duration::from_millis(50));
     }
 
     Err(
-        format!("timed out waiting for {needle:?} in {target}; last capture:\n{last_capture}")
+        format!("timed out waiting for {expected:?} in {target}; last command: {last_command:?}")
             .into(),
     )
 }

--- a/tests/release_downstream_result_evidence_spec.rs
+++ b/tests/release_downstream_result_evidence_spec.rs
@@ -388,6 +388,10 @@ fn result_envelope_normalizes_exact_github_artifact_metadata() {
 with tempfile.TemporaryDirectory(dir=pathlib.Path.cwd()) as root:
     root = pathlib.Path(root)
     paths = write_fixture(root)
+    control_sha = 'f' * 40
+    metadata = json.loads(paths['predicate_meta'].read_text(encoding='utf-8'))
+    metadata['source_git_sha'] = control_sha
+    write_object(paths['predicate_meta'], metadata)
     bundle = root / 'downstream-channel-result.sigstore.json'
     bundle.write_text('{}\n', encoding='utf-8')
     spec = importlib.util.spec_from_file_location(
@@ -402,6 +406,7 @@ with tempfile.TemporaryDirectory(dir=pathlib.Path.cwd()) as root:
         attestation_id='result-attestation-7',
         attestation_bundle=bundle,
         bundle_artifact=paths['predicate_meta'],
+        artifact_source_sha=control_sha,
         created_at='2026-07-20T00:00:30Z',
     ))
     expected = artifact(

--- a/tests/release_receipt_recovery_spec.rs
+++ b/tests/release_receipt_recovery_spec.rs
@@ -259,7 +259,7 @@ fn downstream_failure_jobs() -> Value {
 fn direct_downstream_failure_jobs() -> Value {
     let mut value = downstream_failure_jobs();
     let jobs = value["jobs"].as_array_mut().expect("jobs array");
-    for job in jobs {
+    for job in jobs.iter_mut() {
         let name = job["name"].as_str().expect("job name");
         let Some(short) = name.strip_prefix("Receipt-gated downstream publication / ") else {
             continue;
@@ -280,8 +280,87 @@ fn direct_downstream_failure_jobs() -> Value {
     value
 }
 
+fn post_mutation_failure_jobs() -> Value {
+    let mut value = direct_downstream_failure_jobs();
+    let jobs = value["jobs"].as_array_mut().expect("jobs array");
+    jobs.retain(|job| {
+        job["name"]
+            != "Build exact signed Linux repository trees / Publish only this run's authorized recovery artifact"
+    });
+    for job in jobs.iter_mut() {
+        let name = job["name"].as_str().expect("job name");
+        let replacement = match name {
+            "Build exact signed Linux repository trees / Sign retained APT and RPM repository trees" => {
+                Some(("Build exact signed Linux repository trees", "success", "Run ./.github/actions/release-linux-repository-build"))
+            }
+            "Publish exact Homebrew tap formula / Publish owned channel homebrew_tap" => {
+                Some(("Publish exact Homebrew tap formula", "failure", "Run ./.github/actions/release-owned-repository-publish"))
+            }
+            "Publish exact Scoop manifest / Publish owned channel scoop" => {
+                Some(("Publish exact Scoop manifest", "failure", "Run ./.github/actions/release-owned-repository-publish"))
+            }
+            "Publish exact Web Share WASM bytes / Publish owned channel web_share" => {
+                Some(("Publish exact Web Share WASM bytes", "failure", "Run ./.github/actions/release-owned-repository-publish"))
+            }
+            _ => None,
+        };
+        if let Some((name, conclusion, action)) = replacement {
+            job["name"] = json!(name);
+            job["conclusion"] = json!(conclusion);
+            let mut steps = vec![
+                step("Set up job", "success"),
+                step(
+                    "Run actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5",
+                    "success",
+                ),
+                step(action, conclusion),
+            ];
+            if conclusion == "failure" {
+                steps.push(step(&format!("Post {action}"), "success"));
+            }
+            steps.extend([
+                step(
+                    "Post Run actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5",
+                    "success",
+                ),
+                step("Complete job", "success"),
+            ]);
+            job["steps"] = json!(steps);
+        }
+    }
+    value["total_count"] = json!(jobs.len());
+    value
+}
+
 fn downstream_failure_artifacts() -> (Value, u64) {
     downstream_failure_artifacts_for(FAILED_RUN, FAILED_CONTROL, 81)
+}
+
+fn post_mutation_failure_artifacts() -> (Value, u64) {
+    let (mut value, receipt_id) = downstream_failure_artifacts();
+    let artifacts = value["artifacts"].as_array_mut().expect("artifacts array");
+    for name in [
+        format!("rmux-downstream-apt_rpm-signed-{SOURCE}-{RELEASE_ID}"),
+        format!("rmux-downstream-homebrew_tap-result-{SOURCE}-{RELEASE_ID}"),
+        format!("rmux-downstream-scoop-result-{SOURCE}-{RELEASE_ID}"),
+        format!("rmux-downstream-web_share-result-{SOURCE}-{RELEASE_ID}"),
+    ] {
+        artifacts.push(json!({
+            "id": receipt_id + artifacts.len() as u64,
+            "name": name,
+            "expired": false,
+            "digest": format!("sha256:{}", "a".repeat(64)),
+            "workflow_run": {
+                "id": FAILED_RUN,
+                "head_sha": FAILED_CONTROL,
+                "head_branch": "main",
+                "repository_id": 1_239_918_790,
+                "head_repository_id": 1_239_918_790,
+            },
+        }));
+    }
+    value["total_count"] = json!(artifacts.len());
+    (value, receipt_id)
 }
 
 fn downstream_failure_artifacts_for(
@@ -404,6 +483,35 @@ fn protected_main_recovery_accepts_the_flattened_pre_mutation_topology() {
     let root = fixture_root("flattened-pre-mutation");
     let jobs = direct_downstream_failure_jobs();
     let (artifacts, receipt_id) = downstream_failure_artifacts();
+    let output = run_recovery(
+        &root,
+        failed_run(FAILED_CONTROL, "main", "failure"),
+        jobs,
+        artifacts,
+        json!({
+            "total_count": 1,
+            "artifacts": [{
+                "id": receipt_id,
+                "name": format!("rmux-publication-receipt-{SOURCE}-{RELEASE_ID}"),
+                "expired": false,
+                "workflow_run": {"id": FAILED_RUN},
+            }],
+        }),
+    );
+    fs::remove_dir_all(&root).expect("remove fixture root");
+    assert!(
+        output.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn protected_main_recovery_accepts_only_the_exact_post_mutation_seal_failure() {
+    let root = fixture_root("post-mutation-seal");
+    let jobs = post_mutation_failure_jobs();
+    let (artifacts, receipt_id) = post_mutation_failure_artifacts();
     let output = run_recovery(
         &root,
         failed_run(FAILED_CONTROL, "main", "failure"),


### PR DESCRIPTION
## Summary

- recognize the exact post-mutation receipt failure topology
- allow receipt recovery jobs to seal results from the protected control SHA
- preserve exact artifact, runner, job-step, and receipt-chain validation

## Validation

- all release integration tests
- cargo clippy --workspace --all-targets --locked -- -D warnings
- release contracts, Ruff, Rustfmt, and diff checks
- replay against the exact jobs and artifacts from failed run 30950485655
