### PR TITLE
fix(release): seal Windows channel recovery

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -20,5 +20,11 @@ test-group = 'windows-console'
 threads-required = "num-test-threads"
 
 [[profile.default.overrides]]
+platform = 'cfg(windows)'
+filter = 'binary(/^acceptance_/)'
+test-group = 'windows-console'
+threads-required = "num-test-threads"
+
+[[profile.default.overrides]]
 filter = 'kind(test) & (package(rmux) | package(rmux-client) | package(rmux-server) | package(rmux-sdk) | package(rmux-pty))'
 test-group = 'daemon-integration'

--- a/.github/actions/release-channel-result/action.yml
+++ b/.github/actions/release-channel-result/action.yml
@@ -222,7 +222,12 @@ runs:
         set -euo pipefail
         install_root="$RUNNER_TEMP/rmux-gh-2.93.0-result-${{ inputs.channel }}"
         scripts/release/install-gh-2.93.0.sh "$install_root"
-        echo "binary=$install_root/gh" >> "$GITHUB_OUTPUT"
+        binary="$install_root/gh"
+        if [[ -x "$install_root/gh.exe" ]]; then
+          binary="$install_root/gh.exe"
+        fi
+        test -x "$binary"
+        echo "binary=$binary" >> "$GITHUB_OUTPUT"
 
     - name: Verify the exact signed channel result
       shell: bash

--- a/scripts/release/install-gh-2.93.0.sh
+++ b/scripts/release/install-gh-2.93.0.sh
@@ -8,14 +8,27 @@ fi
 
 install_root=$1
 version=2.93.0
-archive="gh_${version}_linux_amd64.tar.gz"
-expected_sha256=02d1290eba130e0b896f3709ffff22e1c75a51475ddb70476a85abc6b5807af0
+system=$(uname -s)
+machine=$(uname -m)
+
+case "$system:$machine" in
+  Linux:x86_64)
+    archive="gh_${version}_linux_amd64.tar.gz"
+    expected_sha256=02d1290eba130e0b896f3709ffff22e1c75a51475ddb70476a85abc6b5807af0
+    binary="$install_root/gh"
+    ;;
+  MINGW*:x86_64 | MSYS*:x86_64 | CYGWIN*:x86_64)
+    archive="gh_${version}_windows_amd64.zip"
+    expected_sha256=77aa01ed7317295ad550de0ad04f3f276b1ef0e9272e3d002ac28dd99853d211
+    binary="$install_root/gh.exe"
+    ;;
+  *)
+    echo "the pinned verifier CLI installer does not support $system $machine" >&2
+    exit 2
+    ;;
+esac
 url="https://github.com/cli/cli/releases/download/v${version}/${archive}"
 
-[[ $(uname -s) == Linux && $(uname -m) == x86_64 ]] || {
-  echo "the pinned verifier CLI installer supports only Linux x86_64" >&2
-  exit 2
-}
 command -v curl >/dev/null || { echo "curl is required" >&2; exit 2; }
 command -v sha256sum >/dev/null || { echo "sha256sum is required" >&2; exit 2; }
 
@@ -24,16 +37,27 @@ trap 'rm -rf "$work"' EXIT
 curl --fail --location --proto '=https' --tlsv1.2 \
   --output "$work/$archive" "$url"
 printf '%s  %s\n' "$expected_sha256" "$work/$archive" | sha256sum --check --strict
-tar -xzf "$work/$archive" -C "$work"
 mkdir -p "$install_root"
-install -m 0755 "$work/gh_${version}_linux_amd64/bin/gh" "$install_root/gh"
+if [[ $system == Linux ]]; then
+  tar -xzf "$work/$archive" -C "$work"
+  install -m 0755 "$work/gh_${version}_linux_amd64/bin/gh" "$binary"
+else
+  command -v cygpath >/dev/null || { echo "cygpath is required" >&2; exit 2; }
+  command -v powershell.exe >/dev/null || { echo "powershell.exe is required" >&2; exit 2; }
+  RMUX_GH_ARCHIVE=$(cygpath -w "$work/$archive") \
+    RMUX_GH_DEST=$(cygpath -w "$work") \
+    powershell.exe -NoProfile -NonInteractive -Command \
+      'Expand-Archive -LiteralPath $env:RMUX_GH_ARCHIVE -DestinationPath $env:RMUX_GH_DEST -Force'
+  cp "$work/bin/gh.exe" "$binary"
+  chmod 0755 "$binary"
+fi
 
-first_line=$("$install_root/gh" --version | head -n 1)
+first_line=$("$binary" --version | head -n 1)
 [[ $first_line == "gh version $version "* ]] || {
   echo "unexpected gh version: $first_line" >&2
   exit 1
 }
-"$install_root/gh" release verify --help >/dev/null
-"$install_root/gh" release verify-asset --help >/dev/null
-"$install_root/gh" attestation verify --help >/dev/null
-printf 'gh-bin=%s\n' "$install_root/gh"
+"$binary" release verify --help >/dev/null
+"$binary" release verify-asset --help >/dev/null
+"$binary" attestation verify --help >/dev/null
+printf 'gh-bin=%s\n' "$binary"

--- a/scripts/release/receipt_recovery_topology.py
+++ b/scripts/release/receipt_recovery_topology.py
@@ -102,6 +102,27 @@ CRATES_RESULT_FAILURE_MODES = frozenset(
     {"package-result-seal-failure", "crates-result-seal-failure"}
 )
 LINUX_REBUILD_FAILURE_MODE = "linux-repository-rebuild-failure"
+CHOCOLATEY_RESULT_SEAL_FAILURE_MODE = "chocolatey-result-seal-failure"
+CHOCOLATEY_RESULT_SEAL_JOB = "Submit exact Chocolatey package"
+CHOCOLATEY_RESULT_SEAL_SUCCESS_JOBS = DIRECT_SUCCESS_JOBS | {
+    *(f"{PREPARATION_PREFIX}{name}" for name in PREPARATION_SUCCESS_JOBS),
+    *PACKAGE_WRITER_JOB_MAP,
+    CRATES_PREFLIGHT_JOB,
+    APT_PUBLISH_JOB,
+    "Record disabled Snap stable channel / Record policy result snap_stable",
+    "Record manual Homebrew Core submission / Record policy result homebrew_core",
+    "Record manual WinGet submission / Record policy result winget",
+}
+CHOCOLATEY_RESULT_SEAL_SKIPPED_JOBS = frozenset(
+    {
+        "Record denied RC Linux repository channel",
+        "Aggregate ten exact pre-site results",
+        "Publish exact Snap candidate revisions",
+        "Record blocked automated rmux.io update",
+        "Prepare manual rmux.io handoff",
+        "Aggregate all eleven exact channel results",
+    }
+)
 
 
 def result_envelope_names(source_sha: str, release_id: int) -> set[str]:
@@ -242,6 +263,38 @@ def verify_skipped_jobs(
             raise ValueError(f"post-failure downstream job {name} was not untouched")
 
 
+def verify_chocolatey_result_seal_failure(
+    jobs: dict[str, dict[str, Any]],
+) -> bool:
+    expected = (
+        CHOCOLATEY_RESULT_SEAL_SUCCESS_JOBS
+        | CHOCOLATEY_RESULT_SEAL_SKIPPED_JOBS
+        | {CHOCOLATEY_RESULT_SEAL_JOB}
+    )
+    if set(jobs) != expected:
+        return False
+    for name in CHOCOLATEY_RESULT_SEAL_SUCCESS_JOBS:
+        if jobs[name].get("conclusion") != "success":
+            raise ValueError(f"pre-Chocolatey downstream job {name} is not successful")
+    verify_skipped_jobs(jobs, CHOCOLATEY_RESULT_SEAL_SKIPPED_JOBS)
+    checkout = "Run actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5"
+    action = "Run ./.github/actions/release-chocolatey-publish"
+    exact_job_shape(
+        jobs[CHOCOLATEY_RESULT_SEAL_JOB],
+        name=CHOCOLATEY_RESULT_SEAL_JOB,
+        conclusion="failure",
+        steps={
+            "Set up job": "success",
+            checkout: "success",
+            action: "failure",
+            f"Post {action}": "success",
+            f"Post {checkout}": "success",
+            "Complete job": "success",
+        },
+    )
+    return True
+
+
 def verify_failed_downstream_jobs(value: dict[str, Any]) -> str:
     jobs = value.get("jobs")
     if not isinstance(jobs, list) or value.get("total_count") != len(jobs):
@@ -254,6 +307,8 @@ def verify_failed_downstream_jobs(value: dict[str, Any]) -> str:
         if name in by_name:
             raise ValueError("failed downstream job names are not unique")
         by_name[name] = job
+    if verify_chocolatey_result_seal_failure(by_name):
+        return CHOCOLATEY_RESULT_SEAL_FAILURE_MODE
     by_name, post_mutation = canonical_failed_jobs(by_name)
     for name in EARLY_SUCCESS_JOBS:
         if by_name[name].get("conclusion") != "success":
@@ -458,7 +513,20 @@ def verify_failed_downstream_artifacts(
         ),
     }
     allowed_names = (expected_names,)
-    if failure_mode == LINUX_REBUILD_FAILURE_MODE:
+    if failure_mode == CHOCOLATEY_RESULT_SEAL_FAILURE_MODE:
+        expected_names.add(
+            f"rmux-downstream-apt_rpm-signed-{args.source_sha}-{args.release_id}"
+        )
+        for channel in set(PAYLOAD_CHANNELS) - {"chocolatey", "snap_candidate"}:
+            for suffix in ("result", "result-envelope", "result-reference"):
+                expected_names.add(
+                    f"rmux-downstream-{channel}-{suffix}-{args.source_sha}-{args.release_id}"
+                )
+        for suffix in ("result", "result-envelope"):
+            expected_names.add(
+                f"rmux-downstream-chocolatey-{suffix}-{args.source_sha}-{args.release_id}"
+            )
+    elif failure_mode == LINUX_REBUILD_FAILURE_MODE:
         expected_names.update(
             f"rmux-downstream-{channel}-result-{args.source_sha}-{args.release_id}"
             for channel in POST_MUTATION_RESULT_CHANNELS

--- a/tests/release_automation_spec.rs
+++ b/tests/release_automation_spec.rs
@@ -812,9 +812,19 @@ fn ci_builds_windows_tests_once_and_runs_eighteen_hosted_shards() {
         nextest
             .matches("threads-required = \"num-test-threads\"")
             .count(),
-        2,
-        "Windows console tests must be exclusive while other shard tests stay parallel"
+        3,
+        "Windows console and acceptance tests must be exclusive while other shard tests stay parallel"
     );
+    for required in [
+        "platform = 'cfg(windows)'",
+        "filter = 'binary(/^acceptance_/)'",
+        "test-group = 'windows-console'",
+    ] {
+        assert!(
+            nextest.contains(required),
+            "Windows acceptance test isolation lost {required:?}"
+        );
+    }
     for required in [
         "name: Platform build and smoke on windows-latest",
         "always() &&",

--- a/tests/release_receipt_recovery_spec.rs
+++ b/tests/release_receipt_recovery_spec.rs
@@ -532,6 +532,81 @@ fn crates_result_seal_failure_jobs() -> Value {
     value
 }
 
+fn chocolatey_result_seal_failure_jobs() -> Value {
+    let mut value = crates_result_seal_failure_jobs();
+    let jobs = value["jobs"].as_array_mut().expect("jobs array");
+    for job in jobs.iter_mut() {
+        let name = job["name"].as_str().expect("job name");
+        if name == "Publish exact crates.io package set / Publish exact crates.io package set" {
+            job["conclusion"] = json!("success");
+            for step in job["steps"].as_array_mut().expect("crates steps") {
+                if step["name"] == "Seal exact crates.io result evidence" {
+                    step["conclusion"] = json!("success");
+                }
+            }
+            continue;
+        }
+        let policy_name = match name {
+            "Record disabled Snap stable channel" => {
+                Some("Record disabled Snap stable channel / Record policy result snap_stable")
+            }
+            "Record manual Homebrew Core submission" => {
+                Some("Record manual Homebrew Core submission / Record policy result homebrew_core")
+            }
+            "Record manual WinGet submission" => {
+                Some("Record manual WinGet submission / Record policy result winget")
+            }
+            _ => None,
+        };
+        if let Some(policy_name) = policy_name {
+            job["name"] = json!(policy_name);
+            job["conclusion"] = json!("success");
+            job["steps"] = json!([
+                step("Set up job", "success"),
+                step(
+                    "Run actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5",
+                    "success",
+                ),
+                step("Run ./.github/actions/release-channel-prepare", "success"),
+                step(
+                    "Materialize the exact blocked or denied observation",
+                    "success",
+                ),
+                step(
+                    "Refuse an executable request in the policy-only worker",
+                    "success"
+                ),
+                step("Seal exact policy-only channel result evidence", "success"),
+                step(
+                    "Post Run actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5",
+                    "success",
+                ),
+                step("Complete job", "success"),
+            ]);
+            continue;
+        }
+        if name == "Submit exact Chocolatey package" {
+            let action = "Run ./.github/actions/release-chocolatey-publish";
+            job["conclusion"] = json!("failure");
+            job["steps"] = json!([
+                step("Set up job", "success"),
+                step(
+                    "Run actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5",
+                    "success",
+                ),
+                step(action, "failure"),
+                step(&format!("Post {action}"), "success"),
+                step(
+                    "Post Run actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5",
+                    "success",
+                ),
+                step("Complete job", "success"),
+            ]);
+        }
+    }
+    value
+}
+
 fn downstream_failure_artifacts() -> (Value, u64) {
     downstream_failure_artifacts_for(FAILED_RUN, FAILED_CONTROL, 81)
 }
@@ -600,6 +675,41 @@ fn crates_result_seal_failure_artifacts() -> (Value, u64) {
         format!("rmux-downstream-apt_rpm-result-reference-{SOURCE}-{RELEASE_ID}"),
         format!("rmux-downstream-crates_io-result-{SOURCE}-{RELEASE_ID}"),
     ] {
+        artifacts.push(json!({
+            "id": receipt_id + artifacts.len() as u64,
+            "name": name,
+            "expired": false,
+            "digest": format!("sha256:{}", "a".repeat(64)),
+            "workflow_run": {
+                "id": FAILED_RUN,
+                "head_sha": FAILED_CONTROL,
+                "head_branch": "main",
+                "repository_id": 1_239_918_790,
+                "head_repository_id": 1_239_918_790,
+            },
+        }));
+    }
+    value["total_count"] = json!(artifacts.len());
+    (value, receipt_id)
+}
+
+fn chocolatey_result_seal_failure_artifacts() -> (Value, u64) {
+    let (mut value, receipt_id) = crates_result_seal_failure_artifacts();
+    let artifacts = value["artifacts"].as_array_mut().expect("artifacts array");
+    let mut names = vec![
+        format!("rmux-downstream-crates_io-result-envelope-{SOURCE}-{RELEASE_ID}"),
+        format!("rmux-downstream-crates_io-result-reference-{SOURCE}-{RELEASE_ID}"),
+        format!("rmux-downstream-chocolatey-result-{SOURCE}-{RELEASE_ID}"),
+        format!("rmux-downstream-chocolatey-result-envelope-{SOURCE}-{RELEASE_ID}"),
+    ];
+    for channel in ["snap_stable", "homebrew_core", "winget"] {
+        for suffix in ["result", "result-envelope", "result-reference"] {
+            names.push(format!(
+                "rmux-downstream-{channel}-{suffix}-{SOURCE}-{RELEASE_ID}"
+            ));
+        }
+    }
+    for name in names {
         artifacts.push(json!({
             "id": receipt_id + artifacts.len() as u64,
             "name": name,
@@ -941,6 +1051,65 @@ fn protected_main_recovery_accepts_exact_progressive_result_seal_failure() {
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
+}
+
+#[test]
+fn protected_main_recovery_accepts_exact_chocolatey_result_seal_failure() {
+    let root = fixture_root("chocolatey-result-seal-failure");
+    let (artifacts, receipt_id) = chocolatey_result_seal_failure_artifacts();
+    let output = run_recovery(
+        &root,
+        failed_run(FAILED_CONTROL, "main", "failure"),
+        chocolatey_result_seal_failure_jobs(),
+        artifacts,
+        json!({
+            "total_count": 1,
+            "artifacts": [{
+                "id": receipt_id,
+                "name": format!("rmux-publication-receipt-{SOURCE}-{RELEASE_ID}"),
+                "expired": false,
+                "workflow_run": {"id": FAILED_RUN},
+            }],
+        }),
+    );
+    fs::remove_dir_all(&root).expect("remove fixture root");
+    assert!(
+        output.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn protected_main_recovery_rejects_partial_chocolatey_result_evidence() {
+    let root = fixture_root("chocolatey-partial-result-evidence");
+    let (mut artifacts, receipt_id) = chocolatey_result_seal_failure_artifacts();
+    let entries = artifacts["artifacts"]
+        .as_array_mut()
+        .expect("artifacts array");
+    entries.retain(|artifact| {
+        artifact["name"]
+            != format!("rmux-downstream-chocolatey-result-envelope-{SOURCE}-{RELEASE_ID}")
+    });
+    artifacts["total_count"] = json!(entries.len());
+    let output = run_recovery(
+        &root,
+        failed_run(FAILED_CONTROL, "main", "failure"),
+        chocolatey_result_seal_failure_jobs(),
+        artifacts,
+        json!({
+            "total_count": 1,
+            "artifacts": [{
+                "id": receipt_id,
+                "name": format!("rmux-publication-receipt-{SOURCE}-{RELEASE_ID}"),
+                "expired": false,
+                "workflow_run": {"id": FAILED_RUN},
+            }],
+        }),
+    );
+    fs::remove_dir_all(&root).expect("remove fixture root");
+    assert!(!output.status.success());
 }
 
 #[test]

--- a/tests/release_shadow_spec.rs
+++ b/tests/release_shadow_spec.rs
@@ -1,6 +1,8 @@
 #[cfg(unix)]
 use std::fs;
 #[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+#[cfg(unix)]
 use std::path::{Path, PathBuf};
 #[cfg(unix)]
 use std::process::{Command, Output};
@@ -33,6 +35,14 @@ fn run(program: &Path, args: &[&str]) -> Output {
         .current_dir(repo_root())
         .output()
         .unwrap_or_else(|error| panic!("failed to run {}: {error}", program.display()))
+}
+
+#[cfg(unix)]
+fn write_executable(path: &Path, source: &str) {
+    fs::write(path, source).expect("write executable fixture");
+    let mut permissions = fs::metadata(path).expect("fixture metadata").permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions).expect("set fixture permissions");
 }
 
 #[test]
@@ -870,11 +880,71 @@ fn atomic_authority_schemas_cannot_drive_a_workflow_directly() {
 #[test]
 fn release_verification_cli_is_pinned_and_capability_checked() {
     let installer = include_str!("../scripts/release/install-gh-2.93.0.sh");
+    let result = include_str!("../.github/actions/release-channel-result/action.yml");
     assert!(installer.contains("version=2.93.0"));
     assert!(installer.contains("02d1290eba130e0b896f3709ffff22e1c75a51475ddb70476a85abc6b5807af0"));
+    assert!(installer.contains("gh_${version}_windows_amd64.zip"));
+    assert!(installer.contains("77aa01ed7317295ad550de0ad04f3f276b1ef0e9272e3d002ac28dd99853d211"));
+    assert!(installer.contains("$work/bin/gh.exe"));
+    assert!(installer.contains("Expand-Archive"));
     assert!(installer.contains("release verify --help"));
     assert!(installer.contains("release verify-asset --help"));
     assert!(installer.contains("attestation verify --help"));
+    assert!(result.contains("if [[ -x \"$install_root/gh.exe\" ]]"));
+    assert!(result.contains("echo \"binary=$binary\" >> \"$GITHUB_OUTPUT\""));
+}
+
+#[cfg(unix)]
+#[test]
+fn release_verification_cli_installer_supports_git_bash_windows() {
+    let root = temp_dir("gh-windows-installer");
+    let bin = root.join("bin");
+    let install = root.join("installed");
+    fs::create_dir(&bin).expect("create fake command directory");
+    write_executable(
+        &bin.join("uname"),
+        "#!/usr/bin/env bash\ncase \"$1\" in -s) echo MINGW64_NT-10.0-22631;; -m) echo x86_64;; *) exit 2;; esac\n",
+    );
+    write_executable(
+        &bin.join("curl"),
+        "#!/usr/bin/env bash\nset -euo pipefail\nout=\nwhile (( $# )); do\n  if [[ $1 == --output ]]; then out=$2; shift 2; else shift; fi\ndone\nprintf fixture > \"$out\"\n",
+    );
+    write_executable(
+        &bin.join("sha256sum"),
+        "#!/usr/bin/env bash\ncat >/dev/null\n",
+    );
+    write_executable(
+        &bin.join("cygpath"),
+        "#!/usr/bin/env bash\ntest \"$1\" = -w\nprintf '%s\\n' \"$2\"\n",
+    );
+    write_executable(
+        &bin.join("powershell.exe"),
+        "#!/usr/bin/env bash\nset -euo pipefail\nmkdir -p \"$RMUX_GH_DEST/bin\"\nprintf '%s\\n' '#!/usr/bin/env bash' 'if [[ $1 == --version ]]; then echo \"gh version 2.93.0 (fixture)\"; fi' > \"$RMUX_GH_DEST/bin/gh.exe\"\nchmod 755 \"$RMUX_GH_DEST/bin/gh.exe\"\n",
+    );
+
+    let path = format!(
+        "{}:{}",
+        bin.display(),
+        std::env::var("PATH").expect("PATH is set")
+    );
+    let output = Command::new("bash")
+        .arg(repo_root().join("scripts/release/install-gh-2.93.0.sh"))
+        .arg(&install)
+        .env("PATH", path)
+        .current_dir(repo_root())
+        .output()
+        .expect("run Windows verifier installer fixture");
+    assert!(
+        output.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(install.join("gh.exe").is_file());
+    assert!(!install.join("gh").exists());
+    assert!(String::from_utf8_lossy(&output.stdout)
+        .contains(&format!("gh-bin={}", install.join("gh.exe").display())));
+    fs::remove_dir_all(root).expect("remove installer fixture");
 }
 
 #[test]


### PR DESCRIPTION
This closes the Windows-only evidence sealing failure observed after the v0.10.0 Chocolatey submission.\n\n- install and verify the pinned GitHub CLI archive on Git Bash/Windows\n- pass the platform-correct verifier path to channel result sealing\n- admit only the exact post-Chocolatey result-seal recovery topology\n- reject partial Chocolatey result evidence\n\nValidation:\n- all release contract tests\n- all release_* integration tests\n- workspace Clippy with warnings denied\n- Rustfmt, Ruff, Bash syntax, unsafe policy\n- exact live topology and 41-artifact set from run 30983791914\n- public Chocolatey package bytes equal the authorized payload