### PR TITLE
test(windows): stabilize teardown observations

### DIFF
--- a/crates/rmux-sdk/tests/smoke_v1_windows.rs
+++ b/crates/rmux-sdk/tests/smoke_v1_windows.rs
@@ -6,7 +6,8 @@ mod windows {
     use super::common;
 
     use std::fs;
-    use std::path::PathBuf;
+    use std::io;
+    use std::path::{Path, PathBuf};
     use std::time::Duration;
     use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -132,7 +133,7 @@ mod windows {
         );
 
         harness.finish().await?;
-        fs::remove_dir_all(&root)?;
+        remove_dir_all_after_release(&root).await?;
         cleanup.disarm();
         Ok(())
     }
@@ -442,6 +443,20 @@ mod windows {
             "rmux-sdk-windows-config-{}-{nonce}",
             std::process::id()
         )))
+    }
+
+    async fn remove_dir_all_after_release(path: &Path) -> TestResult {
+        let deadline = Instant::now() + DEFAULT_TIMEOUT;
+        loop {
+            match fs::remove_dir_all(path) {
+                Ok(()) => return Ok(()),
+                Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+                Err(error) if error.raw_os_error() == Some(32) && Instant::now() < deadline => {
+                    sleep(Duration::from_millis(25)).await;
+                }
+                Err(error) => return Err(error.into()),
+            }
+        }
     }
 
     struct TempRoot {

--- a/crates/rmux-server/src/handler_pane_stream_tests.rs
+++ b/crates/rmux-server/src/handler_pane_stream_tests.rs
@@ -1553,14 +1553,36 @@ async fn natural_pane_exit_drains_raw_and_surface_streams_before_end() {
         .await;
 
     let raw_events = cursor_until_unlimited(&handler, raw.subscription_id, 1).await;
-    assert!(matches!(
-        raw_events.as_slice(),
-        [
-            PaneStreamEvent::RawBytes(bytes),
-            PaneStreamEvent::Lifecycle(PaneStreamLifecycleEvent::ProcessExited { .. }),
-            PaneStreamEvent::End(PaneStreamEndReason::PaneRemoved),
-        ] if bytes.bytes == b"natural-tail"
-    ));
+    assert_unique_pane_removed_end(&raw_events, "natural Raw exit drain");
+    assert!(
+        raw_events[..raw_events.len() - 1].iter().all(|event| {
+            matches!(
+                event,
+                PaneStreamEvent::RawBytes(_)
+                    | PaneStreamEvent::Lifecycle(PaneStreamLifecycleEvent::ProcessExited { .. })
+            )
+        }),
+        "natural Raw exit drain emitted an unexpected pre-terminal event: {raw_events:?}"
+    );
+    assert_eq!(
+        raw_events
+            .iter()
+            .filter(|event| matches!(event, PaneStreamEvent::RawBytes(bytes) if bytes.bytes == b"natural-tail"))
+            .count(),
+        1,
+        "natural Raw exit drain must deliver the staged tail exactly once: {raw_events:?}"
+    );
+    assert_eq!(
+        raw_events
+            .iter()
+            .filter(|event| matches!(
+                event,
+                PaneStreamEvent::Lifecycle(PaneStreamLifecycleEvent::ProcessExited { .. })
+            ))
+            .count(),
+        1,
+        "natural Raw exit must publish one lifecycle event: {raw_events:?}"
+    );
 
     let surface_events = cursor_until_unlimited(&handler, surface.subscription_id, 1).await;
     assert_unique_pane_removed_end(&surface_events, "natural Surface exit drain");

--- a/crates/rmux-server/src/status_jobs/windows_tests.rs
+++ b/crates/rmux-server/src/status_jobs/windows_tests.rs
@@ -114,6 +114,10 @@ impl WindowsStatusJobProbe {
 
     fn assert_process_dead(&self, stage: &str) {
         let pid = self.wait_for_pid();
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while rmux_os::process::is_live(pid) && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(20));
+        }
         assert!(
             !rmux_os::process::is_live(pid),
             "Windows status descendant {pid} survived {stage}"

--- a/tests/windows_descendant_liveness.rs
+++ b/tests/windows_descendant_liveness.rs
@@ -16,6 +16,8 @@ const PROCESS_QUERY_LIMITED_INFORMATION: u32 = 0x1000;
 const SYNCHRONIZE: u32 = 0x0010_0000;
 const WAIT_TIMEOUT: u32 = 258;
 const CASE_TIMEOUT: Duration = Duration::from_secs(10);
+const DESCENDANT_START_TIMEOUT_SECONDS: u64 = 20;
+const DESCENDANT_READY_TIMEOUT: Duration = Duration::from_secs(30);
 const HOSTED_DAEMON_OPT_IN: (&str, &str) = ("RMUX_ALLOW_INTERNAL_DAEMON_IN_CALLER_JOB", "1");
 
 type RawHandle = *mut c_void;
@@ -276,6 +278,7 @@ fn spawn_durable(
     let pid = pid_path.to_string_lossy().into_owned();
     let ready = ready_path.to_string_lossy().into_owned();
     let input = input_path.to_string_lossy().into_owned();
+    let start_timeout = DESCENDANT_START_TIMEOUT_SECONDS.to_string();
 
     run_rmux(
         binary,
@@ -297,11 +300,12 @@ fn spawn_durable(
             &pid,
             &ready,
             &input,
+            &start_timeout,
         ],
     )?;
 
-    wait_for_path(&ready_path, CASE_TIMEOUT)?;
-    let descendant_pid = wait_for_pid_file(&pid_path, CASE_TIMEOUT)?;
+    wait_for_path(&ready_path, DESCENDANT_READY_TIMEOUT)?;
+    let descendant_pid = wait_for_pid_file(&pid_path, DESCENDANT_READY_TIMEOUT)?;
     let target = format!("{session}:0.0");
     let leader_pid = display_u32(binary, label, Some(&target), "#{pane_pid}")?;
     wait_for_process_exit(leader_pid, CASE_TIMEOUT)?;
@@ -337,13 +341,14 @@ impl DurableHelpers {
     [Parameter(Mandatory = $true)][string]$DescendantScript,
     [Parameter(Mandatory = $true)][string]$PidFile,
     [Parameter(Mandatory = $true)][string]$ReadyFile,
-    [Parameter(Mandatory = $true)][string]$InputFile
+    [Parameter(Mandatory = $true)][string]$InputFile,
+    [Parameter(Mandatory = $true)][int]$StartTimeoutSeconds
 )
 $ErrorActionPreference = 'Stop'
 $arguments = "-NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File `"$DescendantScript`" `"$ReadyFile`" `"$InputFile`""
 $child = Start-Process -FilePath "$PSHOME\powershell.exe" -ArgumentList $arguments -NoNewWindow -PassThru
 [System.IO.File]::WriteAllText($PidFile, "$($child.Id)`n")
-$deadline = [DateTime]::UtcNow.AddSeconds(5)
+$deadline = [DateTime]::UtcNow.AddSeconds($StartTimeoutSeconds)
 while (-not (Test-Path -LiteralPath $ReadyFile) -and [DateTime]::UtcNow -lt $deadline) {
     Start-Sleep -Milliseconds 10
 }


### PR DESCRIPTION
The exact main CI run 30976450324 exposed two independent Windows-only timing assumptions. The first PR run 30977513659 then exposed an existing helper startup budget that was too short under 18-shard load.

- Poll briefly for Job Object descendant death after the runtime has already joined.
- Assert pane-stream teardown invariants without requiring an exact Windows event vector.
- Separate PowerShell fixture startup budgets from the stricter RMUX behavior deadlines.

The change is test-only. Local validation includes 12 repeated pane-stream runs, Windows GNU test builds and Clippy, 48 release automation tests, rustfmt, and diff-check. Native Windows CI remains the merge gate.