### PR TITLE
fix(release): recover exact package publication

### DIFF
--- a/.github/workflows/release-crates-channel.yml
+++ b/.github/workflows/release-crates-channel.yml
@@ -55,6 +55,14 @@ jobs:
           --target-evidence "${{ steps.prepare.outputs.root }}/downstream-channel-target-evidence.json"
           --github-output "$GITHUB_OUTPUT"
 
+      - name: Check out the exact release source
+        if: steps.decision.outputs.execute == 'true'
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ inputs.expected_source_sha }}
+          path: rmux-release-source
+          persist-credentials: false
+
       - id: auth
         name: Exchange GitHub OIDC for a short-lived crates.io token
         if: steps.decision.outputs.execute == 'true'
@@ -70,6 +78,7 @@ jobs:
           scripts/release/publish-crate-set.py
           --payload-dir "${{ steps.prepare.outputs.payload-root }}"
           --source-sha "${{ inputs.expected_source_sha }}"
+          --source-dir "$GITHUB_WORKSPACE/rmux-release-source"
           --release-ref "${{ inputs.release_ref }}"
           --target-dir "$RUNNER_TEMP/rmux-crates-publish"
           --target-evidence "${{ steps.prepare.outputs.root }}/downstream-channel-target-evidence.json"

--- a/scripts/release/github_repository_writer.py
+++ b/scripts/release/github_repository_writer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import time
 import urllib.error
@@ -156,7 +157,11 @@ class GitHubApi:
 
 def object_sha(value: dict[str, Any], label: str) -> str:
     sha = value.get("sha")
-    if not isinstance(sha, str) or len(sha) != 40:
+    if (
+        not isinstance(sha, str)
+        or len(sha) != 40
+        or any(character not in "0123456789abcdef" for character in sha)
+    ):
         raise ValueError(f"GitHub {label} has no canonical SHA")
     return sha
 
@@ -170,6 +175,68 @@ def object_oid(value: dict[str, Any], label: str) -> str:
     ):
         raise ValueError(f"GitHub {label} has no canonical OID")
     return oid
+
+
+def git_blob_sha(contents: bytes) -> str:
+    digest = hashlib.sha1(usedforsecurity=False)
+    digest.update(f"blob {len(contents)}\0".encode())
+    digest.update(contents)
+    return digest.hexdigest()
+
+
+def verify_rest_commit(
+    api: GitHubApi,
+    full_name: str,
+    commit_sha: str,
+    *,
+    expected_parent: str,
+) -> None:
+    commit = api.get(f"/repos/{full_name}/git/commits/{commit_sha}")
+    verification = commit.get("verification")
+    parents = commit.get("parents")
+    if (
+        not isinstance(verification, dict)
+        or verification.get("verified") is not True
+        or verification.get("reason") != "valid"
+        or not isinstance(verification.get("signature"), str)
+        or not verification["signature"]
+    ):
+        raise ValueError("GitHub REST verification rejected the signed commit")
+    if (
+        not isinstance(parents, list)
+        or len(parents) != 1
+        or not isinstance(parents[0], dict)
+        or object_sha(parents[0], "commit parent") != expected_parent
+    ):
+        raise ValueError("GitHub signed commit parent differs")
+
+
+def recover_exact_signed_commit(
+    api: GitHubApi,
+    *,
+    full_name: str,
+    commit_sha: str,
+    base_commit: str,
+    additions: dict[str, bytes],
+    deletions: set[str],
+) -> bool:
+    verify_rest_commit(
+        api,
+        full_name,
+        commit_sha,
+        expected_parent=base_commit,
+    )
+    expected = tree_blobs(api, full_name, base_commit)
+    for path in deletions:
+        expected.pop(path, None)
+    for path, contents in additions.items():
+        expected[path] = git_blob_sha(contents)
+    if tree_blobs(api, full_name, commit_sha) != expected:
+        return False
+    return all(
+        file_at(api, full_name, path, commit_sha) == contents
+        for path, contents in additions.items()
+    )
 
 
 def create_signed_commit(
@@ -206,12 +273,24 @@ def create_signed_commit(
             transient = isinstance(error, OSError) or any(
                 marker in str(error) for marker in TRANSIENT_GRAPHQL_ERRORS
             )
-            if not transient or attempt == 2:
+            if not transient:
                 raise
-            if branch_head(api, full_name, branch) != base_commit:
+            current = branch_head(api, full_name, branch)
+            if current != base_commit:
+                if recover_exact_signed_commit(
+                    api,
+                    full_name=full_name,
+                    commit_sha=current,
+                    base_commit=base_commit,
+                    additions=additions,
+                    deletions=deletions,
+                ):
+                    return current
                 raise ValueError(
-                    "signed commit outcome is ambiguous; rerun idempotent recovery"
+                    "signed commit outcome advanced to unexpected repository bytes"
                 ) from error
+            if attempt == 2:
+                raise
             time.sleep(2**attempt)
     mutation = data.get("createCommitOnBranch")
     if not isinstance(mutation, dict):
@@ -232,17 +311,12 @@ def create_signed_commit(
         or signature.get("wasSignedByGitHub") is not True
     ):
         raise ValueError("GitHub did not create a valid platform-signed commit")
-    verification = api.get(f"/repos/{full_name}/git/commits/{commit_sha}").get(
-        "verification"
+    verify_rest_commit(
+        api,
+        full_name,
+        commit_sha,
+        expected_parent=base_commit,
     )
-    if (
-        not isinstance(verification, dict)
-        or verification.get("verified") is not True
-        or verification.get("reason") != "valid"
-        or not isinstance(verification.get("signature"), str)
-        or not verification["signature"]
-    ):
-        raise ValueError("GitHub REST verification rejected the signed commit")
     return commit_sha
 
 
@@ -282,19 +356,23 @@ def file_at(api: GitHubApi, full_name: str, path: str, ref: str) -> bytes | None
         raise
 
 
-def tree_paths(api: GitHubApi, full_name: str, commit_sha: str) -> set[str]:
+def tree_blobs(api: GitHubApi, full_name: str, commit_sha: str) -> dict[str, str]:
     value = api.get(f"/repos/{full_name}/git/trees/{commit_sha}?recursive=1")
     if value.get("truncated") is not False or not isinstance(value.get("tree"), list):
         raise ValueError("downstream repository tree is missing or truncated")
-    paths: set[str] = set()
+    blobs: dict[str, str] = {}
     for entry in value["tree"]:
         if not isinstance(entry, dict) or entry.get("type") != "blob":
             continue
         path = entry.get("path")
-        if not isinstance(path, str) or not path or path in paths:
+        if not isinstance(path, str) or not path or path in blobs:
             raise ValueError("downstream repository tree path is invalid")
-        paths.add(path)
-    return paths
+        blobs[path] = object_sha(entry, "tree blob")
+    return blobs
+
+
+def tree_paths(api: GitHubApi, full_name: str, commit_sha: str) -> set[str]:
+    return set(tree_blobs(api, full_name, commit_sha))
 
 
 def managed_paths(paths: set[str], prefixes: tuple[str, ...]) -> set[str]:

--- a/scripts/release/publish-crate-set.py
+++ b/scripts/release/publish-crate-set.py
@@ -29,6 +29,7 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("--payload-dir", type=Path, required=True)
     parser.add_argument("--source-sha", required=True)
+    parser.add_argument("--source-dir", type=Path, required=True)
     parser.add_argument("--release-ref", required=True)
     parser.add_argument("--target-dir", type=Path, required=True)
     parser.add_argument("--target-evidence", type=Path, required=True)
@@ -48,6 +49,39 @@ def prepare_target_dir(path: Path) -> None:
     if path.exists() or path.is_symlink():
         raise ValueError("crates.io target directory must start absent")
     path.mkdir(parents=True)
+
+
+def git_output(source_dir: Path, *arguments: str) -> str:
+    completed = subprocess.run(
+        ["git", "-C", str(source_dir), *arguments],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if completed.returncode != 0:
+        raise ValueError(f"release source Git check failed: {completed.stderr.strip()}")
+    return completed.stdout.strip()
+
+
+def validate_source_checkout(path: Path, source_sha: str) -> Path:
+    if path.is_symlink() or not path.is_dir():
+        raise ValueError("release source checkout is missing or symbolic")
+    source_dir = path.resolve(strict=True)
+    root_text = git_output(source_dir, "rev-parse", "--show-toplevel")
+    root = Path(root_text).resolve(strict=True)
+    if root != source_dir:
+        raise ValueError("release source checkout root differs")
+    if git_output(source_dir, "rev-parse", "--verify", "HEAD^{commit}") != source_sha:
+        raise ValueError("release source checkout SHA differs")
+    if git_output(
+        source_dir,
+        "status",
+        "--porcelain=v1",
+        "--untracked-files=all",
+    ):
+        raise ValueError("release source checkout is dirty")
+    return source_dir
 
 
 def registry_url(name: str, version: str, *, download: bool = False) -> str:
@@ -103,7 +137,9 @@ def registry_bytes(name: str, version: str) -> bytes | None:
     return data
 
 
-def run_cargo(args: list[str], *, token: str, target_dir: Path) -> None:
+def run_cargo(
+    args: list[str], *, token: str, target_dir: Path, source_dir: Path
+) -> None:
     environment = {
         **os.environ,
         "CARGO_REGISTRY_TOKEN": token,
@@ -112,6 +148,7 @@ def run_cargo(args: list[str], *, token: str, target_dir: Path) -> None:
     completed = subprocess.run(
         ["cargo", *args],
         check=False,
+        cwd=source_dir,
         env=environment,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -167,6 +204,7 @@ def execute(args: argparse.Namespace) -> None:
     if not token or "\n" in token or "\r" in token:
         raise ValueError("short-lived crates.io token is missing or malformed")
     package_set = package_set_file(args.payload_dir, version)
+    source_dir = validate_source_checkout(args.source_dir, args.source_sha)
     prepare_target_dir(args.target_dir)
     extracted = args.target_dir / "canonical"
     manifest = unpack(package_set, extracted)
@@ -188,6 +226,7 @@ def execute(args: argparse.Namespace) -> None:
             ["publish", "--dry-run", "--locked", "--package", name],
             token=token,
             target_dir=cargo_target,
+            source_dir=source_dir,
         )
         if file_hash(generated_package(cargo_target, package["file"])) != file_hash(
             canonical
@@ -198,6 +237,7 @@ def execute(args: argparse.Namespace) -> None:
             ["publish", "--locked", "--package", name],
             token=token,
             target_dir=cargo_target,
+            source_dir=source_dir,
         )
         if file_hash(generated_package(cargo_target, package["file"])) != file_hash(
             canonical

--- a/tests/release_downstream_workflows_spec.rs
+++ b/tests/release_downstream_workflows_spec.rs
@@ -17,6 +17,7 @@ const DOWNSTREAM_AUTHORITY_PROOF: &str =
 const DOWNSTREAM_PREPARE: &str =
     include_str!("../.github/workflows/release-downstream-prepare.yml");
 const RECEIPT: &str = include_str!("../.github/workflows/release-receipt.yml");
+const CRATES_CHANNEL: &str = include_str!("../.github/workflows/release-crates-channel.yml");
 const CI: &str = include_str!("../.github/workflows/ci.yml");
 const LINUX_REPOSITORY_BUILD: &str =
     include_str!("../.github/workflows/release-linux-repository-build.yml");
@@ -393,6 +394,24 @@ fn downstream_writers_keep_the_python_310_runtime_contract() {
 }
 
 #[test]
+fn crates_writer_repackages_only_the_exact_release_source() {
+    assert_workflow_call_only(CRATES_CHANNEL);
+    let source_checkout = CRATES_CHANNEL
+        .find("name: Check out the exact release source")
+        .expect("exact release source checkout");
+    let token_exchange = CRATES_CHANNEL
+        .find("name: Exchange GitHub OIDC")
+        .expect("crates.io token exchange");
+    let writer = CRATES_CHANNEL
+        .find("name: Publish and redownload every exact crate")
+        .expect("crates.io writer");
+    assert!(source_checkout < token_exchange && token_exchange < writer);
+    assert!(CRATES_CHANNEL.contains("ref: ${{ inputs.expected_source_sha }}"));
+    assert!(CRATES_CHANNEL.contains("path: rmux-release-source"));
+    assert!(CRATES_CHANNEL.contains("--source-dir \"$GITHUB_WORKSPACE/rmux-release-source\""));
+}
+
+#[test]
 fn linux_repository_build_retains_authenticated_previous_by_hash_indexes() {
     let authenticated = LINUX_REPOSITORY_BUILD
         .find("scripts/retain-linux-package-history.py")
@@ -410,6 +429,7 @@ fn crates_writer_distinguishes_missing_versions_from_download_denials() {
     let fixture = r#"
 import importlib.util
 import pathlib
+import subprocess
 import sys
 import tempfile
 import urllib.error
@@ -481,6 +501,35 @@ with tempfile.TemporaryDirectory() as directory:
         raise AssertionError("ambiguous Cargo package output was accepted")
     module.remove_generated_package(target, filename)
     assert not direct.exists() and not temporary.exists()
+
+with tempfile.TemporaryDirectory() as directory:
+    source = pathlib.Path(directory) / "source"
+    source.mkdir()
+    subprocess.run(["git", "init", "-q", str(source)], check=True)
+    (source / "Cargo.toml").write_text("[workspace]\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(source), "add", "Cargo.toml"], check=True)
+    subprocess.run([
+        "git", "-C", str(source), "-c", "user.name=RMUX Release Test",
+        "-c", "user.email=release-test@rmux.invalid", "commit", "-q", "-m", "baseline"
+    ], check=True)
+    head = subprocess.run(
+        ["git", "-C", str(source), "rev-parse", "HEAD"],
+        check=True, capture_output=True, text=True,
+    ).stdout.strip()
+    assert module.validate_source_checkout(source, head) == source.resolve()
+    try:
+        module.validate_source_checkout(source, "f" * 40)
+    except ValueError as error:
+        assert "SHA differs" in str(error)
+    else:
+        raise AssertionError("wrong release source SHA was accepted")
+    (source / "untracked").write_text("dirty\n", encoding="utf-8")
+    try:
+        module.validate_source_checkout(source, head)
+    except ValueError as error:
+        assert "is dirty" in str(error)
+    else:
+        raise AssertionError("dirty release source checkout was accepted")
 "#;
     let output = Command::new("python3")
         .args(["-c", fixture])

--- a/tests/release_downstream_writer_spec.rs
+++ b/tests/release_downstream_writer_spec.rs
@@ -382,12 +382,19 @@ fn github_repository_writer_is_atomic_idempotent_and_prefix_exact() {
     assert_python(
         r#"
 import base64
+import hashlib
 import urllib.parse
 import sys
 
 sys.path.insert(0, 'scripts/release')
 import github_repository_commit_plan as commit_plan
 from github_repository_writer import publish
+
+def blob_sha(data):
+    digest = hashlib.sha1()
+    digest.update(f'blob {len(data)}\0'.encode())
+    digest.update(data)
+    return digest.hexdigest()
 
 class FakeApi:
     def __init__(self, files, verified=True):
@@ -401,7 +408,7 @@ class FakeApi:
         self.ref_deletes = 0
         self.fail_graphql_at = None
         self.transient_graphql_at = None
-        self.transient_advances = False
+        self.transient_advances = None
         self.verified = verified
 
     @property
@@ -429,6 +436,7 @@ class FakeApi:
             sha = path.rsplit('/', 1)[1]
             if sha in self.signed:
                 return {
+                    'parents': [{'sha': self.parents[sha]}],
                     'verification': {
                         'verified': self.verified,
                         'reason': 'valid' if self.verified else 'unsigned',
@@ -441,7 +449,8 @@ class FakeApi:
             return {
                 'truncated': False,
                 'tree': [
-                    {'path': name, 'type': 'blob'} for name in sorted(self.trees[sha])
+                    {'path': name, 'type': 'blob', 'sha': blob_sha(self.trees[sha][name])}
+                    for name in sorted(self.trees[sha])
                 ],
             }
         raise AssertionError(path)
@@ -475,19 +484,12 @@ class FakeApi:
         if self.transient_graphql_at == self.graphql_calls:
             self.transient_graphql_at = None
             if self.transient_advances:
-                self.branches[branch_name] = 'f' * 40
+                self.apply_payload(
+                    payload,
+                    tamper=self.transient_advances == 'unexpected',
+                )
             raise ValueError('GitHub API POST /graphql failed: 502 transient')
-        sha = self.sha()
-        files = dict(self.trees[payload['expectedHeadOid']])
-        changes = payload['fileChanges']
-        for entry in changes['deletions']:
-            files.pop(entry['path'], None)
-        for entry in changes['additions']:
-            files[entry['path']] = base64.b64decode(entry['contents'])
-        self.trees[sha] = files
-        self.parents[sha] = payload['expectedHeadOid']
-        self.signed.add(sha)
-        self.branches[branch_name] = sha
+        sha = self.apply_payload(payload)
         return {
             'createCommitOnBranch': {
                 'commit': {
@@ -501,6 +503,23 @@ class FakeApi:
                 'ref': {'target': {'oid': sha}},
             }
         }
+
+    def apply_payload(self, payload, *, tamper=False):
+        branch_name = payload['branch']['branchName']
+        sha = self.sha()
+        files = dict(self.trees[payload['expectedHeadOid']])
+        changes = payload['fileChanges']
+        for entry in changes['deletions']:
+            files.pop(entry['path'], None)
+        for entry in changes['additions']:
+            files[entry['path']] = base64.b64decode(entry['contents'])
+        if tamper:
+            files['managed/unexpected.bin'] = b'unexpected'
+        self.trees[sha] = files
+        self.parents[sha] = payload['expectedHeadOid']
+        self.signed.add(sha)
+        self.branches[branch_name] = sha
+        return sha
 
     def post(self, path, payload):
         if path != '/repos/Helvesec/rmux-packages/git/refs':
@@ -616,24 +635,42 @@ if transient_outcome.state != 'public-live' or transient.ref_updates != 1:
 ambiguous = FakeApi({'managed/old.bin': b'old'})
 ambiguous_base = ambiguous.head
 ambiguous.transient_graphql_at = 2
-ambiguous.transient_advances = True
+ambiguous.transient_advances = 'exact'
+ambiguous_outcome = publish(
+    ambiguous,
+    full_name='Helvesec/rmux-packages',
+    branch='main',
+    updates=large_updates,
+    message='recover exact committed response',
+    managed_prefixes=('managed',),
+    expected_base=ambiguous_base,
+)
+if ambiguous_outcome.state != 'public-live' or ambiguous.ref_updates != 1:
+    raise SystemExit('exact signed commit response loss was not recovered')
+if ambiguous.files != large_updates or set(ambiguous.branches) != {'main'}:
+    raise SystemExit('recovered signed commit tree differs or leaked staging')
+
+unexpected = FakeApi({'managed/old.bin': b'old'})
+unexpected_base = unexpected.head
+unexpected.transient_graphql_at = 2
+unexpected.transient_advances = 'unexpected'
 try:
     publish(
-        ambiguous,
+        unexpected,
         full_name='Helvesec/rmux-packages',
         branch='main',
         updates=large_updates,
-        message='reject ambiguous chunked bytes',
+        message='reject unexpected committed bytes',
         managed_prefixes=('managed',),
-        expected_base=ambiguous_base,
+        expected_base=unexpected_base,
     )
 except ValueError as error:
-    if 'outcome is ambiguous' not in str(error):
+    if 'unexpected repository bytes' not in str(error):
         raise
 else:
-    raise SystemExit('ambiguous signed commit result was retried')
-if ambiguous.head != ambiguous_base or set(ambiguous.branches) != {'main'}:
-    raise SystemExit('ambiguous staging mutation changed main or leaked staging')
+    raise SystemExit('unexpected signed commit result was accepted')
+if unexpected.head != unexpected_base or set(unexpected.branches) != {'main'}:
+    raise SystemExit('unexpected staging mutation changed main or leaked staging')
 
 broken = FakeApi({'managed/old.bin': b'old'})
 broken_base = broken.head


### PR DESCRIPTION
## Summary

- repackage crates.io payloads from the immutable release source SHA
- recover a lost GitHub signed-commit response only after exact parent, signature, tree, and byte verification
- add regression contracts for both publication failures

## Validation

- 115 targeted release tests
- full 106.7 MB APT/RPM publication drill on a temporary branch, cleaned after verification
- exact v0.10.0 crate dry-run hash match
- release contracts, Rustfmt, Ruff, and diff checks