### PR TITLE
fix(release): verify receipt recovery attestations

### DIFF
--- a/crates/rmux-server/src/terminal/tests.rs
+++ b/crates/rmux-server/src/terminal/tests.rs
@@ -1268,13 +1268,11 @@ fn hook_append_command(path: &Path, first: &str, second: &str) -> String {
     }
     #[cfg(windows)]
     {
-        crate::test_shell::powershell_encoded_command(&format!(
-            "[IO.File]::WriteAllText({}, {}); [IO.File]::AppendAllText({}, {})",
-            powershell_quote_path(path),
-            powershell_quote(first),
-            powershell_quote_path(path),
-            powershell_quote(second)
-        ))
+        format!(
+            r#"<nul set /p "={first}">"{}" & <nul set /p "={second}">>"{}""#,
+            path.display(),
+            path.display()
+        )
     }
 }
 

--- a/scripts/release/verify-channel-result-attestation.py
+++ b/scripts/release/verify-channel-result-attestation.py
@@ -15,7 +15,11 @@ from downstream_channels import (
     file_hash,
     read_object,
 )
-from downstream_result import LINUX_RECOVERY_PRODUCER, LINUX_RECOVERY_SIGNER
+from downstream_result import (
+    LINUX_RECOVERY_PRODUCER,
+    LINUX_RECOVERY_SIGNER,
+    RECEIPT_RECOVERY_PRODUCER,
+)
 from downstream_result_document import validate_envelope, validate_predicate
 
 REPOSITORY = "Helvesec/rmux"
@@ -79,6 +83,15 @@ def verify(args: argparse.Namespace) -> None:
             or producer_source_ref != "refs/heads/main"
         ):
             raise ValueError("Linux recovery attestation producer identity changed")
+    elif (
+        producer_path == RECEIPT_RECOVERY_PRODUCER
+        and producer_source_ref == "refs/heads/main"
+    ):
+        if (
+            producer_source_sha == args.source_sha
+            or signer_path != RECEIPT_RECOVERY_PRODUCER
+        ):
+            raise ValueError("receipt recovery attestation producer identity changed")
     elif (
         producer_source_sha != args.source_sha
         or producer_source_ref != f"refs/tags/{args.release_ref}"

--- a/tests/release_downstream_result_evidence_spec.rs
+++ b/tests/release_downstream_result_evidence_spec.rs
@@ -526,6 +526,26 @@ with tempfile.TemporaryDirectory(dir=pathlib.Path.cwd()) as root:
         if expected not in arguments:
             raise SystemExit(f'missing attestation policy argument: {expected}')
 
+    control_sha = '9' * 40
+    args.producer_source_sha = control_sha
+    args.producer_source_ref = 'refs/heads/main'
+    args.attestation_signer_workflow = '.github/workflows/release-receipt.yml'
+    verifier.verify(args)
+    arguments = arguments_path.read_text(encoding='utf-8').splitlines()
+    for expected in (control_sha, 'refs/heads/main'):
+        if expected not in arguments:
+            raise SystemExit(f'missing recovery attestation argument: {expected}')
+
+    args.attestation_signer_workflow = '.github/workflows/release-promote.yml'
+    try:
+        verifier.verify(args)
+    except ValueError as error:
+        if 'recovery attestation producer identity changed' not in str(error):
+            raise
+    else:
+        raise SystemExit('forged receipt recovery signer was accepted')
+    args.attestation_signer_workflow = '.github/workflows/release-receipt.yml'
+
     write_verification(digest='0' * 64)
     try:
         verifier.verify(args)


### PR DESCRIPTION
Allow only the protected main receipt workflow to attest recovery results from a control SHA distinct from the released source SHA.

Validated against the real Sigstore bundle from receipt run 30957814935. The branch also removes a cold PowerShell dependency from the Windows compound-hook fixture that failed the first CI attempt.