### PR TITLE
test: preserve recovery and automation contribution provenance

### DIFF
--- a/crates/rmux-sdk/src/events/recovery_tests.rs
+++ b/crates/rmux-sdk/src/events/recovery_tests.rs
@@ -705,6 +705,7 @@ async fn detached_transport_loss_becomes_a_typed_terminal_event() {
     server_task.await.expect("server task");
 }
 
+/// Pins the atomic rebase/raw-byte boundary proposed by Prabir Shrestha in #139.
 #[test]
 fn recovery_state_owns_rebase_bytes_lifecycle_and_end_ordering() {
     let mut state = PaneRecoveryState::default();
@@ -712,6 +713,7 @@ fn recovery_state_owns_rebase_bytes_lifecycle_and_end_ordering() {
         super::rebase_from_proto(rebase(1, ProtoReason::Initial)).expect("initial rebase"),
     );
     state.apply(&initial).expect("initial rebase");
+    assert_eq!(state.next_sequence(), Some(5));
     state
         .apply(&PaneRecoveryEvent::Bytes {
             epoch: 1,

--- a/tests/automation_cli.rs
+++ b/tests/automation_cli.rs
@@ -188,6 +188,7 @@ fn nonzero_pane_base_index_preserves_targeted_automation_and_percent_resize(
 /// this one pins both indices at once and covers all three target spellings,
 /// including a bare session target which must land on the ACTIVE pane rather
 /// than the first one.
+/// Scenario and regression coverage contributed by Edwin Hu in #178.
 #[test]
 fn base_index_one_resolves_every_automation_target_spelling() -> Result<(), Box<dyn Error>> {
     let harness = CliHarness::new("automation-base-index-one")?;
@@ -236,6 +237,10 @@ fn base_index_one_resolves_every_automation_target_spelling() -> Result<(), Box<
 
     let pane_one_id = pane_id(&harness, "alpha:1", 1)?;
     let pane_two_id = pane_id(&harness, "alpha:1", 2)?;
+    assert_ne!(
+        pane_one_id, pane_two_id,
+        "fixture pane ids must be distinct"
+    );
 
     // Explicit slot targets must address the pane the user named, and a `%id`
     // must agree with the slot that reported it.


### PR DESCRIPTION
Records the provenance of two regression contracts whose finalized implementations landed without contributor trailers:

- Prabir Shrestha: the atomic recovery boundary proposed in #139.
- Edwin Hu: the indexed-target regression contributed in #178.

The branch intentionally contains two independently signed commits. It must be merged with **Rebase and merge**, not Squash, so each contributor retains a distinct commit.