### PR TITLE
release: make Linux repository recovery idempotent

### DIFF
--- a/.github/actions/release-linux-repository-build/action.yml
+++ b/.github/actions/release-linux-repository-build/action.yml
@@ -135,23 +135,34 @@ runs:
           --apt-signing-key "$RMUX_APT_GPG_KEY" \
           --rpm-signing-key "$RMUX_RPM_GPG_KEY" --current-version "$version" \
           --apt-architecture amd64 --apt-architecture arm64 \
-          --rpm-architecture x86_64 --rpm-architecture aarch64
-        scripts/generate-apt-repository.sh \
-          --input-dir "$root/packages" --output-dir "$root/output/debian" \
-          --previous-repository-dir "$root/history/debian" \
-          --suite stable --component main --architecture amd64 --architecture arm64 \
-          --signing-key "$RMUX_APT_GPG_KEY"
-        scripts/generate-rpm-repository.sh \
-          --input-dir "$root/packages" --output-dir "$root/output/rpm" \
-          --previous-repository-dir "$root/history/rpm" \
-          --baseurl https://packages.rmux.io/rpm \
-          --gpg-key-url https://packages.rmux.io/rpm/RPM-GPG-KEY-rmux \
-          --repo-gpg-key-url https://packages.rmux.io/rpm/RPM-GPG-KEY-rmux-repository \
-          --rpm-signing-key "$RMUX_RPM_GPG_KEY" --rpm-signing-version "$version" \
-          --repo-signing-key "$RMUX_RPM_REPO_GPG_KEY"
-        gpg --armor --export "$RMUX_APT_GPG_KEY" > "$root/output/debian/rmux.asc"
-        gpg --armor --export "$RMUX_RPM_GPG_KEY" > "$root/output/rpm/RPM-GPG-KEY-rmux"
-        gpg --armor --export "$RMUX_RPM_REPO_GPG_KEY" > "$root/output/rpm/RPM-GPG-KEY-rmux-repository"
+          --rpm-architecture x86_64 --rpm-architecture aarch64 \
+          --allow-current-version-exact | tee "$root/HISTORY_STATUS"
+        if grep -qx 'current_version_already_published=true' "$root/HISTORY_STATUS"; then
+          for path in debian rpm index.html _headers; do
+            test -e "$root/history/$path" && test ! -L "$root/history/$path"
+          done
+          test -z "$(find "$root/history/debian" "$root/history/rpm" -type l -print -quit)"
+          cp -a "$root/history/debian" "$root/history/rpm" "$root/output/"
+          cp "$root/history/index.html" "$root/history/_headers" "$root/output/"
+          touch "$root/CURRENT_VERSION_ALREADY_PUBLISHED"
+        else
+          scripts/generate-apt-repository.sh \
+            --input-dir "$root/packages" --output-dir "$root/output/debian" \
+            --previous-repository-dir "$root/history/debian" \
+            --suite stable --component main --architecture amd64 --architecture arm64 \
+            --signing-key "$RMUX_APT_GPG_KEY"
+          scripts/generate-rpm-repository.sh \
+            --input-dir "$root/packages" --output-dir "$root/output/rpm" \
+            --previous-repository-dir "$root/history/rpm" \
+            --baseurl https://packages.rmux.io/rpm \
+            --gpg-key-url https://packages.rmux.io/rpm/RPM-GPG-KEY-rmux \
+            --repo-gpg-key-url https://packages.rmux.io/rpm/RPM-GPG-KEY-rmux-repository \
+            --rpm-signing-key "$RMUX_RPM_GPG_KEY" --rpm-signing-version "$version" \
+            --repo-signing-key "$RMUX_RPM_REPO_GPG_KEY"
+          gpg --armor --export "$RMUX_APT_GPG_KEY" > "$root/output/debian/rmux.asc"
+          gpg --armor --export "$RMUX_RPM_GPG_KEY" > "$root/output/rpm/RPM-GPG-KEY-rmux"
+          gpg --armor --export "$RMUX_RPM_REPO_GPG_KEY" > "$root/output/rpm/RPM-GPG-KEY-rmux-repository"
+        fi
         cp "$root/PACKAGE_REPOSITORY_BASE" "$root/output/PACKAGE_REPOSITORY_BASE"
 
     - name: Add static package host files and exact checksum inventory
@@ -159,8 +170,10 @@ runs:
       run: |
         set -euo pipefail
         root="$RUNNER_TEMP/rmux-linux-repository/output"
-        cp scripts/release/package-repository-index.html "$root/index.html"
-        cp scripts/release/package-repository-headers "$root/_headers"
+        if ! test -f "$RUNNER_TEMP/rmux-linux-repository/CURRENT_VERSION_ALREADY_PUBLISHED"; then
+          cp scripts/release/package-repository-index.html "$root/index.html"
+          cp scripts/release/package-repository-headers "$root/_headers"
+        fi
         (
           cd "$root"
           find debian rpm -type f -print0 | LC_ALL=C sort -z | \

--- a/.github/workflows/release-linux-repository-build.yml
+++ b/.github/workflows/release-linux-repository-build.yml
@@ -185,23 +185,34 @@ jobs:
             --apt-signing-key "$RMUX_APT_GPG_KEY" \
             --rpm-signing-key "$RMUX_RPM_GPG_KEY" --current-version "$version" \
             --apt-architecture amd64 --apt-architecture arm64 \
-            --rpm-architecture x86_64 --rpm-architecture aarch64
-          "$apt_generator" \
-            --input-dir "$root/packages" --output-dir "$root/output/debian" \
-            --previous-repository-dir "$root/history/debian" \
-            --suite stable --component main --architecture amd64 --architecture arm64 \
-            --signing-key "$RMUX_APT_GPG_KEY"
-          scripts/generate-rpm-repository.sh \
-            --input-dir "$root/packages" --output-dir "$root/output/rpm" \
-            --previous-repository-dir "$root/history/rpm" \
-            --baseurl https://packages.rmux.io/rpm \
-            --gpg-key-url https://packages.rmux.io/rpm/RPM-GPG-KEY-rmux \
-            --repo-gpg-key-url https://packages.rmux.io/rpm/RPM-GPG-KEY-rmux-repository \
-            --rpm-signing-key "$RMUX_RPM_GPG_KEY" --rpm-signing-version "$version" \
-            --repo-signing-key "$RMUX_RPM_REPO_GPG_KEY"
-          gpg --armor --export "$RMUX_APT_GPG_KEY" > "$root/output/debian/rmux.asc"
-          gpg --armor --export "$RMUX_RPM_GPG_KEY" > "$root/output/rpm/RPM-GPG-KEY-rmux"
-          gpg --armor --export "$RMUX_RPM_REPO_GPG_KEY" > "$root/output/rpm/RPM-GPG-KEY-rmux-repository"
+            --rpm-architecture x86_64 --rpm-architecture aarch64 \
+            --allow-current-version-exact | tee "$root/HISTORY_STATUS"
+          if grep -qx 'current_version_already_published=true' "$root/HISTORY_STATUS"; then
+            for path in debian rpm index.html _headers; do
+              test -e "$root/history/$path" && test ! -L "$root/history/$path"
+            done
+            test -z "$(find "$root/history/debian" "$root/history/rpm" -type l -print -quit)"
+            cp -a "$root/history/debian" "$root/history/rpm" "$root/output/"
+            cp "$root/history/index.html" "$root/history/_headers" "$root/output/"
+            touch "$root/CURRENT_VERSION_ALREADY_PUBLISHED"
+          else
+            "$apt_generator" \
+              --input-dir "$root/packages" --output-dir "$root/output/debian" \
+              --previous-repository-dir "$root/history/debian" \
+              --suite stable --component main --architecture amd64 --architecture arm64 \
+              --signing-key "$RMUX_APT_GPG_KEY"
+            scripts/generate-rpm-repository.sh \
+              --input-dir "$root/packages" --output-dir "$root/output/rpm" \
+              --previous-repository-dir "$root/history/rpm" \
+              --baseurl https://packages.rmux.io/rpm \
+              --gpg-key-url https://packages.rmux.io/rpm/RPM-GPG-KEY-rmux \
+              --repo-gpg-key-url https://packages.rmux.io/rpm/RPM-GPG-KEY-rmux-repository \
+              --rpm-signing-key "$RMUX_RPM_GPG_KEY" --rpm-signing-version "$version" \
+              --repo-signing-key "$RMUX_RPM_REPO_GPG_KEY"
+            gpg --armor --export "$RMUX_APT_GPG_KEY" > "$root/output/debian/rmux.asc"
+            gpg --armor --export "$RMUX_RPM_GPG_KEY" > "$root/output/rpm/RPM-GPG-KEY-rmux"
+            gpg --armor --export "$RMUX_RPM_REPO_GPG_KEY" > "$root/output/rpm/RPM-GPG-KEY-rmux-repository"
+          fi
           cp "$root/PACKAGE_REPOSITORY_BASE" "$root/output/PACKAGE_REPOSITORY_BASE"
 
       - name: Add static package host files and exact checksum inventory
@@ -209,8 +220,10 @@ jobs:
         run: |
           set -euo pipefail
           root="$RUNNER_TEMP/rmux-linux-repository/output"
-          cp scripts/release/package-repository-index.html "$root/index.html"
-          cp scripts/release/package-repository-headers "$root/_headers"
+          if ! test -f "$RUNNER_TEMP/rmux-linux-repository/CURRENT_VERSION_ALREADY_PUBLISHED"; then
+            cp scripts/release/package-repository-index.html "$root/index.html"
+            cp scripts/release/package-repository-headers "$root/_headers"
+          fi
           (
             cd "$root"
             find debian rpm -type f -print0 | LC_ALL=C sort -z | \

--- a/scripts/release/receipt_recovery_topology.py
+++ b/scripts/release/receipt_recovery_topology.py
@@ -101,6 +101,7 @@ APT_SUCCESS_FAILURE_MODES = frozenset(
 CRATES_RESULT_FAILURE_MODES = frozenset(
     {"package-result-seal-failure", "crates-result-seal-failure"}
 )
+LINUX_REBUILD_FAILURE_MODE = "linux-repository-rebuild-failure"
 
 
 def result_envelope_names(source_sha: str, release_id: int) -> set[str]:
@@ -172,6 +173,7 @@ def canonical_failed_jobs(
         | (POST_MUTATION_SKIPPED_AFTER_FAILURE - {CRATES_PUBLISH_JOB})
     )
     package_execution_names = package_writer_names | {CRATES_PREFLIGHT_JOB}
+    linux_rebuild_failure_names = post_mutation_names | {CRATES_PREFLIGHT_JOB}
     raw_names = set(jobs)
     if raw_names == legacy_names:
         return (
@@ -204,6 +206,17 @@ def canonical_failed_jobs(
         return (
             {
                 PACKAGE_WRITER_JOB_MAP.get(
+                    name.removeprefix(PREPARATION_PREFIX),
+                    name.removeprefix(PREPARATION_PREFIX),
+                ): job
+                for name, job in jobs.items()
+            },
+            True,
+        )
+    if raw_names == linux_rebuild_failure_names:
+        return (
+            {
+                POST_MUTATION_JOB_MAP.get(
                     name.removeprefix(PREPARATION_PREFIX),
                     name.removeprefix(PREPARATION_PREFIX),
                 ): job
@@ -249,14 +262,17 @@ def verify_failed_downstream_jobs(value: dict[str, Any]) -> str:
     if post_mutation:
         checkout = "Run actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5"
         post_checkout = f"Post {checkout}"
+        linux_conclusion = linux.get("conclusion")
+        if linux_conclusion not in {"success", "failure"}:
+            raise ValueError("Linux repository builder conclusion differs")
         exact_job_shape(
             linux,
             name=LINUX_SIGNING_JOB,
-            conclusion="success",
+            conclusion=linux_conclusion,
             steps={
                 "Set up job": "success",
                 checkout: "success",
-                "Run ./.github/actions/release-linux-repository-build": "success",
+                "Run ./.github/actions/release-linux-repository-build": linux_conclusion,
                 post_checkout: "success",
                 "Complete job": "success",
             },
@@ -272,6 +288,10 @@ def verify_failed_downstream_jobs(value: dict[str, Any]) -> str:
             by_name[name].get("conclusion") for name in OWNED_WRITER_JOBS
         }
         if owned_conclusions == {"failure"}:
+            if linux_conclusion != "success":
+                raise ValueError(
+                    "Linux builder and owned repository writers failed together"
+                )
             verify_skipped_jobs(by_name, POST_MUTATION_SKIPPED_AFTER_FAILURE)
             for name in OWNED_WRITER_JOBS:
                 exact_job_shape(
@@ -304,6 +324,11 @@ def verify_failed_downstream_jobs(value: dict[str, Any]) -> str:
                     "Complete job": "success",
                 },
             )
+        if linux_conclusion == "failure":
+            if preflight is None:
+                raise ValueError("Linux repository recovery lost crates.io preflight")
+            verify_skipped_jobs(by_name, POST_MUTATION_SKIPPED_AFTER_FAILURE)
+            return LINUX_REBUILD_FAILURE_MODE
         verify_skipped_jobs(
             by_name,
             POST_MUTATION_SKIPPED_AFTER_FAILURE - {APT_PUBLISH_JOB, CRATES_PUBLISH_JOB},
@@ -433,7 +458,15 @@ def verify_failed_downstream_artifacts(
         ),
     }
     allowed_names = (expected_names,)
-    if failure_mode != "pre-mutation-failure":
+    if failure_mode == LINUX_REBUILD_FAILURE_MODE:
+        expected_names.update(
+            f"rmux-downstream-{channel}-result-{args.source_sha}-{args.release_id}"
+            for channel in POST_MUTATION_RESULT_CHANNELS
+        )
+        expected_names.update(result_envelope_names(args.source_sha, args.release_id))
+        expected_names.update(result_reference_names(args.source_sha, args.release_id))
+        allowed_names = (expected_names,)
+    elif failure_mode != "pre-mutation-failure":
         expected_names.add(
             f"rmux-downstream-apt_rpm-signed-{args.source_sha}-{args.release_id}"
         )

--- a/scripts/retain-linux-package-history.py
+++ b/scripts/retain-linux-package-history.py
@@ -27,7 +27,9 @@ class StableVersion:
 
     @classmethod
     def parse(cls, value: str) -> StableVersion | None:
-        match = re.fullmatch(r"(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)", value)
+        match = re.fullmatch(
+            r"(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)", value
+        )
         if match is None:
             return None
         return cls(*(int(part) for part in match.groups()))
@@ -272,7 +274,9 @@ def authenticated_apt_packages(
                 package.stat().st_size != expected_package_size
                 or sha256(package) != expected_package_hash
             ):
-                raise HistoryError(f"APT package failed its signed index checksum: {filename}")
+                raise HistoryError(
+                    f"APT package failed its signed index checksum: {filename}"
+                )
             authenticated.append(AuthenticatedPackage(version, architecture, package))
     if package_records == 0:
         raise HistoryError("published APT repository contains no RMUX packages")
@@ -332,6 +336,38 @@ def authenticated_rpm_packages(
     return authenticated
 
 
+def rpm_content_identity(path: Path) -> tuple[str, ...]:
+    rpm = shutil.which("rpm")
+    if rpm is None:
+        raise HistoryError("rpm is required to compare RPM package content")
+    fields = run_checked(
+        [
+            rpm,
+            "-qp",
+            "--qf",
+            "%{NAME}\n%{VERSION}\n%{RELEASE}\n%{ARCH}\n"
+            "%{SHA256HEADER}\n%{PAYLOADDIGEST}\n",
+            str(path),
+        ],
+        capture_stdout=True,
+    ).splitlines()
+    if (
+        len(fields) != 6
+        or fields[0] != "rmux"
+        or any(not field or field == "(none)" for field in fields[1:])
+    ):
+        raise HistoryError(f"RPM content identity is incomplete: {path.name}")
+    return tuple(fields)
+
+
+def package_contents_match(published: Path, incoming: Path, manager: str) -> bool:
+    if manager == "RPM":
+        return rpm_content_identity(incoming) == rpm_content_identity(published)
+    return incoming.stat().st_size == published.stat().st_size and sha256(
+        incoming
+    ) == sha256(published)
+
+
 def latest_predecessor(
     packages: list[AuthenticatedPackage], current: StableVersion, manager: str
 ) -> StableVersion | None:
@@ -347,6 +383,66 @@ def latest_predecessor(
         )
     predecessors = [version for version in versions if version < current]
     return max(predecessors, default=None)
+
+
+def current_release_is_exact(
+    packages: list[AuthenticatedPackage],
+    current: StableVersion,
+    required_architectures: set[str],
+    manager: str,
+    staging: Path,
+    extension: str,
+) -> bool:
+    newer = sorted(
+        {package.version for package in packages if package.version > current}
+    )
+    if newer:
+        raise HistoryError(
+            f"refusing to replace newer {manager} release {newer[-1]} with {current}"
+        )
+    current_packages = [package for package in packages if package.version == current]
+    if not current_packages:
+        return False
+
+    by_architecture: dict[str, AuthenticatedPackage] = {}
+    for package in current_packages:
+        if package.architecture in by_architecture:
+            raise HistoryError(
+                f"published {manager} release {current} contains duplicate "
+                f"architecture {package.architecture}"
+            )
+        by_architecture[package.architecture] = package
+
+    missing = sorted(required_architectures - set(by_architecture))
+    if missing:
+        raise HistoryError(
+            f"published {manager} current release {current} lacks architecture(s): "
+            + ", ".join(missing)
+        )
+
+    expected_names: set[str] = set()
+    for architecture in sorted(required_architectures):
+        published = by_architecture[architecture].path
+        incoming = staging / published.name
+        if not incoming.is_file() or not package_contents_match(
+            published, incoming, manager
+        ):
+            raise HistoryError(
+                f"incoming {manager} package differs from published current release: "
+                f"{published.name}"
+            )
+        expected_names.add(published.name)
+
+    incoming_names = {
+        path.name
+        for path in staging.iterdir()
+        if path.is_file() and path.name.endswith(extension)
+    }
+    if incoming_names != expected_names:
+        raise HistoryError(
+            f"incoming {manager} package set differs from published current release"
+        )
+    return True
 
 
 def retain_predecessor(
@@ -371,7 +467,10 @@ def retain_predecessor(
     for package in packages:
         if package.version != predecessor:
             continue
-        if required_architectures and package.architecture not in required_architectures:
+        if (
+            required_architectures
+            and package.architecture not in required_architectures
+        ):
             continue
         if copy_without_replacing(package.path, staging):
             retained += 1
@@ -391,6 +490,7 @@ def main() -> int:
     )
     parser.add_argument("--apt-architecture", action="append", default=[])
     parser.add_argument("--rpm-architecture", action="append", default=[])
+    parser.add_argument("--allow-current-version-exact", action="store_true")
     parser.add_argument("--suite", default="stable")
     args = parser.parse_args()
 
@@ -402,10 +502,44 @@ def main() -> int:
         raise HistoryError(f"staging directory not found: {staging}")
     current = StableVersion.parse(args.current_version)
     if current is None:
-        raise HistoryError("--current-version must be stable MAJOR.MINOR.PATCH (not an RC)")
+        raise HistoryError(
+            "--current-version must be stable MAJOR.MINOR.PATCH (not an RC)"
+        )
 
-    apt_packages = authenticated_apt_packages(repository, args.suite, args.apt_signing_key)
+    apt_packages = authenticated_apt_packages(
+        repository, args.suite, args.apt_signing_key
+    )
     rpm_packages = authenticated_rpm_packages(repository, args.rpm_signing_key)
+    if args.allow_current_version_exact:
+        apt_current = current_release_is_exact(
+            apt_packages,
+            current,
+            set(args.apt_architecture),
+            "APT",
+            staging,
+            ".deb",
+        )
+        rpm_current = current_release_is_exact(
+            rpm_packages,
+            current,
+            set(args.rpm_architecture),
+            "RPM",
+            staging,
+            ".rpm",
+        )
+        if apt_current != rpm_current:
+            raise HistoryError(
+                "APT and RPM repositories disagree on whether the current release "
+                "is already published"
+            )
+        if apt_current:
+            print(f"current_version={current}")
+            print("current_version_already_published=true")
+            print("retained_predecessor=None")
+            print("retained_apt_packages=0")
+            print("retained_rpm_packages=0")
+            return 0
+
     apt_predecessor = latest_predecessor(apt_packages, current, "APT")
     rpm_predecessor = latest_predecessor(rpm_packages, current, "RPM")
     if apt_predecessor != rpm_predecessor:
@@ -430,6 +564,7 @@ def main() -> int:
     if apt_predecessor is not None and (apt_count == 0 or rpm_count == 0):
         raise HistoryError("stable predecessor has no retainable APT or RPM packages")
     print(f"current_version={current}")
+    print("current_version_already_published=false")
     print(f"retained_predecessor={apt_predecessor}")
     print(f"retained_apt_packages={apt_count}")
     print(f"retained_rpm_packages={rpm_count}")

--- a/tests/release_automation_spec.rs
+++ b/tests/release_automation_spec.rs
@@ -2778,7 +2778,7 @@ fn linux_repository_history_is_authenticated_before_retention() {
     )
     .expect("write older RPM fixture");
     let predecessor_rpm = rpm_repository.join("rmux-0.8.0-1.x86_64.rpm");
-    fs::write(&predecessor_rpm, b"signed-rpm").expect("write retained RPM fixture");
+    fs::write(&predecessor_rpm, b"signature:current-rpm").expect("write retained RPM fixture");
     let outside_matrix_rpm = rpm_repository.join("rmux-0.8.0-1.i686.rpm");
     fs::write(&outside_matrix_rpm, b"signed-rpm-other-architecture")
         .expect("write RPM fixture for an architecture outside the release matrix");
@@ -2817,7 +2817,7 @@ fn linux_repository_history_is_authenticated_before_retention() {
     let rpm = tools.join("rpm");
     fs::write(
         &rpm,
-        "#!/bin/sh\nset -eu\n[ \"$1\" = -qp ]\ncase \" $* \" in *0.7.0*) version=0.7.0 ;; *0.8.0*) version=0.8.0 ;; *) exit 93 ;; esac\ncase \" $* \" in *i686*) architecture=i686 ;; *) architecture=x86_64 ;; esac\nprintf 'rmux\\n%s\\n%s\\n' \"$version\" \"$architecture\"\n",
+        "#!/bin/sh\nset -eu\n[ \"$1\" = -qp ]\nfor package do :; done\ncase \" $* \" in *0.7.0*) version=0.7.0 ;; *0.8.0*) version=0.8.0 ;; *) exit 93 ;; esac\ncase \" $* \" in *i686*) architecture=i686 ;; *) architecture=x86_64 ;; esac\ncase \" $* \" in\n  *SHA256HEADER*)\n    normalized=$(sed 's/^signature://' \"$package\")\n    digest=$(printf '%s' \"$normalized\" | sha256sum | cut -d' ' -f1)\n    printf 'rmux\\n%s\\n1\\n%s\\n%s\\n%s\\n' \"$version\" \"$architecture\" \"$digest\" \"$digest\"\n    ;;\n  *) printf 'rmux\\n%s\\n%s\\n' \"$version\" \"$architecture\" ;;\nesac\n",
     )
     .expect("write fake rpm");
     make_executable(&rpm);
@@ -2928,7 +2928,7 @@ fn linux_repository_history_is_authenticated_before_retention() {
     let rejected_divergence = run_retention("0.9.0", "amd64", "x86_64", false, false);
     assert!(!rejected_divergence.status.success());
     assert!(stderr(&rejected_divergence).contains("disagree on the latest stable predecessor"));
-    fs::write(&predecessor_rpm, b"signed-rpm").expect("restore RPM predecessor");
+    fs::write(&predecessor_rpm, b"signature:current-rpm").expect("restore RPM predecessor");
     fs::write(&outside_matrix_rpm, b"signed-rpm-other-architecture")
         .expect("restore outside-matrix RPM predecessor");
 
@@ -2940,6 +2940,62 @@ fn linux_repository_history_is_authenticated_before_retention() {
     assert!(!rejected_republication.status.success());
     assert!(stderr(&rejected_republication)
         .contains("published APT repository already contains current release 0.8.0"));
+
+    let recovery_staging = root.join("recovery-staging");
+    fs::create_dir(&recovery_staging).expect("create exact republication staging");
+    fs::copy(&apt_package, recovery_staging.join("rmux_0.8.0_amd64.deb"))
+        .expect("stage exact published Debian package");
+    fs::write(
+        recovery_staging.join("rmux-0.8.0-1.x86_64.rpm"),
+        b"current-rpm",
+    )
+    .expect("stage unsigned RPM package with exact signed payload");
+    let run_exact_republication = || {
+        Command::new(repo_root().join("scripts/retain-linux-package-history.py"))
+            .args(["--repository-dir"])
+            .arg(&repository)
+            .args(["--staging-dir"])
+            .arg(&recovery_staging)
+            .args([
+                "--apt-signing-key",
+                "apt-key",
+                "--rpm-signing-key",
+                "rpm-key",
+                "--current-version",
+                "0.8.0",
+                "--apt-architecture",
+                "amd64",
+                "--rpm-architecture",
+                "x86_64",
+                "--allow-current-version-exact",
+            ])
+            .env("FAKE_RPM_DIGEST_ONLY", "0")
+            .env("FAKE_AMBIGUOUS_RPM_SELECTOR", "0")
+            .env("PATH", &path)
+            .current_dir(repo_root())
+            .output()
+            .expect("run exact package-history republication check")
+    };
+    let accepted_exact_republication = run_exact_republication();
+    assert!(
+        accepted_exact_republication.status.success(),
+        "{}",
+        stderr(&accepted_exact_republication)
+    );
+    assert!(
+        String::from_utf8_lossy(&accepted_exact_republication.stdout)
+            .contains("current_version_already_published=true")
+    );
+
+    fs::write(
+        recovery_staging.join("rmux-0.8.0-1.x86_64.rpm"),
+        b"divergent-current-rpm",
+    )
+    .expect("tamper staged current RPM package");
+    let rejected_divergent_republication = run_exact_republication();
+    assert!(!rejected_divergent_republication.status.success());
+    assert!(stderr(&rejected_divergent_republication)
+        .contains("incoming RPM package differs from published current release"));
 
     fs::remove_file(staging.join("rmux_0.8.0_amd64.deb"))
         .expect("remove accepted retained package");

--- a/tests/release_downstream_workflows_spec.rs
+++ b/tests/release_downstream_workflows_spec.rs
@@ -21,6 +21,8 @@ const CRATES_CHANNEL: &str = include_str!("../.github/workflows/release-crates-c
 const CI: &str = include_str!("../.github/workflows/ci.yml");
 const LINUX_REPOSITORY_BUILD: &str =
     include_str!("../.github/workflows/release-linux-repository-build.yml");
+const LINUX_REPOSITORY_BUILD_ACTION: &str =
+    include_str!("../.github/actions/release-linux-repository-build/action.yml");
 const CHANNEL_RESULT_ACTION: &str =
     include_str!("../.github/actions/release-channel-result/action.yml");
 const RECEIPT_REFERENCE_BUILDER: &str =
@@ -421,6 +423,12 @@ fn linux_repository_build_retains_authenticated_previous_by_hash_indexes() {
         .expect("APT repository generator");
     assert!(authenticated < generated);
     assert!(LINUX_REPOSITORY_BUILD.contains("--previous-repository-dir \"$root/history/debian\""));
+    for builder in [LINUX_REPOSITORY_BUILD, LINUX_REPOSITORY_BUILD_ACTION] {
+        assert!(builder.contains("--allow-current-version-exact"));
+        assert!(builder.contains("current_version_already_published=true"));
+        assert!(builder.contains("CURRENT_VERSION_ALREADY_PUBLISHED"));
+        assert!(builder.contains("cp -a \"$root/history/debian\" \"$root/history/rpm\""));
+    }
 }
 
 #[cfg(unix)]

--- a/tests/release_linux_repository_recovery_spec.rs
+++ b/tests/release_linux_repository_recovery_spec.rs
@@ -190,6 +190,8 @@ fn manual_recovery_is_same_run_revalidated_and_canonically_sealed() {
     assert!(RESULT.contains("producer-head-sha:"));
     assert!(RESULT.contains("attestation-signer-workflow-path:"));
     assert!(HISTORY.contains("already contains current release"));
+    assert!(HISTORY.contains("--allow-current-version-exact"));
+    assert!(HISTORY.contains("incoming {manager} package differs from published current release"));
 }
 
 #[test]
@@ -200,6 +202,7 @@ import copy
 import importlib.util
 import pathlib
 import sys
+import tempfile
 
 sys.path.insert(0, 'scripts/release')
 from downstream_result import validate_producer, validate_result_artifact_source
@@ -323,6 +326,33 @@ for manager in ('APT', 'RPM'):
             raise
     else:
         raise SystemExit(f'{manager} republish was accepted')
+
+with tempfile.TemporaryDirectory() as root:
+    root = pathlib.Path(root)
+    published = root / 'published'
+    staging = root / 'staging'
+    published.mkdir()
+    staging.mkdir()
+    package_path = published / 'rmux_1.2.3_amd64.deb'
+    package_path.write_bytes(b'exact-current-package')
+    (staging / package_path.name).write_bytes(package_path.read_bytes())
+    exact = history.AuthenticatedPackage(current, 'amd64', package_path)
+    if not history.current_release_is_exact(
+        [exact], current, {'amd64'}, 'APT', staging, '.deb'
+    ):
+        raise SystemExit('exact current release was not recognized')
+    newer = history.StableVersion.parse('1.2.4')
+    assert newer is not None
+    newer_package = history.AuthenticatedPackage(newer, 'amd64', package_path)
+    try:
+        history.current_release_is_exact(
+            [exact, newer_package], current, {'amd64'}, 'APT', staging, '.deb'
+        )
+    except history.HistoryError as error:
+        if 'refusing to replace newer APT release 1.2.4 with 1.2.3' not in str(error):
+            raise
+    else:
+        raise SystemExit('newer published release was accepted during exact recovery')
 "#,
     );
     assert!(output.status.success(), "{}", stderr(&output));

--- a/tests/release_receipt_recovery_spec.rs
+++ b/tests/release_receipt_recovery_spec.rs
@@ -439,6 +439,52 @@ fn package_execution_failure_jobs() -> Value {
     value
 }
 
+fn linux_rebuild_failure_jobs() -> Value {
+    let mut value = post_mutation_failure_jobs();
+    let jobs = value["jobs"].as_array_mut().expect("jobs array");
+    for job in jobs.iter_mut() {
+        let name = job["name"].as_str().expect("job name");
+        if name == "Build exact signed Linux repository trees" {
+            job["conclusion"] = json!("failure");
+            for step in job["steps"].as_array_mut().expect("builder steps") {
+                if step["name"] == "Run ./.github/actions/release-linux-repository-build" {
+                    step["conclusion"] = json!("failure");
+                }
+            }
+            continue;
+        }
+        if [
+            "Publish exact Homebrew tap formula",
+            "Publish exact Scoop manifest",
+            "Publish exact Web Share WASM bytes",
+        ]
+        .contains(&name)
+        {
+            job["conclusion"] = json!("success");
+            for step in job["steps"].as_array_mut().expect("writer steps") {
+                if step["name"] == "Run ./.github/actions/release-owned-repository-publish" {
+                    step["conclusion"] = json!("success");
+                }
+            }
+        }
+    }
+    jobs.push(json!({
+        "name": "Verify crates.io Trusted Publishing authority",
+        "conclusion": "success",
+        "steps": [
+            step("Set up job", "success"),
+            step("Exchange and revoke a preflight crates.io token", "success"),
+            step(
+                "Post Exchange and revoke a preflight crates.io token",
+                "success",
+            ),
+            step("Complete job", "success"),
+        ],
+    }));
+    value["total_count"] = json!(jobs.len());
+    value
+}
+
 fn crates_result_seal_failure_jobs() -> Value {
     let mut value = package_execution_failure_jobs();
     let jobs = value["jobs"].as_array_mut().expect("jobs array");
@@ -516,6 +562,32 @@ fn package_writer_failure_artifacts() -> (Value, u64) {
     }
     let total_count = artifacts.len();
     value["total_count"] = json!(total_count);
+    (value, receipt_id)
+}
+
+fn linux_rebuild_failure_artifacts() -> (Value, u64) {
+    let (mut value, receipt_id) = downstream_failure_artifacts();
+    let artifacts = value["artifacts"].as_array_mut().expect("artifacts array");
+    for channel in ["homebrew_tap", "scoop", "web_share"] {
+        for suffix in ["result", "result-envelope", "result-reference"] {
+            artifacts.push(json!({
+                "id": receipt_id + artifacts.len() as u64,
+                "name": format!(
+                    "rmux-downstream-{channel}-{suffix}-{SOURCE}-{RELEASE_ID}"
+                ),
+                "expired": false,
+                "digest": format!("sha256:{}", "a".repeat(64)),
+                "workflow_run": {
+                    "id": FAILED_RUN,
+                    "head_sha": FAILED_CONTROL,
+                    "head_branch": "main",
+                    "repository_id": 1_239_918_790,
+                    "head_repository_id": 1_239_918_790,
+                },
+            }));
+        }
+    }
+    value["total_count"] = json!(artifacts.len());
     (value, receipt_id)
 }
 
@@ -795,6 +867,34 @@ fn protected_main_recovery_accepts_exact_package_execution_failures() {
         &root,
         failed_run(FAILED_CONTROL, "main", "failure"),
         package_execution_failure_jobs(),
+        artifacts,
+        json!({
+            "total_count": 1,
+            "artifacts": [{
+                "id": receipt_id,
+                "name": format!("rmux-publication-receipt-{SOURCE}-{RELEASE_ID}"),
+                "expired": false,
+                "workflow_run": {"id": FAILED_RUN},
+            }],
+        }),
+    );
+    fs::remove_dir_all(&root).expect("remove fixture root");
+    assert!(
+        output.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn protected_main_recovery_accepts_exact_linux_rebuild_failures() {
+    let root = fixture_root("linux-rebuild-failure");
+    let (artifacts, receipt_id) = linux_rebuild_failure_artifacts();
+    let output = run_recovery(
+        &root,
+        failed_run(FAILED_CONTROL, "main", "failure"),
+        linux_rebuild_failure_jobs(),
         artifacts,
         json!({
             "total_count": 1,


### PR DESCRIPTION
## Summary

- recognize an already-published exact APT/RPM release during receipt recovery
- reuse the authenticated public repository tree instead of regenerating package signatures
- admit only the exact failed-run topology produced by the interrupted v0.10.0 recovery
- keep normal publication and every divergent recovery fail-closed

## Verification

- `scripts/gate-unix-fast.sh --platform linux`
- release contract validation
- targeted Rust recovery and workflow tests
- Ruff, Rustfmt, and `git diff --check`
- live v0.10.0 APT/RPM identity check in Ubuntu 22.04