### PR TITLE
fix(release): accept progressive receipt recovery

### DIFF
--- a/scripts/release/receipt_recovery_topology.py
+++ b/scripts/release/receipt_recovery_topology.py
@@ -81,6 +81,26 @@ PACKAGE_WRITER_JOB_MAP = POST_MUTATION_JOB_MAP | {
     CRATES_PUBLISH_JOB_EXPANDED: CRATES_PUBLISH_JOB,
 }
 POST_MUTATION_RESULT_CHANNELS = ("homebrew_tap", "scoop", "web_share")
+PACKAGE_FAILURE_MODES = frozenset(
+    {
+        "package-writer-failure",
+        "package-execution-failure",
+        "package-result-seal-failure",
+        "crates-writer-failure",
+        "crates-execution-failure",
+        "crates-result-seal-failure",
+    }
+)
+APT_SUCCESS_FAILURE_MODES = frozenset(
+    {
+        "crates-writer-failure",
+        "crates-execution-failure",
+        "crates-result-seal-failure",
+    }
+)
+CRATES_RESULT_FAILURE_MODES = frozenset(
+    {"package-result-seal-failure", "crates-result-seal-failure"}
+)
 
 
 def result_envelope_names(source_sha: str, release_id: int) -> set[str]:
@@ -289,41 +309,67 @@ def verify_failed_downstream_jobs(value: dict[str, Any]) -> str:
             POST_MUTATION_SKIPPED_AFTER_FAILURE - {APT_PUBLISH_JOB, CRATES_PUBLISH_JOB},
         )
         apt_action = "Run ./.github/actions/release-linux-repository-publish"
+        apt = by_name[APT_PUBLISH_JOB]
+        apt_conclusion = apt.get("conclusion")
+        if apt_conclusion not in {"success", "failure"}:
+            raise ValueError("APT and RPM repository writer conclusion differs")
         exact_job_shape(
-            by_name[APT_PUBLISH_JOB],
+            apt,
             name=APT_PUBLISH_JOB,
-            conclusion="failure",
+            conclusion=apt_conclusion,
             steps=writer_prefix
-            | {apt_action: "failure", f"Post {apt_action}": "success"},
+            | {apt_action: apt_conclusion, f"Post {apt_action}": "success"},
         )
-        crates_steps = {
-            "Set up job": "success",
-            checkout: "success",
-            "Run ./.github/actions/release-channel-prepare": "success",
-            "Resolve exact crates.io execution authority": "success",
-            "Exchange GitHub OIDC for a short-lived crates.io token": (
-                "success" if preflight is not None else "failure"
+
+        crates = by_name[CRATES_PUBLISH_JOB]
+        if crates.get("conclusion") != "failure":
+            raise ValueError("crates.io package writer did not fail closed")
+        actual_crates_steps = job_steps(crates, CRATES_PUBLISH_JOB)
+        release_checkout = "Check out the exact release source"
+        post_release_checkout = f"Post {release_checkout}"
+
+        def crates_steps(
+            *, auth: str, writer: str, outcome: str, seal: str
+        ) -> tuple[dict[str, str], dict[str, str]]:
+            common = {
+                "Set up job": "success",
+                checkout: "success",
+                "Run ./.github/actions/release-channel-prepare": "success",
+                "Resolve exact crates.io execution authority": "success",
+                "Exchange GitHub OIDC for a short-lived crates.io token": auth,
+                "Publish and redownload every exact crate": writer,
+                "Normalize executable and policy-only outcomes": outcome,
+                "Seal exact crates.io result evidence": seal,
+                "Post Exchange GitHub OIDC for a short-lived crates.io token": "success",
+                post_checkout: "success",
+                "Complete job": "success",
+            }
+            with_release_checkout = common | {
+                release_checkout: "success",
+                post_release_checkout: "success",
+            }
+            return common, with_release_checkout
+
+        modes = {
+            "writer-failure": crates_steps(
+                auth="failure", writer="skipped", outcome="skipped", seal="skipped"
             ),
-            "Publish and redownload every exact crate": (
-                "failure" if preflight is not None else "skipped"
+            "execution-failure": crates_steps(
+                auth="success", writer="failure", outcome="skipped", seal="skipped"
             ),
-            "Normalize executable and policy-only outcomes": "skipped",
-            "Seal exact crates.io result evidence": "skipped",
-            "Post Exchange GitHub OIDC for a short-lived crates.io token": "success",
-            post_checkout: "success",
-            "Complete job": "success",
+            "result-seal-failure": crates_steps(
+                auth="success", writer="success", outcome="success", seal="failure"
+            ),
         }
-        exact_job_shape(
-            by_name[CRATES_PUBLISH_JOB],
-            name=CRATES_PUBLISH_JOB,
-            conclusion="failure",
-            steps=crates_steps,
-        )
-        return (
-            "package-execution-failure"
-            if preflight is not None
-            else "package-writer-failure"
-        )
+        matching_modes = [
+            mode
+            for mode, allowed_steps in modes.items()
+            if actual_crates_steps in allowed_steps
+        ]
+        if len(matching_modes) != 1:
+            raise ValueError("failed downstream job crates.io package writer differs")
+        prefix = "crates" if apt_conclusion == "success" else "package"
+        return f"{prefix}-{matching_modes[0]}"
     verify_skipped_jobs(by_name, SKIPPED_AFTER_FAILURE)
     if linux.get("conclusion") != "failure":
         raise ValueError("Linux repository signing did not fail closed")
@@ -401,13 +447,22 @@ def verify_failed_downstream_artifacts(
                 expected_names
                 | result_envelope_names(args.source_sha, args.release_id),
             )
-        elif failure_mode in {"package-writer-failure", "package-execution-failure"}:
+        elif failure_mode in PACKAGE_FAILURE_MODES:
             expected_names.update(
                 result_envelope_names(args.source_sha, args.release_id)
             )
             expected_names.update(
                 result_reference_names(args.source_sha, args.release_id)
             )
+            if failure_mode in APT_SUCCESS_FAILURE_MODES:
+                for suffix in ("result", "result-envelope", "result-reference"):
+                    expected_names.add(
+                        f"rmux-downstream-apt_rpm-{suffix}-{args.source_sha}-{args.release_id}"
+                    )
+            if failure_mode in CRATES_RESULT_FAILURE_MODES:
+                expected_names.add(
+                    f"rmux-downstream-crates_io-result-{args.source_sha}-{args.release_id}"
+                )
             allowed_names = (expected_names,)
         else:
             raise ValueError("failed downstream recovery mode differs")

--- a/tests/release_receipt_recovery_spec.rs
+++ b/tests/release_receipt_recovery_spec.rs
@@ -439,6 +439,53 @@ fn package_execution_failure_jobs() -> Value {
     value
 }
 
+fn crates_result_seal_failure_jobs() -> Value {
+    let mut value = package_execution_failure_jobs();
+    let jobs = value["jobs"].as_array_mut().expect("jobs array");
+    for job in jobs.iter_mut() {
+        let name = job["name"].as_str().expect("job name");
+        if name == "Publish exact signed APT and RPM repositories" {
+            job["conclusion"] = json!("success");
+            for step in job["steps"].as_array_mut().expect("APT steps") {
+                if step["name"] == "Run ./.github/actions/release-linux-repository-publish" {
+                    step["conclusion"] = json!("success");
+                }
+            }
+            continue;
+        }
+        if name == "Publish exact crates.io package set / Publish exact crates.io package set" {
+            job["steps"] = json!([
+                step("Set up job", "success"),
+                step(
+                    "Run actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5",
+                    "success",
+                ),
+                step("Run ./.github/actions/release-channel-prepare", "success"),
+                step("Resolve exact crates.io execution authority", "success"),
+                step("Check out the exact release source", "success"),
+                step(
+                    "Exchange GitHub OIDC for a short-lived crates.io token",
+                    "success",
+                ),
+                step("Publish and redownload every exact crate", "success"),
+                step("Normalize executable and policy-only outcomes", "success"),
+                step("Seal exact crates.io result evidence", "failure"),
+                step(
+                    "Post Exchange GitHub OIDC for a short-lived crates.io token",
+                    "success",
+                ),
+                step("Post Check out the exact release source", "success"),
+                step(
+                    "Post Run actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5",
+                    "success",
+                ),
+                step("Complete job", "success"),
+            ]);
+        }
+    }
+    value
+}
+
 fn downstream_failure_artifacts() -> (Value, u64) {
     downstream_failure_artifacts_for(FAILED_RUN, FAILED_CONTROL, 81)
 }
@@ -469,6 +516,33 @@ fn package_writer_failure_artifacts() -> (Value, u64) {
     }
     let total_count = artifacts.len();
     value["total_count"] = json!(total_count);
+    (value, receipt_id)
+}
+
+fn crates_result_seal_failure_artifacts() -> (Value, u64) {
+    let (mut value, receipt_id) = package_writer_failure_artifacts();
+    let artifacts = value["artifacts"].as_array_mut().expect("artifacts array");
+    for name in [
+        format!("rmux-downstream-apt_rpm-result-{SOURCE}-{RELEASE_ID}"),
+        format!("rmux-downstream-apt_rpm-result-envelope-{SOURCE}-{RELEASE_ID}"),
+        format!("rmux-downstream-apt_rpm-result-reference-{SOURCE}-{RELEASE_ID}"),
+        format!("rmux-downstream-crates_io-result-{SOURCE}-{RELEASE_ID}"),
+    ] {
+        artifacts.push(json!({
+            "id": receipt_id + artifacts.len() as u64,
+            "name": name,
+            "expired": false,
+            "digest": format!("sha256:{}", "a".repeat(64)),
+            "workflow_run": {
+                "id": FAILED_RUN,
+                "head_sha": FAILED_CONTROL,
+                "head_branch": "main",
+                "repository_id": 1_239_918_790,
+                "head_repository_id": 1_239_918_790,
+            },
+        }));
+    }
+    value["total_count"] = json!(artifacts.len());
     (value, receipt_id)
 }
 
@@ -739,6 +813,64 @@ fn protected_main_recovery_accepts_exact_package_execution_failures() {
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
+}
+
+#[test]
+fn protected_main_recovery_accepts_exact_progressive_result_seal_failure() {
+    let root = fixture_root("progressive-result-seal-failure");
+    let (artifacts, receipt_id) = crates_result_seal_failure_artifacts();
+    let output = run_recovery(
+        &root,
+        failed_run(FAILED_CONTROL, "main", "failure"),
+        crates_result_seal_failure_jobs(),
+        artifacts,
+        json!({
+            "total_count": 1,
+            "artifacts": [{
+                "id": receipt_id,
+                "name": format!("rmux-publication-receipt-{SOURCE}-{RELEASE_ID}"),
+                "expired": false,
+                "workflow_run": {"id": FAILED_RUN},
+            }],
+        }),
+    );
+    fs::remove_dir_all(&root).expect("remove fixture root");
+    assert!(
+        output.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn protected_main_recovery_rejects_partial_progressive_result_evidence() {
+    let root = fixture_root("progressive-result-evidence");
+    let (mut artifacts, receipt_id) = crates_result_seal_failure_artifacts();
+    let entries = artifacts["artifacts"]
+        .as_array_mut()
+        .expect("artifacts array");
+    entries.retain(|artifact| {
+        artifact["name"] != format!("rmux-downstream-crates_io-result-{SOURCE}-{RELEASE_ID}")
+    });
+    artifacts["total_count"] = json!(entries.len());
+    let output = run_recovery(
+        &root,
+        failed_run(FAILED_CONTROL, "main", "failure"),
+        crates_result_seal_failure_jobs(),
+        artifacts,
+        json!({
+            "total_count": 1,
+            "artifacts": [{
+                "id": receipt_id,
+                "name": format!("rmux-publication-receipt-{SOURCE}-{RELEASE_ID}"),
+                "expired": false,
+                "workflow_run": {"id": FAILED_RUN},
+            }],
+        }),
+    );
+    fs::remove_dir_all(&root).expect("remove fixture root");
+    assert!(!output.status.success());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- distinguish exact APT/RPM and crates.io failure stages during protected-main recovery
- accept a later recovery failure only with its exact successful and partial result artifacts
- preserve strict validation of every earlier receipt in the chain

## Verification

- replayed live runs 30970035820 and 30973272330 through the recovery verifier
- verified the complete live receipt chain
- passed 129 targeted release tests, contracts, Ruff, rustfmt, Python compilation, and diff checks