### PR TITLE
fix(release): make package publication recoverable

### DIFF
--- a/.github/release/candidate-contract.json
+++ b/.github/release/candidate-contract.json
@@ -495,6 +495,7 @@
     "scripts/release/downstream_workflow_contract.py",
     "scripts/release/github_actions.py",
     "scripts/release/github_release_api.py",
+    "scripts/release/github_repository_commit_plan.py",
     "scripts/release/github_repository_writer.py",
     "scripts/release/install-gh-2.93.0.sh",
     "scripts/release/install-linux-glibc-build-tools.sh",

--- a/.github/workflows/release-receipt.yml
+++ b/.github/workflows/release-receipt.yml
@@ -139,6 +139,19 @@ jobs:
       release_ref: ${{ inputs.release_ref }}
       release_kind: ${{ inputs.release_kind }}
       snap_candidate_opt_in: ${{ inputs.snap_candidate_opt_in }}
+
+  preflight-crates-oidc:
+    name: Verify crates.io Trusted Publishing authority
+    needs: [downstream-preparation]
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    environment: release
+    permissions:
+      id-token: write
+    steps:
+      - name: Exchange and revoke a preflight crates.io token
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18
+
   build-linux-repository:
     name: Build exact signed Linux repository trees
     needs: [downstream-preparation]
@@ -173,7 +186,7 @@ jobs:
 
   publish-homebrew-tap:
     name: Publish exact Homebrew tap formula
-    needs: [downstream-preparation]
+    needs: [downstream-preparation, preflight-crates-oidc]
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     environment: release-publication
@@ -204,7 +217,7 @@ jobs:
 
   publish-scoop:
     name: Publish exact Scoop manifest
-    needs: [downstream-preparation]
+    needs: [downstream-preparation, preflight-crates-oidc]
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     environment: release-publication
@@ -235,7 +248,7 @@ jobs:
 
   publish-web-share:
     name: Publish exact Web Share WASM bytes
-    needs: [downstream-preparation]
+    needs: [downstream-preparation, preflight-crates-oidc]
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     environment: release-publication
@@ -266,7 +279,7 @@ jobs:
 
   publish-linux-repository:
     name: Publish exact signed APT and RPM repositories
-    needs: [downstream-preparation, build-linux-repository, publish-homebrew-tap, publish-scoop, publish-web-share]
+    needs: [downstream-preparation, preflight-crates-oidc, build-linux-repository, publish-homebrew-tap, publish-scoop, publish-web-share]
     if: ${{ !cancelled() && !failure() && inputs.release_kind == 'stable' }}
     runs-on: ubuntu-22.04
     timeout-minutes: 20
@@ -320,7 +333,7 @@ jobs:
 
   publish-crates:
     name: Publish exact crates.io package set
-    needs: [downstream-preparation, build-linux-repository, publish-homebrew-tap, publish-scoop, publish-web-share]
+    needs: [downstream-preparation, preflight-crates-oidc, build-linux-repository, publish-homebrew-tap, publish-scoop, publish-web-share]
     if: ${{ !cancelled() && !failure() }}
     uses: ./.github/workflows/release-crates-channel.yml
     permissions:

--- a/scripts/release/downstream_workflow_contract.py
+++ b/scripts/release/downstream_workflow_contract.py
@@ -574,6 +574,8 @@ def _validate_helper_sizes(root: Path) -> None:
         "downstream_result_reference.py",
         "downstream_summary.py",
         "collect-downstream-repository.py",
+        "github_repository_commit_plan.py",
+        "github_repository_writer.py",
         "verify-downstream-repository.py",
         "verify-channel-result-attestation.py",
         "prepare-channel-retry.py",
@@ -627,6 +629,24 @@ def _validate_channel_orchestration(receipt: str, preparation: str) -> None:
     for secret, count in protected_secrets.items():
         if receipt.count(f"secrets.{secret}") != count:
             raise ValueError(f"protected receipt secret count changed for {secret}")
+    crates_auth = (
+        "rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18"
+    )
+    if receipt.count(crates_auth) != 1:
+        raise ValueError("receipt lost its exact crates.io OIDC preflight")
+    preflight = receipt.find("\n  preflight-crates-oidc:\n")
+    first_writer = receipt.find("\n  publish-homebrew-tap:\n")
+    if preflight <= 0 or first_writer <= preflight:
+        raise ValueError("crates.io OIDC preflight must precede public writers")
+    if receipt.count("needs: [downstream-preparation, preflight-crates-oidc]") != 3:
+        raise ValueError("owned repository writers bypass the crates.io preflight")
+    crates_needs = (
+        "needs: [downstream-preparation, preflight-crates-oidc, "
+        "build-linux-repository, publish-homebrew-tap, publish-scoop, "
+        "publish-web-share]"
+    )
+    if receipt.count(crates_needs) != 2:
+        raise ValueError("package publication bypasses its OIDC preflight")
     markers = tuple(
         receipt.find(f"\n  {job}:\n")
         for job in (

--- a/scripts/release/github_repository_commit_plan.py
+++ b/scripts/release/github_repository_commit_plan.py
@@ -1,0 +1,159 @@
+"""Plan bounded GitHub-signed commits for one downstream repository update."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from typing import Any
+
+
+CREATE_COMMIT_MUTATION = """
+mutation CreateSignedCommit($input: CreateCommitOnBranchInput!) {
+  createCommitOnBranch(input: $input) {
+    commit {
+      oid
+      signature {
+        isValid
+        state
+        wasSignedByGitHub
+      }
+    }
+    ref {
+      target {
+        oid
+      }
+    }
+  }
+}
+"""
+
+GRAPHQL_COMMIT_MAX_BYTES = 44_000_000
+STAGING_BRANCH_PREFIX = "rmux-release-stage"
+
+
+def commit_variables(
+    *,
+    full_name: str,
+    branch: str,
+    base_commit: str,
+    additions: dict[str, bytes],
+    deletions: set[str],
+    message: str,
+) -> dict[str, Any]:
+    return {
+        "input": {
+            "branch": {
+                "repositoryNameWithOwner": full_name,
+                "branchName": branch,
+            },
+            "expectedHeadOid": base_commit,
+            "message": {"headline": message},
+            "fileChanges": {
+                "additions": [
+                    {
+                        "path": path,
+                        "contents": base64.b64encode(contents).decode("ascii"),
+                    }
+                    for path, contents in sorted(additions.items())
+                ],
+                "deletions": [{"path": path} for path in sorted(deletions)],
+            },
+        }
+    }
+
+
+def commit_request_size(
+    *,
+    full_name: str,
+    branch: str,
+    base_commit: str,
+    additions: dict[str, bytes],
+    deletions: set[str],
+    message: str,
+) -> int:
+    variables = commit_variables(
+        full_name=full_name,
+        branch=branch,
+        base_commit=base_commit,
+        additions=additions,
+        deletions=deletions,
+        message=message,
+    )
+    return len(
+        json.dumps(
+            {"query": CREATE_COMMIT_MUTATION, "variables": variables},
+            separators=(",", ":"),
+        ).encode()
+    )
+
+
+def signed_commit_batches(
+    *,
+    full_name: str,
+    branch: str,
+    base_commit: str,
+    additions: dict[str, bytes],
+    deletions: set[str],
+    message: str,
+) -> list[tuple[dict[str, bytes], set[str]]]:
+    batches: list[tuple[dict[str, bytes], set[str]]] = []
+    current: dict[str, bytes] = {}
+    pending_deletions = set(deletions)
+    sizing_message = f"{message} (part 999/999)"
+    for path, contents in sorted(additions.items()):
+        candidate = {**current, path: contents}
+        size = commit_request_size(
+            full_name=full_name,
+            branch=branch,
+            base_commit=base_commit,
+            additions=candidate,
+            deletions=pending_deletions,
+            message=sizing_message,
+        )
+        if size <= GRAPHQL_COMMIT_MAX_BYTES:
+            current = candidate
+            continue
+        if not current:
+            raise ValueError(
+                f"downstream file exceeds GitHub's signed commit limit: {path}"
+            )
+        batches.append((current, pending_deletions))
+        current = {path: contents}
+        pending_deletions = set()
+        if (
+            commit_request_size(
+                full_name=full_name,
+                branch=branch,
+                base_commit=base_commit,
+                additions=current,
+                deletions=pending_deletions,
+                message=sizing_message,
+            )
+            > GRAPHQL_COMMIT_MAX_BYTES
+        ):
+            raise ValueError(
+                f"downstream file exceeds GitHub's signed commit limit: {path}"
+            )
+    if current or pending_deletions:
+        batches.append((current, pending_deletions))
+    if not batches:
+        raise ValueError("downstream repository update has no file changes")
+    return batches
+
+
+def staging_branch_name(
+    base_commit: str, updates: dict[str, bytes], deletions: set[str]
+) -> str:
+    digest = hashlib.sha256()
+    digest.update(base_commit.encode())
+    for path, contents in sorted(updates.items()):
+        digest.update(b"A\0")
+        digest.update(path.encode())
+        digest.update(b"\0")
+        digest.update(hashlib.sha256(contents).digest())
+    for path in sorted(deletions):
+        digest.update(b"D\0")
+        digest.update(path.encode())
+        digest.update(b"\0")
+    return f"{STAGING_BRANCH_PREFIX}-{base_commit[:12]}-{digest.hexdigest()[:16]}"

--- a/scripts/release/github_repository_writer.py
+++ b/scripts/release/github_repository_writer.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import base64
 import json
 import urllib.error
 import urllib.parse
@@ -10,26 +9,13 @@ import urllib.request
 from dataclasses import dataclass
 from typing import Any
 
-
-CREATE_COMMIT_MUTATION = """
-mutation CreateSignedCommit($input: CreateCommitOnBranchInput!) {
-  createCommitOnBranch(input: $input) {
-    commit {
-      oid
-      signature {
-        isValid
-        state
-        wasSignedByGitHub
-      }
-    }
-    ref {
-      target {
-        oid
-      }
-    }
-  }
-}
-"""
+from github_repository_commit_plan import (
+    CREATE_COMMIT_MUTATION,
+    GRAPHQL_COMMIT_MAX_BYTES,
+    commit_variables,
+    signed_commit_batches,
+    staging_branch_name,
+)
 
 
 @dataclass(frozen=True)
@@ -113,12 +99,48 @@ class GitHubApi:
     def post(self, path: str, payload: dict[str, Any]) -> dict[str, Any]:
         return self.request("POST", path, payload)
 
+    def patch(self, path: str, payload: dict[str, Any]) -> dict[str, Any]:
+        return self.request("PATCH", path, payload)
+
+    def delete(self, path: str) -> None:
+        if not path.startswith("/") or "//" in path:
+            raise ValueError("GitHub API path is invalid")
+        request = urllib.request.Request(
+            f"https://api.github.com{path}",
+            method="DELETE",
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {self._token}",
+                "User-Agent": "rmux-release-writer/1",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                raw = response.read(1)
+        except urllib.error.HTTPError as error:
+            detail = error.read(4096).decode("utf-8", errors="replace")
+            raise ValueError(
+                f"GitHub API DELETE {path} failed: {error.code} {detail}"
+            ) from error
+        if raw:
+            raise ValueError("GitHub API DELETE returned an unexpected response")
+
     def graphql(self, query: str, variables: dict[str, Any]) -> dict[str, Any]:
         value = self.post("/graphql", {"query": query, "variables": variables})
         errors = value.get("errors")
         data = value.get("data")
         if errors is not None or not isinstance(data, dict):
-            raise ValueError("GitHub GraphQL commit mutation failed")
+            messages = []
+            if isinstance(errors, list):
+                for error in errors[:3]:
+                    if not isinstance(error, dict):
+                        continue
+                    message = error.get("message")
+                    if isinstance(message, str):
+                        messages.append(" ".join(message.split())[:500])
+            detail = f": {'; '.join(messages)}" if messages else ""
+            raise ValueError(f"GitHub GraphQL commit mutation failed{detail}")
         return data
 
 
@@ -150,28 +172,25 @@ def create_signed_commit(
     deletions: set[str],
     message: str,
 ) -> str:
+    variables = commit_variables(
+        full_name=full_name,
+        branch=branch,
+        base_commit=base_commit,
+        additions=additions,
+        deletions=deletions,
+        message=message,
+    )
+    request_size = len(
+        json.dumps(
+            {"query": CREATE_COMMIT_MUTATION, "variables": variables},
+            separators=(",", ":"),
+        ).encode()
+    )
+    if request_size > GRAPHQL_COMMIT_MAX_BYTES:
+        raise ValueError("signed GitHub commit request exceeds its safe payload limit")
     data = api.graphql(
         CREATE_COMMIT_MUTATION,
-        {
-            "input": {
-                "branch": {
-                    "repositoryNameWithOwner": full_name,
-                    "branchName": branch,
-                },
-                "expectedHeadOid": base_commit,
-                "message": {"headline": message},
-                "fileChanges": {
-                    "additions": [
-                        {
-                            "path": path,
-                            "contents": base64.b64encode(contents).decode("ascii"),
-                        }
-                        for path, contents in sorted(additions.items())
-                    ],
-                    "deletions": [{"path": path} for path in sorted(deletions)],
-                },
-            }
-        },
+        variables,
     )
     mutation = data.get("createCommitOnBranch")
     if not isinstance(mutation, dict):
@@ -257,6 +276,133 @@ def tree_paths(api: GitHubApi, full_name: str, commit_sha: str) -> set[str]:
     return paths
 
 
+def managed_paths(paths: set[str], prefixes: tuple[str, ...]) -> set[str]:
+    return {
+        path
+        for path in paths
+        if any(path == prefix or path.startswith(f"{prefix}/") for prefix in prefixes)
+    }
+
+
+def repository_state_is_exact(
+    api: GitHubApi,
+    *,
+    full_name: str,
+    commit_sha: str,
+    updates: dict[str, bytes],
+    managed_prefixes: tuple[str, ...],
+    managed_expected: set[str],
+) -> bool:
+    if managed_prefixes:
+        existing = managed_paths(
+            tree_paths(api, full_name, commit_sha), managed_prefixes
+        )
+        if existing != managed_expected:
+            return False
+    return all(
+        file_at(api, full_name, path, commit_sha) == data
+        for path, data in updates.items()
+    )
+
+
+def delete_branch_if_present(api: GitHubApi, full_name: str, branch: str) -> None:
+    encoded = urllib.parse.quote(branch, safe="")
+    get_path = f"/repos/{full_name}/git/ref/heads/{encoded}"
+    try:
+        api.get(get_path)
+    except ValueError as error:
+        if "failed: 404 " in str(error):
+            return
+        raise
+    api.delete(f"/repos/{full_name}/git/refs/heads/{encoded}")
+
+
+def create_staging_branch(
+    api: GitHubApi, full_name: str, branch: str, base_commit: str
+) -> None:
+    value = api.post(
+        f"/repos/{full_name}/git/refs",
+        {"ref": f"refs/heads/{branch}", "sha": base_commit},
+    )
+    target = value.get("object")
+    if (
+        value.get("ref") != f"refs/heads/{branch}"
+        or not isinstance(target, dict)
+        or object_sha(target, "created staging branch") != base_commit
+    ):
+        raise ValueError("GitHub created an unexpected staging branch")
+
+
+def advance_branch(
+    api: GitHubApi, full_name: str, branch: str, commit_sha: str
+) -> None:
+    encoded = urllib.parse.quote(branch, safe="")
+    value = api.patch(
+        f"/repos/{full_name}/git/refs/heads/{encoded}",
+        {"sha": commit_sha, "force": False},
+    )
+    target = value.get("object")
+    if (
+        value.get("ref") != f"refs/heads/{branch}"
+        or not isinstance(target, dict)
+        or object_sha(target, "advanced branch") != commit_sha
+    ):
+        raise ValueError("GitHub advanced an unexpected downstream branch")
+
+
+def publish_batched_signed_commits(
+    api: GitHubApi,
+    *,
+    full_name: str,
+    branch: str,
+    base_commit: str,
+    batches: list[tuple[dict[str, bytes], set[str]]],
+    updates: dict[str, bytes],
+    managed_prefixes: tuple[str, ...],
+    managed_expected: set[str],
+    message: str,
+) -> str:
+    staging = staging_branch_name(
+        base_commit,
+        updates,
+        set().union(*(deletions for _, deletions in batches)),
+    )
+    delete_branch_if_present(api, full_name, staging)
+    create_staging_branch(api, full_name, staging, base_commit)
+    current = base_commit
+    try:
+        for index, (additions, deletions) in enumerate(batches, start=1):
+            current = create_signed_commit(
+                api,
+                full_name=full_name,
+                branch=staging,
+                base_commit=current,
+                additions=additions,
+                deletions=deletions,
+                message=f"{message} (part {index}/{len(batches)})",
+            )
+        if not repository_state_is_exact(
+            api,
+            full_name=full_name,
+            commit_sha=current,
+            updates=updates,
+            managed_prefixes=managed_prefixes,
+            managed_expected=managed_expected,
+        ):
+            raise ValueError("staged downstream repository bytes differ")
+        if branch_head(api, full_name, branch) != base_commit:
+            raise ValueError("downstream repository changed during signed staging")
+        advance_branch(api, full_name, branch, current)
+    except (OSError, ValueError):
+        try:
+            delete_branch_if_present(api, full_name, staging)
+        except (OSError, ValueError):
+            pass
+        raise
+    delete_branch_if_present(api, full_name, staging)
+    return current
+
+
 def publish(
     api: GitHubApi,
     *,
@@ -268,58 +414,70 @@ def publish(
     expected_base: str | None = None,
 ) -> PublishOutcome:
     base_commit = branch_head(api, full_name, branch)
-    if expected_base is not None and base_commit != expected_base:
-        raise ValueError("downstream repository changed after payload preparation")
     existing_paths = (
         tree_paths(api, full_name, base_commit) if managed_prefixes else set()
     )
-    managed_existing = {
-        path
-        for path in existing_paths
-        if any(
-            path == prefix or path.startswith(f"{prefix}/")
-            for prefix in managed_prefixes
-        )
-    }
-    managed_expected = {
-        path
-        for path in updates
-        if any(
-            path == prefix or path.startswith(f"{prefix}/")
-            for prefix in managed_prefixes
-        )
-    }
+    managed_existing = managed_paths(existing_paths, managed_prefixes)
+    managed_expected = managed_paths(set(updates), managed_prefixes)
     if managed_prefixes and not managed_expected:
         raise ValueError("managed repository update has no files under its prefixes")
-    if managed_existing == managed_expected and all(
-        file_at(api, full_name, path, base_commit) == data
-        for path, data in updates.items()
+    if repository_state_is_exact(
+        api,
+        full_name=full_name,
+        commit_sha=base_commit,
+        updates=updates,
+        managed_prefixes=managed_prefixes,
+        managed_expected=managed_expected,
     ):
         return PublishOutcome("no-op-exact", False, base_commit)
-    commit_sha = create_signed_commit(
-        api,
+    if expected_base is not None and base_commit != expected_base:
+        raise ValueError("downstream repository changed after payload preparation")
+    deletions = managed_existing - managed_expected
+    changed_updates = {
+        path: data
+        for path, data in updates.items()
+        if file_at(api, full_name, path, base_commit) != data
+    }
+    batches = signed_commit_batches(
         full_name=full_name,
         branch=branch,
         base_commit=base_commit,
-        additions=updates,
-        deletions=managed_existing - managed_expected,
+        additions=changed_updates,
+        deletions=deletions,
         message=message,
     )
+    if len(batches) == 1:
+        additions, batch_deletions = batches[0]
+        commit_sha = create_signed_commit(
+            api,
+            full_name=full_name,
+            branch=branch,
+            base_commit=base_commit,
+            additions=additions,
+            deletions=batch_deletions,
+            message=message,
+        )
+    else:
+        commit_sha = publish_batched_signed_commits(
+            api,
+            full_name=full_name,
+            branch=branch,
+            base_commit=base_commit,
+            batches=batches,
+            updates=updates,
+            managed_prefixes=managed_prefixes,
+            managed_expected=managed_expected,
+            message=message,
+        )
     if branch_head(api, full_name, branch) != commit_sha:
         raise ValueError("downstream branch did not advance to the exact commit")
-    for path, expected in updates.items():
-        if file_at(api, full_name, path, commit_sha) != expected:
-            raise ValueError("downstream repository bytes differ after publication")
-    if managed_prefixes:
-        final_paths = tree_paths(api, full_name, commit_sha)
-        managed_final = {
-            path
-            for path in final_paths
-            if any(
-                path == prefix or path.startswith(f"{prefix}/")
-                for prefix in managed_prefixes
-            )
-        }
-        if managed_final != managed_expected:
-            raise ValueError("managed repository paths differ after publication")
+    if not repository_state_is_exact(
+        api,
+        full_name=full_name,
+        commit_sha=commit_sha,
+        updates=updates,
+        managed_prefixes=managed_prefixes,
+        managed_expected=managed_expected,
+    ):
+        raise ValueError("downstream repository bytes differ after publication")
     return PublishOutcome("public-live", True, commit_sha)

--- a/scripts/release/receipt-recovery.py
+++ b/scripts/release/receipt-recovery.py
@@ -12,23 +12,12 @@ from typing import Any
 from github_actions import gh_api, read_json
 from receipt_recovery_topology import (
     ACTIVE,
-    DIRECT_SUCCESS_JOBS,
-    EARLY_SUCCESS_JOBS,
-    LEGACY_DOWNSTREAM_PREFIX,
-    LINUX_SIGNING_JOB,
-    OWNED_WRITER_JOBS,
-    PAYLOAD_CHANNELS,
-    POST_MUTATION_JOB_MAP,
-    POST_MUTATION_RESULT_CHANNELS,
-    POST_MUTATION_SKIPPED_AFTER_FAILURE,
-    PREPARATION_PREFIX,
-    PREPARATION_SUCCESS_JOBS,
-    SKIPPED_AFTER_FAILURE,
-    result_envelope_names,
+    REPOSITORY_ID,
+    verify_failed_downstream_artifacts,
+    verify_failed_downstream_jobs,
 )
 
 REPOSITORY = "Helvesec/rmux"
-REPOSITORY_ID = 1239918790
 RECEIPT_WORKFLOW_ID = 316435347
 CI_WORKFLOW_ID = 277622540
 SHA40 = re.compile(r"[0-9a-f]{40}")
@@ -71,241 +60,6 @@ def verified_commit(value: dict[str, Any], sha: str, label: str) -> None:
         or verification.get("reason") != "valid"
     ):
         raise ValueError(f"{label} is not GitHub-verified")
-
-
-def job_steps(job: dict[str, Any], label: str) -> dict[str, str]:
-    steps = job.get("steps")
-    if not isinstance(steps, list):
-        raise ValueError(f"{label} has no step list")
-    result: dict[str, str] = {}
-    for step in steps:
-        if not isinstance(step, dict):
-            raise ValueError(f"{label} has a malformed step")
-        name = step.get("name")
-        conclusion = step.get("conclusion")
-        if not isinstance(name, str) or not isinstance(conclusion, str):
-            raise ValueError(f"{label} step identity is malformed")
-        if name in result and result[name] != conclusion:
-            raise ValueError(f"{label} duplicate step conclusions differ")
-        result[name] = conclusion
-    return result
-
-
-def exact_step(steps: dict[str, str], name: str, conclusion: str, label: str) -> None:
-    if steps.get(name) != conclusion:
-        raise ValueError(f"{label} step {name} did not conclude {conclusion}")
-
-
-def canonical_failed_jobs(
-    jobs: dict[str, dict[str, Any]],
-) -> tuple[dict[str, dict[str, Any]], bool]:
-    downstream_jobs = (
-        PREPARATION_SUCCESS_JOBS
-        | {LINUX_SIGNING_JOB}
-        | OWNED_WRITER_JOBS
-        | SKIPPED_AFTER_FAILURE
-    )
-    legacy_names = DIRECT_SUCCESS_JOBS | {
-        f"{LEGACY_DOWNSTREAM_PREFIX}{name}" for name in downstream_jobs
-    }
-    direct_names = (
-        DIRECT_SUCCESS_JOBS
-        | {f"{PREPARATION_PREFIX}{name}" for name in PREPARATION_SUCCESS_JOBS}
-        | {LINUX_SIGNING_JOB}
-        | OWNED_WRITER_JOBS
-        | SKIPPED_AFTER_FAILURE
-    )
-    post_mutation_names = (
-        DIRECT_SUCCESS_JOBS
-        | {f"{PREPARATION_PREFIX}{name}" for name in PREPARATION_SUCCESS_JOBS}
-        | set(POST_MUTATION_JOB_MAP)
-        | POST_MUTATION_SKIPPED_AFTER_FAILURE
-    )
-    raw_names = set(jobs)
-    if raw_names == legacy_names:
-        return (
-            {
-                name.removeprefix(LEGACY_DOWNSTREAM_PREFIX): job
-                for name, job in jobs.items()
-            },
-            False,
-        )
-    if raw_names == direct_names:
-        return (
-            {name.removeprefix(PREPARATION_PREFIX): job for name, job in jobs.items()},
-            False,
-        )
-    if raw_names == post_mutation_names:
-        return (
-            {
-                POST_MUTATION_JOB_MAP.get(
-                    name.removeprefix(PREPARATION_PREFIX),
-                    name.removeprefix(PREPARATION_PREFIX),
-                ): job
-                for name, job in jobs.items()
-            },
-            True,
-        )
-    raise ValueError("failed downstream job topology differs")
-
-
-def verify_failed_downstream_jobs(value: dict[str, Any]) -> bool:
-    jobs = value.get("jobs")
-    if not isinstance(jobs, list) or value.get("total_count") != len(jobs):
-        raise ValueError("failed downstream job set is malformed")
-    by_name: dict[str, dict[str, Any]] = {}
-    for job in jobs:
-        if not isinstance(job, dict) or not isinstance(job.get("name"), str):
-            raise ValueError("failed downstream job identity is malformed")
-        name = job["name"]
-        if name in by_name:
-            raise ValueError("failed downstream job names are not unique")
-        by_name[name] = job
-    by_name, post_mutation = canonical_failed_jobs(by_name)
-    for name in EARLY_SUCCESS_JOBS:
-        if by_name[name].get("conclusion") != "success":
-            raise ValueError(f"failed downstream prerequisite {name} is not successful")
-    skipped_jobs = (
-        POST_MUTATION_SKIPPED_AFTER_FAILURE if post_mutation else SKIPPED_AFTER_FAILURE
-    )
-    for name in skipped_jobs:
-        if (
-            by_name[name].get("conclusion") != "skipped"
-            or by_name[name].get("steps") != []
-        ):
-            raise ValueError(f"post-failure downstream job {name} was not untouched")
-
-    linux = by_name[LINUX_SIGNING_JOB]
-    if post_mutation:
-        checkout = "Run actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5"
-        post_checkout = f"Post {checkout}"
-        linux_steps = job_steps(linux, LINUX_SIGNING_JOB)
-        expected_linux_steps = {
-            "Set up job": "success",
-            checkout: "success",
-            "Run ./.github/actions/release-linux-repository-build": "success",
-            post_checkout: "success",
-            "Complete job": "success",
-        }
-        if linux.get("conclusion") != "success" or linux_steps != expected_linux_steps:
-            raise ValueError("post-mutation Linux repository build is not successful")
-        action = "Run ./.github/actions/release-owned-repository-publish"
-        expected_writer_steps = {
-            "Set up job": "success",
-            checkout: "success",
-            action: "failure",
-            f"Post {action}": "success",
-            post_checkout: "success",
-            "Complete job": "success",
-        }
-        for name in OWNED_WRITER_JOBS:
-            job = by_name[name]
-            steps = job_steps(job, name)
-            if job.get("conclusion") != "failure" or steps != expected_writer_steps:
-                raise ValueError(f"post-mutation writer failure {name} differs")
-        return True
-    if linux.get("conclusion") != "failure":
-        raise ValueError("Linux repository signing did not fail closed")
-    linux_steps = job_steps(linux, LINUX_SIGNING_JOB)
-    exact_step(
-        linux_steps,
-        "Import distinct repository signing keys",
-        "failure",
-        LINUX_SIGNING_JOB,
-    )
-    for name in (
-        "Authenticate retained history and generate signed repositories",
-        "Add static package host files and exact checksum inventory",
-        "Upload the exact signed repository tree",
-    ):
-        exact_step(linux_steps, name, "skipped", LINUX_SIGNING_JOB)
-
-    for name in OWNED_WRITER_JOBS:
-        job = by_name[name]
-        if job.get("conclusion") != "failure":
-            raise ValueError(f"owned repository job {name} did not fail closed")
-        steps = job_steps(job, name)
-        exact_step(
-            steps,
-            "Mint a repository-scoped downstream writer token",
-            "failure",
-            name,
-        )
-        exact_step(
-            steps,
-            "Publish and reread exact repository bytes",
-            "skipped",
-            name,
-        )
-        exact_step(
-            steps,
-            "Seal exact owned repository result evidence",
-            "skipped",
-            name,
-        )
-    return False
-
-
-def verify_failed_downstream_artifacts(
-    value: dict[str, Any],
-    args: argparse.Namespace,
-    failed_control_sha: str,
-    post_mutation: bool,
-) -> int:
-    artifacts = value.get("artifacts")
-    if not isinstance(artifacts, list) or value.get("total_count") != len(artifacts):
-        raise ValueError("failed downstream artifact set is malformed")
-    expected_names = {
-        f"rmux-publication-receipt-{args.source_sha}-{args.release_id}",
-        f"rmux-publication-receipt-envelope-{args.source_sha}-{args.release_id}",
-        f"rmux-downstream-authority-{args.source_sha}-{args.failed_run_id}",
-        f"rmux-downstream-plan-{args.source_sha}-{args.release_id}",
-        *(
-            f"rmux-downstream-{channel}-payload-{args.source_sha}-{args.release_id}"
-            for channel in PAYLOAD_CHANNELS
-        ),
-    }
-    allowed_names = (expected_names,)
-    if post_mutation:
-        expected_names.add(
-            f"rmux-downstream-apt_rpm-signed-{args.source_sha}-{args.release_id}"
-        )
-        expected_names.update(
-            f"rmux-downstream-{channel}-result-{args.source_sha}-{args.release_id}"
-            for channel in POST_MUTATION_RESULT_CHANNELS
-        )
-        allowed_names = (
-            expected_names,
-            expected_names | result_envelope_names(args.source_sha, args.release_id),
-        )
-    by_name: dict[str, dict[str, Any]] = {}
-    for artifact in artifacts:
-        if not isinstance(artifact, dict) or not isinstance(artifact.get("name"), str):
-            raise ValueError("failed downstream artifact identity is malformed")
-        name = artifact["name"]
-        if name in by_name:
-            raise ValueError("failed downstream artifact names are not unique")
-        by_name[name] = artifact
-    if set(by_name) not in allowed_names:
-        raise ValueError("failed downstream artifact topology differs")
-    for name, artifact in by_name.items():
-        workflow_run = artifact.get("workflow_run", {})
-        if (
-            type(artifact.get("id")) is not int
-            or artifact["id"] <= 0
-            or artifact.get("expired") is not False
-            or not isinstance(artifact.get("digest"), str)
-            or re.fullmatch(r"sha256:[0-9a-f]{64}", artifact["digest"]) is None
-            or workflow_run.get("id") != args.failed_run_id
-            or workflow_run.get("head_sha") != failed_control_sha
-            or workflow_run.get("head_branch") != "main"
-            or workflow_run.get("repository_id") != REPOSITORY_ID
-            or workflow_run.get("head_repository_id") != REPOSITORY_ID
-        ):
-            raise ValueError(f"failed downstream artifact {name} identity differs")
-    return by_name[f"rmux-publication-receipt-{args.source_sha}-{args.release_id}"][
-        "id"
-    ]
 
 
 def verify_failed_attempt(
@@ -364,9 +118,9 @@ def verify_failed_attempt(
     verified_commit(
         failed_commit, failed_control_sha, "failed downstream control commit"
     )
-    post_mutation = verify_failed_downstream_jobs(jobs)
+    failure_mode = verify_failed_downstream_jobs(jobs)
     return verify_failed_downstream_artifacts(
-        artifacts, args, failed_control_sha, post_mutation
+        artifacts, args, failed_control_sha, failure_mode
     )
 
 

--- a/scripts/release/receipt_recovery_topology.py
+++ b/scripts/release/receipt_recovery_topology.py
@@ -1,5 +1,13 @@
 """Exact job and artifact topology for fail-closed receipt recovery."""
 
+from __future__ import annotations
+
+import argparse
+import re
+from typing import Any
+
+REPOSITORY_ID = 1239918790
+
 ACTIVE = frozenset({"queued", "in_progress", "requested", "waiting", "pending"})
 DIRECT_SUCCESS_JOBS = frozenset(
     {
@@ -16,6 +24,11 @@ PREPARATION_SUCCESS_JOBS = frozenset(
 )
 EARLY_SUCCESS_JOBS = DIRECT_SUCCESS_JOBS | PREPARATION_SUCCESS_JOBS
 LINUX_SIGNING_JOB = "Build exact signed Linux repository trees / Sign retained APT and RPM repository trees"
+APT_PUBLISH_JOB = "Publish exact signed APT and RPM repositories"
+CRATES_PUBLISH_JOB = "Publish exact crates.io package set"
+CRATES_PUBLISH_JOB_EXPANDED = (
+    "Publish exact crates.io package set / Publish exact crates.io package set"
+)
 OWNED_WRITER_JOBS = frozenset(
     {
         "Publish exact Homebrew tap formula / Publish owned channel homebrew_tap",
@@ -63,6 +76,9 @@ POST_MUTATION_JOB_MAP = {
     "Publish exact Scoop manifest": "Publish exact Scoop manifest / Publish owned channel scoop",
     "Publish exact Web Share WASM bytes": "Publish exact Web Share WASM bytes / Publish owned channel web_share",
 }
+PACKAGE_WRITER_JOB_MAP = POST_MUTATION_JOB_MAP | {
+    CRATES_PUBLISH_JOB_EXPANDED: CRATES_PUBLISH_JOB,
+}
 POST_MUTATION_RESULT_CHANNELS = ("homebrew_tap", "scoop", "web_share")
 
 
@@ -71,3 +87,328 @@ def result_envelope_names(source_sha: str, release_id: int) -> set[str]:
         f"rmux-downstream-{channel}-result-envelope-{source_sha}-{release_id}"
         for channel in POST_MUTATION_RESULT_CHANNELS
     }
+
+
+def result_reference_names(source_sha: str, release_id: int) -> set[str]:
+    return {
+        f"rmux-downstream-{channel}-result-reference-{source_sha}-{release_id}"
+        for channel in POST_MUTATION_RESULT_CHANNELS
+    }
+
+
+def job_steps(job: dict[str, Any], label: str) -> dict[str, str]:
+    steps = job.get("steps")
+    if not isinstance(steps, list):
+        raise ValueError(f"{label} has no step list")
+    result: dict[str, str] = {}
+    for step in steps:
+        if not isinstance(step, dict):
+            raise ValueError(f"{label} has a malformed step")
+        name = step.get("name")
+        conclusion = step.get("conclusion")
+        if not isinstance(name, str) or not isinstance(conclusion, str):
+            raise ValueError(f"{label} step identity is malformed")
+        if name in result and result[name] != conclusion:
+            raise ValueError(f"{label} duplicate step conclusions differ")
+        result[name] = conclusion
+    return result
+
+
+def exact_step(steps: dict[str, str], name: str, conclusion: str, label: str) -> None:
+    if steps.get(name) != conclusion:
+        raise ValueError(f"{label} step {name} did not conclude {conclusion}")
+
+
+def canonical_failed_jobs(
+    jobs: dict[str, dict[str, Any]],
+) -> tuple[dict[str, dict[str, Any]], bool]:
+    downstream_jobs = (
+        PREPARATION_SUCCESS_JOBS
+        | {LINUX_SIGNING_JOB}
+        | OWNED_WRITER_JOBS
+        | SKIPPED_AFTER_FAILURE
+    )
+    legacy_names = DIRECT_SUCCESS_JOBS | {
+        f"{LEGACY_DOWNSTREAM_PREFIX}{name}" for name in downstream_jobs
+    }
+    direct_names = (
+        DIRECT_SUCCESS_JOBS
+        | {f"{PREPARATION_PREFIX}{name}" for name in PREPARATION_SUCCESS_JOBS}
+        | {LINUX_SIGNING_JOB}
+        | OWNED_WRITER_JOBS
+        | SKIPPED_AFTER_FAILURE
+    )
+    post_mutation_names = (
+        DIRECT_SUCCESS_JOBS
+        | {f"{PREPARATION_PREFIX}{name}" for name in PREPARATION_SUCCESS_JOBS}
+        | set(POST_MUTATION_JOB_MAP)
+        | POST_MUTATION_SKIPPED_AFTER_FAILURE
+    )
+    package_writer_names = (
+        DIRECT_SUCCESS_JOBS
+        | {f"{PREPARATION_PREFIX}{name}" for name in PREPARATION_SUCCESS_JOBS}
+        | set(PACKAGE_WRITER_JOB_MAP)
+        | (POST_MUTATION_SKIPPED_AFTER_FAILURE - {CRATES_PUBLISH_JOB})
+    )
+    raw_names = set(jobs)
+    if raw_names == legacy_names:
+        return (
+            {
+                name.removeprefix(LEGACY_DOWNSTREAM_PREFIX): job
+                for name, job in jobs.items()
+            },
+            False,
+        )
+    if raw_names == direct_names:
+        return (
+            {name.removeprefix(PREPARATION_PREFIX): job for name, job in jobs.items()},
+            False,
+        )
+    if raw_names == post_mutation_names:
+        return (
+            {
+                POST_MUTATION_JOB_MAP.get(
+                    name.removeprefix(PREPARATION_PREFIX),
+                    name.removeprefix(PREPARATION_PREFIX),
+                ): job
+                for name, job in jobs.items()
+            },
+            True,
+        )
+    if raw_names == package_writer_names:
+        return (
+            {
+                PACKAGE_WRITER_JOB_MAP.get(
+                    name.removeprefix(PREPARATION_PREFIX),
+                    name.removeprefix(PREPARATION_PREFIX),
+                ): job
+                for name, job in jobs.items()
+            },
+            True,
+        )
+    raise ValueError("failed downstream job topology differs")
+
+
+def exact_job_shape(
+    job: dict[str, Any], *, name: str, conclusion: str, steps: dict[str, str]
+) -> None:
+    if job.get("conclusion") != conclusion or job_steps(job, name) != steps:
+        raise ValueError(f"failed downstream job {name} differs")
+
+
+def verify_skipped_jobs(
+    jobs: dict[str, dict[str, Any]], names: set[str] | frozenset[str]
+) -> None:
+    for name in names:
+        if jobs[name].get("conclusion") != "skipped" or jobs[name].get("steps") != []:
+            raise ValueError(f"post-failure downstream job {name} was not untouched")
+
+
+def verify_failed_downstream_jobs(value: dict[str, Any]) -> str:
+    jobs = value.get("jobs")
+    if not isinstance(jobs, list) or value.get("total_count") != len(jobs):
+        raise ValueError("failed downstream job set is malformed")
+    by_name: dict[str, dict[str, Any]] = {}
+    for job in jobs:
+        if not isinstance(job, dict) or not isinstance(job.get("name"), str):
+            raise ValueError("failed downstream job identity is malformed")
+        name = job["name"]
+        if name in by_name:
+            raise ValueError("failed downstream job names are not unique")
+        by_name[name] = job
+    by_name, post_mutation = canonical_failed_jobs(by_name)
+    for name in EARLY_SUCCESS_JOBS:
+        if by_name[name].get("conclusion") != "success":
+            raise ValueError(f"failed downstream prerequisite {name} is not successful")
+    linux = by_name[LINUX_SIGNING_JOB]
+    if post_mutation:
+        checkout = "Run actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5"
+        post_checkout = f"Post {checkout}"
+        exact_job_shape(
+            linux,
+            name=LINUX_SIGNING_JOB,
+            conclusion="success",
+            steps={
+                "Set up job": "success",
+                checkout: "success",
+                "Run ./.github/actions/release-linux-repository-build": "success",
+                post_checkout: "success",
+                "Complete job": "success",
+            },
+        )
+        action = "Run ./.github/actions/release-owned-repository-publish"
+        writer_prefix = {
+            "Set up job": "success",
+            checkout: "success",
+            post_checkout: "success",
+            "Complete job": "success",
+        }
+        owned_conclusions = {
+            by_name[name].get("conclusion") for name in OWNED_WRITER_JOBS
+        }
+        if owned_conclusions == {"failure"}:
+            verify_skipped_jobs(by_name, POST_MUTATION_SKIPPED_AFTER_FAILURE)
+            for name in OWNED_WRITER_JOBS:
+                exact_job_shape(
+                    by_name[name],
+                    name=name,
+                    conclusion="failure",
+                    steps=writer_prefix
+                    | {action: "failure", f"Post {action}": "success"},
+                )
+            return "owned-writer-failure"
+        if owned_conclusions != {"success"}:
+            raise ValueError("owned repository writer conclusions differ")
+        for name in OWNED_WRITER_JOBS:
+            exact_job_shape(
+                by_name[name],
+                name=name,
+                conclusion="success",
+                steps=writer_prefix | {action: "success", f"Post {action}": "success"},
+            )
+        verify_skipped_jobs(
+            by_name,
+            POST_MUTATION_SKIPPED_AFTER_FAILURE - {APT_PUBLISH_JOB, CRATES_PUBLISH_JOB},
+        )
+        apt_action = "Run ./.github/actions/release-linux-repository-publish"
+        exact_job_shape(
+            by_name[APT_PUBLISH_JOB],
+            name=APT_PUBLISH_JOB,
+            conclusion="failure",
+            steps=writer_prefix
+            | {apt_action: "failure", f"Post {apt_action}": "success"},
+        )
+        exact_job_shape(
+            by_name[CRATES_PUBLISH_JOB],
+            name=CRATES_PUBLISH_JOB,
+            conclusion="failure",
+            steps={
+                "Set up job": "success",
+                checkout: "success",
+                "Run ./.github/actions/release-channel-prepare": "success",
+                "Resolve exact crates.io execution authority": "success",
+                "Exchange GitHub OIDC for a short-lived crates.io token": "failure",
+                "Publish and redownload every exact crate": "skipped",
+                "Normalize executable and policy-only outcomes": "skipped",
+                "Seal exact crates.io result evidence": "skipped",
+                "Post Exchange GitHub OIDC for a short-lived crates.io token": "success",
+                post_checkout: "success",
+                "Complete job": "success",
+            },
+        )
+        return "package-writer-failure"
+    verify_skipped_jobs(by_name, SKIPPED_AFTER_FAILURE)
+    if linux.get("conclusion") != "failure":
+        raise ValueError("Linux repository signing did not fail closed")
+    linux_steps = job_steps(linux, LINUX_SIGNING_JOB)
+    exact_step(
+        linux_steps,
+        "Import distinct repository signing keys",
+        "failure",
+        LINUX_SIGNING_JOB,
+    )
+    for name in (
+        "Authenticate retained history and generate signed repositories",
+        "Add static package host files and exact checksum inventory",
+        "Upload the exact signed repository tree",
+    ):
+        exact_step(linux_steps, name, "skipped", LINUX_SIGNING_JOB)
+
+    for name in OWNED_WRITER_JOBS:
+        job = by_name[name]
+        if job.get("conclusion") != "failure":
+            raise ValueError(f"owned repository job {name} did not fail closed")
+        steps = job_steps(job, name)
+        exact_step(
+            steps,
+            "Mint a repository-scoped downstream writer token",
+            "failure",
+            name,
+        )
+        exact_step(
+            steps,
+            "Publish and reread exact repository bytes",
+            "skipped",
+            name,
+        )
+        exact_step(
+            steps,
+            "Seal exact owned repository result evidence",
+            "skipped",
+            name,
+        )
+    return "pre-mutation-failure"
+
+
+def verify_failed_downstream_artifacts(
+    value: dict[str, Any],
+    args: argparse.Namespace,
+    failed_control_sha: str,
+    failure_mode: str,
+) -> int:
+    artifacts = value.get("artifacts")
+    if not isinstance(artifacts, list) or value.get("total_count") != len(artifacts):
+        raise ValueError("failed downstream artifact set is malformed")
+    expected_names = {
+        f"rmux-publication-receipt-{args.source_sha}-{args.release_id}",
+        f"rmux-publication-receipt-envelope-{args.source_sha}-{args.release_id}",
+        f"rmux-downstream-authority-{args.source_sha}-{args.failed_run_id}",
+        f"rmux-downstream-plan-{args.source_sha}-{args.release_id}",
+        *(
+            f"rmux-downstream-{channel}-payload-{args.source_sha}-{args.release_id}"
+            for channel in PAYLOAD_CHANNELS
+        ),
+    }
+    allowed_names = (expected_names,)
+    if failure_mode != "pre-mutation-failure":
+        expected_names.add(
+            f"rmux-downstream-apt_rpm-signed-{args.source_sha}-{args.release_id}"
+        )
+        expected_names.update(
+            f"rmux-downstream-{channel}-result-{args.source_sha}-{args.release_id}"
+            for channel in POST_MUTATION_RESULT_CHANNELS
+        )
+        if failure_mode == "owned-writer-failure":
+            allowed_names = (
+                expected_names,
+                expected_names
+                | result_envelope_names(args.source_sha, args.release_id),
+            )
+        elif failure_mode == "package-writer-failure":
+            expected_names.update(
+                result_envelope_names(args.source_sha, args.release_id)
+            )
+            expected_names.update(
+                result_reference_names(args.source_sha, args.release_id)
+            )
+            allowed_names = (expected_names,)
+        else:
+            raise ValueError("failed downstream recovery mode differs")
+    by_name: dict[str, dict[str, Any]] = {}
+    for artifact in artifacts:
+        if not isinstance(artifact, dict) or not isinstance(artifact.get("name"), str):
+            raise ValueError("failed downstream artifact identity is malformed")
+        name = artifact["name"]
+        if name in by_name:
+            raise ValueError("failed downstream artifact names are not unique")
+        by_name[name] = artifact
+    if set(by_name) not in allowed_names:
+        raise ValueError("failed downstream artifact topology differs")
+    for name, artifact in by_name.items():
+        workflow_run = artifact.get("workflow_run", {})
+        if (
+            type(artifact.get("id")) is not int
+            or artifact["id"] <= 0
+            or artifact.get("expired") is not False
+            or not isinstance(artifact.get("digest"), str)
+            or re.fullmatch(r"sha256:[0-9a-f]{64}", artifact["digest"]) is None
+            or workflow_run.get("id") != args.failed_run_id
+            or workflow_run.get("head_sha") != failed_control_sha
+            or workflow_run.get("head_branch") != "main"
+            or workflow_run.get("repository_id") != REPOSITORY_ID
+            or workflow_run.get("head_repository_id") != REPOSITORY_ID
+        ):
+            raise ValueError(f"failed downstream artifact {name} identity differs")
+    return by_name[f"rmux-publication-receipt-{args.source_sha}-{args.release_id}"][
+        "id"
+    ]

--- a/tests/release_downstream_workflows_spec.rs
+++ b/tests/release_downstream_workflows_spec.rs
@@ -214,6 +214,56 @@ fn protected_environment_secrets_are_consumed_by_top_level_receipt_jobs() {
     assert!(!DOWNSTREAM.contains("RMUX_DOWNSTREAM_APP_PRIVATE_KEY"));
 }
 
+#[test]
+fn crates_oidc_authority_is_probed_before_any_public_writer() {
+    let preflight = job(
+        RECEIPT,
+        "preflight-crates-oidc",
+        Some("build-linux-repository"),
+    );
+    assert!(preflight.contains("needs: [downstream-preparation]"));
+    assert!(preflight.contains("environment: release"));
+    assert!(preflight.contains("id-token: write"));
+    assert!(preflight
+        .contains("rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18"));
+    assert_eq!(
+        RECEIPT
+            .matches("needs: [downstream-preparation, preflight-crates-oidc]")
+            .count(),
+        3
+    );
+    let crates = job(RECEIPT, "publish-crates", Some("record-homebrew-core"));
+    assert!(crates.contains(
+        "needs: [downstream-preparation, preflight-crates-oidc, build-linux-repository, publish-homebrew-tap, publish-scoop, publish-web-share]"
+    ));
+    let linux = job(
+        RECEIPT,
+        "publish-linux-repository",
+        Some("record-linux-repository-policy"),
+    );
+    assert!(linux.contains(
+        "needs: [downstream-preparation, preflight-crates-oidc, build-linux-repository, publish-homebrew-tap, publish-scoop, publish-web-share]"
+    ));
+    let preflight_offset = RECEIPT
+        .find("\n  preflight-crates-oidc:\n")
+        .expect("crates preflight job");
+    for writer in [
+        "publish-homebrew-tap",
+        "publish-scoop",
+        "publish-web-share",
+        "publish-linux-repository",
+        "publish-crates",
+    ] {
+        let writer_offset = RECEIPT
+            .find(&format!("\n  {writer}:\n"))
+            .unwrap_or_else(|| panic!("missing public writer {writer}"));
+        assert!(
+            preflight_offset < writer_offset,
+            "{writer} precedes OIDC preflight"
+        );
+    }
+}
+
 #[cfg(unix)]
 #[test]
 fn downstream_workflow_entry_points_are_executable() {

--- a/tests/release_downstream_writer_spec.rs
+++ b/tests/release_downstream_writer_spec.rs
@@ -6,6 +6,8 @@ use std::process::{Command, Output};
 
 const GITHUB_REPOSITORY_WRITER: &str =
     include_str!("../scripts/release/github_repository_writer.py");
+const GITHUB_REPOSITORY_COMMIT_PLAN: &str =
+    include_str!("../scripts/release/github_repository_commit_plan.py");
 
 fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -369,51 +371,75 @@ with tempfile.TemporaryDirectory(dir=pathlib.Path.cwd()) as directory:
 
 #[test]
 fn github_repository_writer_is_atomic_idempotent_and_prefix_exact() {
-    assert!(GITHUB_REPOSITORY_WRITER.contains("createCommitOnBranch"));
+    assert!(GITHUB_REPOSITORY_COMMIT_PLAN.contains("createCommitOnBranch"));
+    assert!(GITHUB_REPOSITORY_COMMIT_PLAN.contains("GRAPHQL_COMMIT_MAX_BYTES = 44_000_000"));
+    assert!(GITHUB_REPOSITORY_COMMIT_PLAN.contains("rmux-release-stage"));
     assert!(GITHUB_REPOSITORY_WRITER.contains("wasSignedByGitHub"));
     assert!(GITHUB_REPOSITORY_WRITER.contains("verification.get(\"verified\") is not True"));
-    assert!(!GITHUB_REPOSITORY_WRITER.contains("/git/refs/heads/"));
+    assert!(GITHUB_REPOSITORY_WRITER.contains("/git/refs/heads/"));
+    assert!(GITHUB_REPOSITORY_WRITER.contains("{\"sha\": commit_sha, \"force\": False}"));
     assert!(!GITHUB_REPOSITORY_WRITER.contains("f\"/repos/{full_name}/git/commits\""));
     assert_python(
         r#"
+import base64
 import urllib.parse
 import sys
 
 sys.path.insert(0, 'scripts/release')
+import github_repository_commit_plan as commit_plan
 from github_repository_writer import publish
 
 class FakeApi:
     def __init__(self, files, verified=True):
-        self.head = '1' * 40
-        self.files = dict(files)
-        self.commits = {}
-        self.posts = 0
+        root = '1' * 40
+        self.branches = {'main': root}
+        self.trees = {root: dict(files)}
+        self.parents = {}
+        self.signed = set()
+        self.graphql_calls = 0
+        self.ref_updates = 0
+        self.ref_deletes = 0
+        self.fail_graphql_at = None
         self.verified = verified
 
+    @property
+    def head(self):
+        return self.branches['main']
+
+    @property
+    def files(self):
+        return self.trees[self.head]
+
     def sha(self):
-        self.posts += 1
-        return f'{self.posts + 1:040x}'
+        return f'{len(self.parents) + 2:040x}'
 
     def get(self, path):
-        if '/git/ref/heads/' in path:
-            return {'object': {'type': 'commit', 'sha': self.head}}
+        if '/git/ref/heads/' in path or '/git/refs/heads/' in path:
+            marker = '/git/refs/heads/' if '/git/refs/heads/' in path else '/git/ref/heads/'
+            branch = urllib.parse.unquote(path.split(marker, 1)[1])
+            if branch not in self.branches:
+                raise ValueError(f'GitHub API GET {path} failed: 404 missing')
+            return {
+                'ref': f'refs/heads/{branch}',
+                'object': {'type': 'commit', 'sha': self.branches[branch]},
+            }
         if '/git/commits/' in path:
             sha = path.rsplit('/', 1)[1]
-            if sha in self.commits:
+            if sha in self.signed:
                 return {
-                    'tree': {'sha': 'f' * 40},
                     'verification': {
                         'verified': self.verified,
                         'reason': 'valid' if self.verified else 'unsigned',
                         'signature': 'github-signature' if self.verified else None,
                     },
                 }
-            return {'tree': {'sha': 'f' * 40}}
+            raise AssertionError(f'unknown commit {sha}')
         if '/git/trees/' in path:
+            sha = path.split('/git/trees/', 1)[1].split('?', 1)[0]
             return {
                 'truncated': False,
                 'tree': [
-                    {'path': name, 'type': 'blob'} for name in sorted(self.files)
+                    {'path': name, 'type': 'blob'} for name in sorted(self.trees[sha])
                 ],
             }
         raise AssertionError(path)
@@ -421,9 +447,12 @@ class FakeApi:
     def get_bytes(self, path, *, limit):
         encoded = path.split('/contents/', 1)[1].split('?ref=', 1)[0]
         name = urllib.parse.unquote(encoded)
-        if name not in self.files:
+        ref = urllib.parse.unquote(path.split('?ref=', 1)[1])
+        sha = self.branches.get(ref, ref)
+        files = self.trees[sha]
+        if name not in files:
             raise ValueError(f'GitHub API GET {path} failed: 404 missing')
-        data = self.files[name]
+        data = files[name]
         if len(data) > limit:
             raise AssertionError('fixture exceeds limit')
         return data
@@ -431,26 +460,27 @@ class FakeApi:
     def graphql(self, query, variables):
         if 'createCommitOnBranch' not in query:
             raise AssertionError('wrong mutation')
+        self.graphql_calls += 1
+        if self.fail_graphql_at == self.graphql_calls:
+            raise ValueError('injected GraphQL failure')
         payload = variables['input']
         branch = payload['branch']
-        if branch != {
-            'repositoryNameWithOwner': 'Helvesec/rmux-packages',
-            'branchName': 'main',
-        }:
+        if branch['repositoryNameWithOwner'] != 'Helvesec/rmux-packages':
             raise AssertionError('wrong branch identity')
-        if payload['expectedHeadOid'] != self.head:
+        branch_name = branch['branchName']
+        if payload['expectedHeadOid'] != self.branches[branch_name]:
             raise AssertionError('non-atomic branch update')
         sha = self.sha()
-        import base64
-        files = dict(self.files)
+        files = dict(self.trees[payload['expectedHeadOid']])
         changes = payload['fileChanges']
         for entry in changes['deletions']:
             files.pop(entry['path'], None)
         for entry in changes['additions']:
             files[entry['path']] = base64.b64decode(entry['contents'])
-        self.commits[sha] = files
-        self.files = files
-        self.head = sha
+        self.trees[sha] = files
+        self.parents[sha] = payload['expectedHeadOid']
+        self.signed.add(sha)
+        self.branches[branch_name] = sha
         return {
             'createCommitOnBranch': {
                 'commit': {
@@ -464,6 +494,35 @@ class FakeApi:
                 'ref': {'target': {'oid': sha}},
             }
         }
+
+    def post(self, path, payload):
+        if path != '/repos/Helvesec/rmux-packages/git/refs':
+            raise AssertionError(path)
+        branch = payload['ref'].removeprefix('refs/heads/')
+        if branch in self.branches:
+            raise AssertionError('staging branch already exists')
+        self.branches[branch] = payload['sha']
+        return {'ref': payload['ref'], 'object': {'sha': payload['sha']}}
+
+    def patch(self, path, payload):
+        branch = urllib.parse.unquote(path.split('/git/refs/heads/', 1)[1])
+        if payload.get('force') is not False:
+            raise AssertionError('force update requested')
+        current = payload['sha']
+        while current != self.branches[branch]:
+            current = self.parents.get(current)
+            if current is None:
+                raise AssertionError('non-fast-forward staging promotion')
+        self.branches[branch] = payload['sha']
+        self.ref_updates += 1
+        return {'ref': f'refs/heads/{branch}', 'object': {'sha': payload['sha']}}
+
+    def delete(self, path):
+        branch = urllib.parse.unquote(path.split('/git/refs/heads/', 1)[1])
+        if branch == 'main':
+            raise AssertionError('main deletion requested')
+        del self.branches[branch]
+        self.ref_deletes += 1
 
 api = FakeApi({'managed/old.bin': b'old', 'keep.txt': b'keep'})
 base = api.head
@@ -481,7 +540,7 @@ if outcome.state != 'public-live' or not outcome.mutation_started:
 if api.files != {'managed/new.bin': b'new', 'keep.txt': b'keep'}:
     raise SystemExit(f'managed repository set differs: {api.files!r}')
 
-posts = api.posts
+posts = api.graphql_calls
 same = publish(
     api,
     full_name='Helvesec/rmux-packages',
@@ -489,25 +548,70 @@ same = publish(
     updates={'managed/new.bin': b'new'},
     message='publish exact bytes',
     managed_prefixes=('managed',),
-    expected_base=api.head,
+    expected_base=base,
 )
-if same.state != 'no-op-exact' or same.mutation_started or api.posts != posts:
-    raise SystemExit('exact repository no-op wrote Git objects')
+if same.state != 'no-op-exact' or same.mutation_started or api.graphql_calls != posts:
+    raise SystemExit('exact stale-base recovery wrote Git objects')
 
 try:
     publish(
         api,
         full_name='Helvesec/rmux-packages',
         branch='main',
-        updates={'managed/new.bin': b'new'},
+        updates={'managed/different.bin': b'different'},
         message='stale',
         managed_prefixes=('managed',),
-        expected_base='0' * 40,
+        expected_base=base,
     )
 except ValueError:
     pass
 else:
     raise SystemExit('stale repository base was accepted')
+
+commit_plan.GRAPHQL_COMMIT_MAX_BYTES = 1_600
+large = FakeApi({'managed/old.bin': b'old', 'keep.txt': b'keep'})
+large_base = large.head
+large_updates = {
+    'managed/one.bin': b'a' * 600,
+    'managed/two.bin': b'b' * 600,
+    'managed/three.bin': b'c' * 600,
+}
+large_outcome = publish(
+    large,
+    full_name='Helvesec/rmux-packages',
+    branch='main',
+    updates=large_updates,
+    message='publish chunked bytes',
+    managed_prefixes=('managed',),
+    expected_base=large_base,
+)
+if large_outcome.state != 'public-live' or large.ref_updates != 1:
+    raise SystemExit('chunked update did not advance main exactly once')
+if large.graphql_calls < 2 or large.files != {**large_updates, 'keep.txt': b'keep'}:
+    raise SystemExit('chunked update did not preserve the exact final tree')
+if set(large.branches) != {'main'} or large.ref_deletes != 1:
+    raise SystemExit('chunked update left its staging branch behind')
+
+broken = FakeApi({'managed/old.bin': b'old'})
+broken_base = broken.head
+broken.fail_graphql_at = 2
+try:
+    publish(
+        broken,
+        full_name='Helvesec/rmux-packages',
+        branch='main',
+        updates=large_updates,
+        message='fail chunked bytes',
+        managed_prefixes=('managed',),
+        expected_base=broken_base,
+    )
+except ValueError as error:
+    if 'injected GraphQL failure' not in str(error):
+        raise
+else:
+    raise SystemExit('chunked mutation failure was accepted')
+if broken.head != broken_base or set(broken.branches) != {'main'}:
+    raise SystemExit('failed chunked update changed main or leaked staging')
 
 unsigned = FakeApi({'managed/old.bin': b'old'}, verified=False)
 try:

--- a/tests/release_receipt_recovery_spec.rs
+++ b/tests/release_receipt_recovery_spec.rs
@@ -332,12 +332,110 @@ fn post_mutation_failure_jobs() -> Value {
     value
 }
 
+fn package_writer_failure_jobs() -> Value {
+    let mut value = post_mutation_failure_jobs();
+    let jobs = value["jobs"].as_array_mut().expect("jobs array");
+    for job in jobs.iter_mut() {
+        let name = job["name"].as_str().expect("job name");
+        if [
+            "Publish exact Homebrew tap formula",
+            "Publish exact Scoop manifest",
+            "Publish exact Web Share WASM bytes",
+        ]
+        .contains(&name)
+        {
+            job["conclusion"] = json!("success");
+            for step in job["steps"].as_array_mut().expect("writer steps") {
+                if step["name"] == "Run ./.github/actions/release-owned-repository-publish" {
+                    step["conclusion"] = json!("success");
+                }
+            }
+            continue;
+        }
+        if name == "Publish exact signed APT and RPM repositories" {
+            let action = "Run ./.github/actions/release-linux-repository-publish";
+            job["conclusion"] = json!("failure");
+            job["steps"] = json!([
+                step("Set up job", "success"),
+                step(
+                    "Run actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5",
+                    "success",
+                ),
+                step(action, "failure"),
+                step(&format!("Post {action}"), "success"),
+                step(
+                    "Post Run actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5",
+                    "success",
+                ),
+                step("Complete job", "success"),
+            ]);
+            continue;
+        }
+        if name == "Publish exact crates.io package set" {
+            job["name"] =
+                json!("Publish exact crates.io package set / Publish exact crates.io package set");
+            job["conclusion"] = json!("failure");
+            job["steps"] = json!([
+                step("Set up job", "success"),
+                step(
+                    "Run actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5",
+                    "success",
+                ),
+                step("Run ./.github/actions/release-channel-prepare", "success"),
+                step("Resolve exact crates.io execution authority", "success"),
+                step(
+                    "Exchange GitHub OIDC for a short-lived crates.io token",
+                    "failure",
+                ),
+                step("Publish and redownload every exact crate", "skipped"),
+                step("Normalize executable and policy-only outcomes", "skipped"),
+                step("Seal exact crates.io result evidence", "skipped"),
+                step(
+                    "Post Exchange GitHub OIDC for a short-lived crates.io token",
+                    "success",
+                ),
+                step(
+                    "Post Run actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5",
+                    "success",
+                ),
+                step("Complete job", "success"),
+            ]);
+        }
+    }
+    value
+}
+
 fn downstream_failure_artifacts() -> (Value, u64) {
     downstream_failure_artifacts_for(FAILED_RUN, FAILED_CONTROL, 81)
 }
 
 fn post_mutation_failure_artifacts() -> (Value, u64) {
     post_mutation_failure_artifacts_for(FAILED_RUN, FAILED_CONTROL, 81, true)
+}
+
+fn package_writer_failure_artifacts() -> (Value, u64) {
+    let (mut value, receipt_id) = post_mutation_failure_artifacts();
+    let artifacts = value["artifacts"].as_array_mut().expect("artifacts array");
+    for channel in ["homebrew_tap", "scoop", "web_share"] {
+        artifacts.push(json!({
+            "id": receipt_id + artifacts.len() as u64,
+            "name": format!(
+                "rmux-downstream-{channel}-result-reference-{SOURCE}-{RELEASE_ID}"
+            ),
+            "expired": false,
+            "digest": format!("sha256:{}", "a".repeat(64)),
+            "workflow_run": {
+                "id": FAILED_RUN,
+                "head_sha": FAILED_CONTROL,
+                "head_branch": "main",
+                "repository_id": 1_239_918_790,
+                "head_repository_id": 1_239_918_790,
+            },
+        }));
+    }
+    let total_count = artifacts.len();
+    value["total_count"] = json!(total_count);
+    (value, receipt_id)
 }
 
 fn post_mutation_failure_artifacts_for(
@@ -551,6 +649,64 @@ fn protected_main_recovery_accepts_only_the_exact_post_mutation_seal_failure() {
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
+}
+
+#[test]
+fn protected_main_recovery_accepts_exact_package_writer_failures() {
+    let root = fixture_root("package-writer-failures");
+    let (artifacts, receipt_id) = package_writer_failure_artifacts();
+    let output = run_recovery(
+        &root,
+        failed_run(FAILED_CONTROL, "main", "failure"),
+        package_writer_failure_jobs(),
+        artifacts,
+        json!({
+            "total_count": 1,
+            "artifacts": [{
+                "id": receipt_id,
+                "name": format!("rmux-publication-receipt-{SOURCE}-{RELEASE_ID}"),
+                "expired": false,
+                "workflow_run": {"id": FAILED_RUN},
+            }],
+        }),
+    );
+    fs::remove_dir_all(&root).expect("remove fixture root");
+    assert!(
+        output.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn protected_main_recovery_rejects_partial_package_result_references() {
+    let root = fixture_root("package-writer-partial-references");
+    let (mut artifacts, receipt_id) = package_writer_failure_artifacts();
+    let entries = artifacts["artifacts"]
+        .as_array_mut()
+        .expect("artifacts array");
+    entries.retain(|artifact| {
+        artifact["name"] != format!("rmux-downstream-scoop-result-reference-{SOURCE}-{RELEASE_ID}")
+    });
+    artifacts["total_count"] = json!(entries.len());
+    let output = run_recovery(
+        &root,
+        failed_run(FAILED_CONTROL, "main", "failure"),
+        package_writer_failure_jobs(),
+        artifacts,
+        json!({
+            "total_count": 1,
+            "artifacts": [{
+                "id": receipt_id,
+                "name": format!("rmux-publication-receipt-{SOURCE}-{RELEASE_ID}"),
+                "expired": false,
+                "workflow_run": {"id": FAILED_RUN},
+            }],
+        }),
+    );
+    fs::remove_dir_all(&root).expect("remove fixture root");
+    assert!(!output.status.success());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- preflight crates.io Trusted Publishing before any public writer
- split oversized signed APT/RPM updates into bounded GitHub-signed staging commits, then advance the protected target branch once
- accept only the exact v0.10.0 package-writer failure topology for receipt recovery

## Validation

- 113 targeted release tests
- release contracts, Ruff, Rustfmt, and diff checks
- live protected-branch signed-writer drill
- live validation of receipt run 30963921967 and its 24 artifacts
- exact v0.10.0 APT/RPM payload plans as two requests below the 44 MB safety limit