### PR TITLE
fix(release): accept exact legacy result topology

### DIFF
--- a/scripts/release/receipt-recovery.py
+++ b/scripts/release/receipt-recovery.py
@@ -24,6 +24,7 @@ from receipt_recovery_topology import (
     PREPARATION_PREFIX,
     PREPARATION_SUCCESS_JOBS,
     SKIPPED_AFTER_FAILURE,
+    result_envelope_names,
 )
 
 REPOSITORY = "Helvesec/rmux"
@@ -264,6 +265,7 @@ def verify_failed_downstream_artifacts(
             for channel in PAYLOAD_CHANNELS
         ),
     }
+    allowed_names = (expected_names,)
     if post_mutation:
         expected_names.add(
             f"rmux-downstream-apt_rpm-signed-{args.source_sha}-{args.release_id}"
@@ -272,9 +274,9 @@ def verify_failed_downstream_artifacts(
             f"rmux-downstream-{channel}-result-{args.source_sha}-{args.release_id}"
             for channel in POST_MUTATION_RESULT_CHANNELS
         )
-        expected_names.update(
-            f"rmux-downstream-{channel}-result-envelope-{args.source_sha}-{args.release_id}"
-            for channel in POST_MUTATION_RESULT_CHANNELS
+        allowed_names = (
+            expected_names,
+            expected_names | result_envelope_names(args.source_sha, args.release_id),
         )
     by_name: dict[str, dict[str, Any]] = {}
     for artifact in artifacts:
@@ -284,7 +286,7 @@ def verify_failed_downstream_artifacts(
         if name in by_name:
             raise ValueError("failed downstream artifact names are not unique")
         by_name[name] = artifact
-    if set(by_name) != expected_names:
+    if set(by_name) not in allowed_names:
         raise ValueError("failed downstream artifact topology differs")
     for name, artifact in by_name.items():
         workflow_run = artifact.get("workflow_run", {})

--- a/scripts/release/receipt_recovery_topology.py
+++ b/scripts/release/receipt_recovery_topology.py
@@ -64,3 +64,10 @@ POST_MUTATION_JOB_MAP = {
     "Publish exact Web Share WASM bytes": "Publish exact Web Share WASM bytes / Publish owned channel web_share",
 }
 POST_MUTATION_RESULT_CHANNELS = ("homebrew_tap", "scoop", "web_share")
+
+
+def result_envelope_names(source_sha: str, release_id: int) -> set[str]:
+    return {
+        f"rmux-downstream-{channel}-result-envelope-{source_sha}-{release_id}"
+        for channel in POST_MUTATION_RESULT_CHANNELS
+    }

--- a/tests/release_receipt_recovery_spec.rs
+++ b/tests/release_receipt_recovery_spec.rs
@@ -337,25 +337,39 @@ fn downstream_failure_artifacts() -> (Value, u64) {
 }
 
 fn post_mutation_failure_artifacts() -> (Value, u64) {
-    let (mut value, receipt_id) = downstream_failure_artifacts();
+    post_mutation_failure_artifacts_for(FAILED_RUN, FAILED_CONTROL, 81, true)
+}
+
+fn post_mutation_failure_artifacts_for(
+    run_id: u64,
+    control_sha: &str,
+    receipt_id: u64,
+    include_envelopes: bool,
+) -> (Value, u64) {
+    let (mut value, receipt_id) = downstream_failure_artifacts_for(run_id, control_sha, receipt_id);
     let artifacts = value["artifacts"].as_array_mut().expect("artifacts array");
-    for name in [
-        format!("rmux-downstream-apt_rpm-signed-{SOURCE}-{RELEASE_ID}"),
-        format!("rmux-downstream-homebrew_tap-result-{SOURCE}-{RELEASE_ID}"),
-        format!("rmux-downstream-homebrew_tap-result-envelope-{SOURCE}-{RELEASE_ID}"),
-        format!("rmux-downstream-scoop-result-{SOURCE}-{RELEASE_ID}"),
-        format!("rmux-downstream-scoop-result-envelope-{SOURCE}-{RELEASE_ID}"),
-        format!("rmux-downstream-web_share-result-{SOURCE}-{RELEASE_ID}"),
-        format!("rmux-downstream-web_share-result-envelope-{SOURCE}-{RELEASE_ID}"),
-    ] {
+    let mut names = vec![format!(
+        "rmux-downstream-apt_rpm-signed-{SOURCE}-{RELEASE_ID}"
+    )];
+    for channel in ["homebrew_tap", "scoop", "web_share"] {
+        names.push(format!(
+            "rmux-downstream-{channel}-result-{SOURCE}-{RELEASE_ID}"
+        ));
+        if include_envelopes {
+            names.push(format!(
+                "rmux-downstream-{channel}-result-envelope-{SOURCE}-{RELEASE_ID}"
+            ));
+        }
+    }
+    for name in names {
         artifacts.push(json!({
             "id": receipt_id + artifacts.len() as u64,
             "name": name,
             "expired": false,
             "digest": format!("sha256:{}", "a".repeat(64)),
             "workflow_run": {
-                "id": FAILED_RUN,
-                "head_sha": FAILED_CONTROL,
+                "id": run_id,
+                "head_sha": control_sha,
                 "head_branch": "main",
                 "repository_id": 1_239_918_790,
                 "head_repository_id": 1_239_918_790,
@@ -540,8 +554,8 @@ fn protected_main_recovery_accepts_only_the_exact_post_mutation_seal_failure() {
 }
 
 #[test]
-fn protected_main_recovery_rejects_missing_post_mutation_result_envelope() {
-    let root = fixture_root("post-mutation-missing-envelope");
+fn protected_main_recovery_rejects_partial_post_mutation_result_envelopes() {
+    let root = fixture_root("post-mutation-partial-envelopes");
     let (mut artifacts, receipt_id) = post_mutation_failure_artifacts();
     let entries = artifacts["artifacts"]
         .as_array_mut()
@@ -570,17 +584,17 @@ fn protected_main_recovery_rejects_missing_post_mutation_result_envelope() {
 }
 
 #[test]
-fn protected_main_recovery_accepts_only_a_verified_linear_receipt_chain() {
-    let root = fixture_root("linear-chain");
-    let (artifacts, receipt_id) = downstream_failure_artifacts();
+fn protected_main_recovery_accepts_complete_results_after_a_legacy_result_set() {
+    let root = fixture_root("legacy-result-chain");
+    let (artifacts, receipt_id) = post_mutation_failure_artifacts();
     let (prior_artifacts, prior_receipt_id) =
-        downstream_failure_artifacts_for(PRIOR_RUN, PRIOR_CONTROL, 181);
+        post_mutation_failure_artifacts_for(PRIOR_RUN, PRIOR_CONTROL, 181, false);
     let mut prior_attempts = serde_json::Map::new();
     prior_attempts.insert(
         PRIOR_RUN.to_string(),
         json!({
             "run": failed_run_with_id(PRIOR_RUN, PRIOR_CONTROL, "main", "failure"),
-            "jobs": downstream_failure_jobs(),
+            "jobs": post_mutation_failure_jobs(),
             "artifacts": prior_artifacts,
             "commit": {
                 "sha": PRIOR_CONTROL,
@@ -591,7 +605,7 @@ fn protected_main_recovery_accepts_only_a_verified_linear_receipt_chain() {
     let output = run_recovery_with_prior(
         &root,
         failed_run(FAILED_CONTROL, "main", "failure"),
-        downstream_failure_jobs(),
+        post_mutation_failure_jobs(),
         artifacts,
         json!({
             "total_count": 2,


### PR DESCRIPTION
Recognize both exact post-mutation recovery shapes present in the v0.10.0 receipt chain: the legacy three-result set and the newer three result-envelope pairs. Continue to reject any partial envelope set.\n\nValidation:\n- 33 targeted release tests\n- complete five-receipt live chain from the GitHub API\n- release contracts\n- Rustfmt and Ruff