### PR TITLE
fix(release): bind recovery result source

### DIFF
--- a/scripts/release/channel-result.py
+++ b/scripts/release/channel-result.py
@@ -105,6 +105,7 @@ def expected_envelope(args: argparse.Namespace) -> dict[str, Any]:
         channel=predicate["channel"],
         release_source_sha=predicate["source_git_sha"],
         producer=predicate["producer"],
+        recovery=request["receipt"].get("recovery"),
     )
     result_bundle = artifact_reference(
         read_object(args.bundle_artifact, "result bundle artifact"),

--- a/scripts/release/downstream_result.py
+++ b/scripts/release/downstream_result.py
@@ -95,16 +95,20 @@ def validate_producer(value: Any, channel: str) -> dict[str, Any]:
 
 
 def validate_result_artifact_source(
-    value: Any, *, channel: str, release_source_sha: str, producer: dict[str, Any]
+    value: Any,
+    *,
+    channel: str,
+    release_source_sha: str,
+    producer: dict[str, Any],
+    recovery: Any = None,
 ) -> str:
     source_sha = match(value, SHA40, "result artifact source SHA")
-    if source_sha != release_source_sha and (
-        producer.get("workflow_path") != RECEIPT_RECOVERY_PRODUCER
-        and (
-            channel != "apt_rpm"
-            or producer.get("workflow_path") != LINUX_RECOVERY_PRODUCER
-        )
-    ):
+    recovery_matches = (
+        isinstance(recovery, dict)
+        and recovery.get("control_sha") == source_sha
+        and recovery.get("control_ref") == "refs/heads/main"
+    )
+    if source_sha != release_source_sha and not recovery_matches:
         raise ValueError("result artifact source differs from its release")
     return source_sha
 

--- a/scripts/release/downstream_result_reference.py
+++ b/scripts/release/downstream_result_reference.py
@@ -214,6 +214,7 @@ def create_reference(
         channel=channel,
         release_source_sha=source_sha,
         producer=predicate["producer"],
+        recovery=request["receipt"].get("recovery"),
     )
     predicate_artifact = artifact_reference(
         read_object(predicate_artifact_path, "predicate artifact metadata"),

--- a/scripts/release/verify-channel-result-attestation.py
+++ b/scripts/release/verify-channel-result-attestation.py
@@ -18,7 +18,6 @@ from downstream_channels import (
 from downstream_result import (
     LINUX_RECOVERY_PRODUCER,
     LINUX_RECOVERY_SIGNER,
-    RECEIPT_RECOVERY_PRODUCER,
 )
 from downstream_result_document import validate_envelope, validate_predicate
 
@@ -74,23 +73,25 @@ def verify(args: argparse.Namespace) -> None:
         getattr(args, "producer_source_ref", None) or f"refs/tags/{args.release_ref}"
     )
     signer_path = getattr(args, "attestation_signer_workflow", None) or producer_path
+    recovery = request["receipt"].get("recovery")
+    recovery_source = (
+        isinstance(recovery, dict)
+        and recovery.get("control_sha") == producer_source_sha
+        and recovery.get("control_ref") == producer_source_ref
+        and producer_source_ref == "refs/heads/main"
+        and producer_source_sha != args.source_sha
+    )
     if SHA40.fullmatch(producer_source_sha) is None:
         raise ValueError("channel result producer source SHA is not canonical")
     if producer_path == LINUX_RECOVERY_PRODUCER:
         if (
             predicate["channel"] != "apt_rpm"
             or signer_path != LINUX_RECOVERY_SIGNER
-            or producer_source_ref != "refs/heads/main"
+            or not recovery_source
         ):
             raise ValueError("Linux recovery attestation producer identity changed")
-    elif (
-        producer_path == RECEIPT_RECOVERY_PRODUCER
-        and producer_source_ref == "refs/heads/main"
-    ):
-        if (
-            producer_source_sha == args.source_sha
-            or signer_path != RECEIPT_RECOVERY_PRODUCER
-        ):
+    elif producer_source_ref == "refs/heads/main":
+        if not recovery_source or signer_path != producer_path:
             raise ValueError("receipt recovery attestation producer identity changed")
     elif (
         producer_source_sha != args.source_sha

--- a/tests/release_downstream_adversarial_spec.rs
+++ b/tests/release_downstream_adversarial_spec.rs
@@ -390,3 +390,51 @@ for external_id, remote_id in (
 "#
     ));
 }
+
+#[test]
+fn recovery_result_artifacts_require_the_exact_receipt_control_sha() {
+    assert_fixture(&format!(
+        "{PRELUDE}\n{}",
+        r#"
+from downstream_result import validate_result_artifact_source
+
+control_sha = '9' * 40
+producer = {
+    'workflow_path': '.github/workflows/release-crates-channel.yml',
+}
+recovery = {
+    'failed_run_id': 2,
+    'failed_conclusion': 'startup_failure',
+    'control_sha': control_sha,
+    'control_ref': 'refs/heads/main',
+}
+if validate_result_artifact_source(
+    control_sha,
+    channel='crates_io',
+    release_source_sha=SOURCE,
+    producer=producer,
+    recovery=recovery,
+) != control_sha:
+    raise SystemExit('exact recovery control SHA was not preserved')
+
+for forged in (
+    None,
+    {**recovery, 'control_sha': '8' * 40},
+    {**recovery, 'control_ref': 'refs/tags/v1.2.3'},
+):
+    try:
+        validate_result_artifact_source(
+            control_sha,
+            channel='crates_io',
+            release_source_sha=SOURCE,
+            producer=producer,
+            recovery=forged,
+        )
+    except ValueError as error:
+        if 'artifact source differs' not in str(error):
+            raise
+    else:
+        raise SystemExit('forged recovery control identity was accepted')
+"#
+    ));
+}

--- a/tests/release_downstream_result_evidence_spec.rs
+++ b/tests/release_downstream_result_evidence_spec.rs
@@ -131,6 +131,12 @@ RECEIPT = {
         'bundle_sha256': '6' * 64,
     },
     'verified_at': '2026-07-20T00:00:00Z',
+    'recovery': {
+        'failed_run_id': 40,
+        'failed_conclusion': 'startup_failure',
+        'control_sha': '9' * 40,
+        'control_ref': 'refs/heads/main',
+    },
 }
 
 def write_fixture(root):
@@ -388,7 +394,7 @@ fn result_envelope_normalizes_exact_github_artifact_metadata() {
 with tempfile.TemporaryDirectory(dir=pathlib.Path.cwd()) as root:
     root = pathlib.Path(root)
     paths = write_fixture(root)
-    control_sha = 'f' * 40
+    control_sha = '9' * 40
     metadata = json.loads(paths['predicate_meta'].read_text(encoding='utf-8'))
     metadata['source_git_sha'] = control_sha
     write_object(paths['predicate_meta'], metadata)

--- a/tests/release_linux_repository_recovery_spec.rs
+++ b/tests/release_linux_repository_recovery_spec.rs
@@ -288,7 +288,11 @@ producer = {
 }
 validate_producer(producer, 'apt_rpm')
 validate_result_artifact_source(
-    main, channel='apt_rpm', release_source_sha=source, producer=producer
+    main,
+    channel='apt_rpm',
+    release_source_sha=source,
+    producer=producer,
+    recovery={'control_sha': main, 'control_ref': 'refs/heads/main'},
 )
 for channel in ('chocolatey', 'snap_candidate'):
     try:


### PR DESCRIPTION
## Summary

- bind main-sourced channel results to the exact receipt recovery control SHA and ref
- verify the reusable channel workflow as the actual attestation signer
- reject missing or forged recovery identities

## Verification

- replayed the failed crates.io result artifact and Sigstore bundle from run 30973272330
- passed 127 targeted release tests
- passed release contracts, Ruff, rustfmt, Python compilation, and diff checks