### PR TITLE
fix(release): harden final package publication

### DIFF
--- a/scripts/release/github_repository_commit_plan.py
+++ b/scripts/release/github_repository_commit_plan.py
@@ -28,7 +28,7 @@ mutation CreateSignedCommit($input: CreateCommitOnBranchInput!) {
 }
 """
 
-GRAPHQL_COMMIT_MAX_BYTES = 44_000_000
+GRAPHQL_COMMIT_MAX_BYTES = 25_000_000
 STAGING_BRANCH_PREFIX = "rmux-release-stage"
 
 

--- a/scripts/release/github_repository_writer.py
+++ b/scripts/release/github_repository_writer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -23,6 +24,15 @@ class PublishOutcome:
     state: str
     mutation_started: bool
     commit_sha: str
+
+
+TRANSIENT_GRAPHQL_ERRORS = (
+    "GitHub API POST /graphql failed: 429 ",
+    "GitHub API POST /graphql failed: 500 ",
+    "GitHub API POST /graphql failed: 502 ",
+    "GitHub API POST /graphql failed: 503 ",
+    "GitHub API POST /graphql failed: 504 ",
+)
 
 
 class GitHubApi:
@@ -188,10 +198,21 @@ def create_signed_commit(
     )
     if request_size > GRAPHQL_COMMIT_MAX_BYTES:
         raise ValueError("signed GitHub commit request exceeds its safe payload limit")
-    data = api.graphql(
-        CREATE_COMMIT_MUTATION,
-        variables,
-    )
+    for attempt in range(3):
+        try:
+            data = api.graphql(CREATE_COMMIT_MUTATION, variables)
+            break
+        except (OSError, ValueError) as error:
+            transient = isinstance(error, OSError) or any(
+                marker in str(error) for marker in TRANSIENT_GRAPHQL_ERRORS
+            )
+            if not transient or attempt == 2:
+                raise
+            if branch_head(api, full_name, branch) != base_commit:
+                raise ValueError(
+                    "signed commit outcome is ambiguous; rerun idempotent recovery"
+                ) from error
+            time.sleep(2**attempt)
     mutation = data.get("createCommitOnBranch")
     if not isinstance(mutation, dict):
         raise ValueError("GitHub signed commit mutation returned no result")

--- a/scripts/release/publish-crate-set.py
+++ b/scripts/release/publish-crate-set.py
@@ -44,6 +44,12 @@ def package_set_file(root: Path, version: str) -> Path:
     return expected
 
 
+def prepare_target_dir(path: Path) -> None:
+    if path.exists() or path.is_symlink():
+        raise ValueError("crates.io target directory must start absent")
+    path.mkdir(parents=True)
+
+
 def registry_url(name: str, version: str, *, download: bool = False) -> str:
     name = urllib.parse.quote(name, safe="")
     version = urllib.parse.quote(version, safe="")
@@ -161,6 +167,7 @@ def execute(args: argparse.Namespace) -> None:
     if not token or "\n" in token or "\r" in token:
         raise ValueError("short-lived crates.io token is missing or malformed")
     package_set = package_set_file(args.payload_dir, version)
+    prepare_target_dir(args.target_dir)
     extracted = args.target_dir / "canonical"
     manifest = unpack(package_set, extracted)
     packages = validate(

--- a/scripts/release/receipt_recovery_topology.py
+++ b/scripts/release/receipt_recovery_topology.py
@@ -26,6 +26,7 @@ EARLY_SUCCESS_JOBS = DIRECT_SUCCESS_JOBS | PREPARATION_SUCCESS_JOBS
 LINUX_SIGNING_JOB = "Build exact signed Linux repository trees / Sign retained APT and RPM repository trees"
 APT_PUBLISH_JOB = "Publish exact signed APT and RPM repositories"
 CRATES_PUBLISH_JOB = "Publish exact crates.io package set"
+CRATES_PREFLIGHT_JOB = "Verify crates.io Trusted Publishing authority"
 CRATES_PUBLISH_JOB_EXPANDED = (
     "Publish exact crates.io package set / Publish exact crates.io package set"
 )
@@ -150,6 +151,7 @@ def canonical_failed_jobs(
         | set(PACKAGE_WRITER_JOB_MAP)
         | (POST_MUTATION_SKIPPED_AFTER_FAILURE - {CRATES_PUBLISH_JOB})
     )
+    package_execution_names = package_writer_names | {CRATES_PREFLIGHT_JOB}
     raw_names = set(jobs)
     if raw_names == legacy_names:
         return (
@@ -175,7 +177,10 @@ def canonical_failed_jobs(
             },
             True,
         )
-    if raw_names == package_writer_names:
+    if frozenset(raw_names) in {
+        frozenset(package_writer_names),
+        frozenset(package_execution_names),
+    }:
         return (
             {
                 PACKAGE_WRITER_JOB_MAP.get(
@@ -266,6 +271,19 @@ def verify_failed_downstream_jobs(value: dict[str, Any]) -> str:
                 conclusion="success",
                 steps=writer_prefix | {action: "success", f"Post {action}": "success"},
             )
+        preflight = by_name.get(CRATES_PREFLIGHT_JOB)
+        if preflight is not None:
+            exact_job_shape(
+                preflight,
+                name=CRATES_PREFLIGHT_JOB,
+                conclusion="success",
+                steps={
+                    "Set up job": "success",
+                    "Exchange and revoke a preflight crates.io token": "success",
+                    "Post Exchange and revoke a preflight crates.io token": "success",
+                    "Complete job": "success",
+                },
+            )
         verify_skipped_jobs(
             by_name,
             POST_MUTATION_SKIPPED_AFTER_FAILURE - {APT_PUBLISH_JOB, CRATES_PUBLISH_JOB},
@@ -278,25 +296,34 @@ def verify_failed_downstream_jobs(value: dict[str, Any]) -> str:
             steps=writer_prefix
             | {apt_action: "failure", f"Post {apt_action}": "success"},
         )
+        crates_steps = {
+            "Set up job": "success",
+            checkout: "success",
+            "Run ./.github/actions/release-channel-prepare": "success",
+            "Resolve exact crates.io execution authority": "success",
+            "Exchange GitHub OIDC for a short-lived crates.io token": (
+                "success" if preflight is not None else "failure"
+            ),
+            "Publish and redownload every exact crate": (
+                "failure" if preflight is not None else "skipped"
+            ),
+            "Normalize executable and policy-only outcomes": "skipped",
+            "Seal exact crates.io result evidence": "skipped",
+            "Post Exchange GitHub OIDC for a short-lived crates.io token": "success",
+            post_checkout: "success",
+            "Complete job": "success",
+        }
         exact_job_shape(
             by_name[CRATES_PUBLISH_JOB],
             name=CRATES_PUBLISH_JOB,
             conclusion="failure",
-            steps={
-                "Set up job": "success",
-                checkout: "success",
-                "Run ./.github/actions/release-channel-prepare": "success",
-                "Resolve exact crates.io execution authority": "success",
-                "Exchange GitHub OIDC for a short-lived crates.io token": "failure",
-                "Publish and redownload every exact crate": "skipped",
-                "Normalize executable and policy-only outcomes": "skipped",
-                "Seal exact crates.io result evidence": "skipped",
-                "Post Exchange GitHub OIDC for a short-lived crates.io token": "success",
-                post_checkout: "success",
-                "Complete job": "success",
-            },
+            steps=crates_steps,
         )
-        return "package-writer-failure"
+        return (
+            "package-execution-failure"
+            if preflight is not None
+            else "package-writer-failure"
+        )
     verify_skipped_jobs(by_name, SKIPPED_AFTER_FAILURE)
     if linux.get("conclusion") != "failure":
         raise ValueError("Linux repository signing did not fail closed")
@@ -374,7 +401,7 @@ def verify_failed_downstream_artifacts(
                 expected_names
                 | result_envelope_names(args.source_sha, args.release_id),
             )
-        elif failure_mode == "package-writer-failure":
+        elif failure_mode in {"package-writer-failure", "package-execution-failure"}:
             expected_names.update(
                 result_envelope_names(args.source_sha, args.release_id)
             )

--- a/tests/release_downstream_workflows_spec.rs
+++ b/tests/release_downstream_workflows_spec.rs
@@ -455,6 +455,17 @@ else:
     raise AssertionError("metadata access denial was treated as a missing version")
 
 with tempfile.TemporaryDirectory() as directory:
+    target = pathlib.Path(directory) / "missing" / "target"
+    module.prepare_target_dir(target)
+    assert target.is_dir()
+    try:
+        module.prepare_target_dir(target)
+    except ValueError as error:
+        assert "must start absent" in str(error)
+    else:
+        raise AssertionError("existing crates.io target directory was accepted")
+
+with tempfile.TemporaryDirectory() as directory:
     target = pathlib.Path(directory)
     filename = "rmux-types-0.9.1.crate"
     direct, temporary = module.generated_package_paths(target, filename)

--- a/tests/release_downstream_writer_spec.rs
+++ b/tests/release_downstream_writer_spec.rs
@@ -372,7 +372,7 @@ with tempfile.TemporaryDirectory(dir=pathlib.Path.cwd()) as directory:
 #[test]
 fn github_repository_writer_is_atomic_idempotent_and_prefix_exact() {
     assert!(GITHUB_REPOSITORY_COMMIT_PLAN.contains("createCommitOnBranch"));
-    assert!(GITHUB_REPOSITORY_COMMIT_PLAN.contains("GRAPHQL_COMMIT_MAX_BYTES = 44_000_000"));
+    assert!(GITHUB_REPOSITORY_COMMIT_PLAN.contains("GRAPHQL_COMMIT_MAX_BYTES = 25_000_000"));
     assert!(GITHUB_REPOSITORY_COMMIT_PLAN.contains("rmux-release-stage"));
     assert!(GITHUB_REPOSITORY_WRITER.contains("wasSignedByGitHub"));
     assert!(GITHUB_REPOSITORY_WRITER.contains("verification.get(\"verified\") is not True"));
@@ -400,6 +400,8 @@ class FakeApi:
         self.ref_updates = 0
         self.ref_deletes = 0
         self.fail_graphql_at = None
+        self.transient_graphql_at = None
+        self.transient_advances = False
         self.verified = verified
 
     @property
@@ -470,6 +472,11 @@ class FakeApi:
         branch_name = branch['branchName']
         if payload['expectedHeadOid'] != self.branches[branch_name]:
             raise AssertionError('non-atomic branch update')
+        if self.transient_graphql_at == self.graphql_calls:
+            self.transient_graphql_at = None
+            if self.transient_advances:
+                self.branches[branch_name] = 'f' * 40
+            raise ValueError('GitHub API POST /graphql failed: 502 transient')
         sha = self.sha()
         files = dict(self.trees[payload['expectedHeadOid']])
         changes = payload['fileChanges']
@@ -591,6 +598,42 @@ if large.graphql_calls < 2 or large.files != {**large_updates, 'keep.txt': b'kee
     raise SystemExit('chunked update did not preserve the exact final tree')
 if set(large.branches) != {'main'} or large.ref_deletes != 1:
     raise SystemExit('chunked update left its staging branch behind')
+
+transient = FakeApi({'managed/old.bin': b'old'})
+transient.transient_graphql_at = 2
+transient_outcome = publish(
+    transient,
+    full_name='Helvesec/rmux-packages',
+    branch='main',
+    updates=large_updates,
+    message='retry transient chunked bytes',
+    managed_prefixes=('managed',),
+    expected_base=transient.head,
+)
+if transient_outcome.state != 'public-live' or transient.ref_updates != 1:
+    raise SystemExit('transient signed commit failure was not recovered')
+
+ambiguous = FakeApi({'managed/old.bin': b'old'})
+ambiguous_base = ambiguous.head
+ambiguous.transient_graphql_at = 2
+ambiguous.transient_advances = True
+try:
+    publish(
+        ambiguous,
+        full_name='Helvesec/rmux-packages',
+        branch='main',
+        updates=large_updates,
+        message='reject ambiguous chunked bytes',
+        managed_prefixes=('managed',),
+        expected_base=ambiguous_base,
+    )
+except ValueError as error:
+    if 'outcome is ambiguous' not in str(error):
+        raise
+else:
+    raise SystemExit('ambiguous signed commit result was retried')
+if ambiguous.head != ambiguous_base or set(ambiguous.branches) != {'main'}:
+    raise SystemExit('ambiguous staging mutation changed main or leaked staging')
 
 broken = FakeApi({'managed/old.bin': b'old'})
 broken_base = broken.head

--- a/tests/release_receipt_recovery_spec.rs
+++ b/tests/release_receipt_recovery_spec.rs
@@ -405,6 +405,40 @@ fn package_writer_failure_jobs() -> Value {
     value
 }
 
+fn package_execution_failure_jobs() -> Value {
+    let mut value = package_writer_failure_jobs();
+    let jobs = value["jobs"].as_array_mut().expect("jobs array");
+    jobs.push(json!({
+        "name": "Verify crates.io Trusted Publishing authority",
+        "conclusion": "success",
+        "steps": [
+            step("Set up job", "success"),
+            step("Exchange and revoke a preflight crates.io token", "success"),
+            step(
+                "Post Exchange and revoke a preflight crates.io token",
+                "success",
+            ),
+            step("Complete job", "success"),
+        ],
+    }));
+    for job in jobs.iter_mut() {
+        if job["name"]
+            == "Publish exact crates.io package set / Publish exact crates.io package set"
+        {
+            for step in job["steps"].as_array_mut().expect("crates steps") {
+                if step["name"] == "Exchange GitHub OIDC for a short-lived crates.io token" {
+                    step["conclusion"] = json!("success");
+                }
+                if step["name"] == "Publish and redownload every exact crate" {
+                    step["conclusion"] = json!("failure");
+                }
+            }
+        }
+    }
+    value["total_count"] = json!(jobs.len());
+    value
+}
+
 fn downstream_failure_artifacts() -> (Value, u64) {
     downstream_failure_artifacts_for(FAILED_RUN, FAILED_CONTROL, 81)
 }
@@ -659,6 +693,34 @@ fn protected_main_recovery_accepts_exact_package_writer_failures() {
         &root,
         failed_run(FAILED_CONTROL, "main", "failure"),
         package_writer_failure_jobs(),
+        artifacts,
+        json!({
+            "total_count": 1,
+            "artifacts": [{
+                "id": receipt_id,
+                "name": format!("rmux-publication-receipt-{SOURCE}-{RELEASE_ID}"),
+                "expired": false,
+                "workflow_run": {"id": FAILED_RUN},
+            }],
+        }),
+    );
+    fs::remove_dir_all(&root).expect("remove fixture root");
+    assert!(
+        output.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn protected_main_recovery_accepts_exact_package_execution_failures() {
+    let root = fixture_root("package-execution-failures");
+    let (artifacts, receipt_id) = package_writer_failure_artifacts();
+    let output = run_recovery(
+        &root,
+        failed_run(FAILED_CONTROL, "main", "failure"),
+        package_execution_failure_jobs(),
         artifacts,
         json!({
             "total_count": 1,


### PR DESCRIPTION
## Summary

- create the isolated crates.io working directory before unpacking the canonical package set
- keep signed GitHub commit requests below 25 MB and retry transient GraphQL failures only while the branch remains unchanged
- accept only the exact latest package-execution failure topology for receipt recovery

## Validation

- 114 targeted release tests
- release contracts, Ruff, Rustfmt, and diff checks
- real 12-crate package set unpacked and validated in a missing nested target
- real v0.10.0 APT/RPM update planned as four requests between 15.0 MB and 21.6 MB
- live validation of receipt run 30967827409 and its exact artifacts