### PR TITLE
fix(release): distinguish pending Chocolatey packages

### DIFF
--- a/.github/release/candidate-contract.json
+++ b/.github/release/candidate-contract.json
@@ -478,6 +478,7 @@
     "scripts/release/channel-summary.py",
     "scripts/release/channel-target-evidence.py",
     "scripts/release/channel_request.py",
+    "scripts/release/chocolatey-package-status.py",
     "scripts/release/collect-downstream-repository.py",
     "scripts/release/crate_package_set.py",
     "scripts/release/dispatch-candidate-shadow-audit.sh",

--- a/scripts/release/chocolatey-package-status.py
+++ b/scripts/release/chocolatey-package-status.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Classify one exact Chocolatey OData package entry."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import xml.etree.ElementTree as ET
+from datetime import datetime, timezone
+from pathlib import Path
+
+ATOM_ENTRY = "{http://www.w3.org/2005/Atom}entry"
+DATA_NAMESPACE = "http://schemas.microsoft.com/ado/2007/08/dataservices"
+MAX_DOCUMENT_SIZE = 1024 * 1024
+PENDING_SENTINEL = datetime(1900, 1, 1, tzinfo=timezone.utc)
+VERSION = re.compile(r"[0-9]+\.[0-9]+\.[0-9]+")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--document", type=Path, required=True)
+    parser.add_argument("--expected-version", required=True)
+    return parser.parse_args()
+
+
+def single_property(root: ET.Element, name: str) -> str:
+    values = root.findall(f".//{{{DATA_NAMESPACE}}}{name}")
+    if len(values) != 1 or values[0].text is None:
+        raise ValueError(f"Chocolatey metadata must contain one {name}")
+    value = values[0].text.strip()
+    if not value or list(values[0]):
+        raise ValueError(f"Chocolatey metadata {name} is malformed")
+    return value
+
+
+def odata_datetime(raw: str) -> datetime:
+    normalized = f"{raw[:-1]}+00:00" if raw.endswith("Z") else raw
+    try:
+        value = datetime.fromisoformat(normalized)
+    except ValueError as error:
+        raise ValueError("Chocolatey Published timestamp is malformed") from error
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def package_status(document: Path, expected_version: str) -> str:
+    if VERSION.fullmatch(expected_version) is None:
+        raise ValueError("expected Chocolatey version is malformed")
+    if document.is_symlink() or not document.is_file():
+        raise ValueError("Chocolatey metadata must be one real file")
+    size = document.stat().st_size
+    if size <= 0 or size > MAX_DOCUMENT_SIZE:
+        raise ValueError("Chocolatey metadata size is invalid")
+    raw = document.read_bytes()
+    if b"<!DOCTYPE" in raw.upper() or b"<!ENTITY" in raw.upper():
+        raise ValueError("Chocolatey metadata cannot contain a DTD")
+    try:
+        root = ET.fromstring(raw)
+    except ET.ParseError as error:
+        raise ValueError("Chocolatey metadata is malformed XML") from error
+    if root.tag != ATOM_ENTRY:
+        raise ValueError("Chocolatey metadata is not one OData entry")
+
+    version = single_property(root, "Version")
+    if version != expected_version:
+        raise ValueError("Chocolatey metadata version differs from the release")
+    approved_raw = single_property(root, "IsApproved")
+    if approved_raw not in {"true", "false"}:
+        raise ValueError("Chocolatey IsApproved value is malformed")
+    approved = approved_raw == "true"
+    published = odata_datetime(single_property(root, "Published"))
+
+    if not approved and published == PENDING_SENTINEL:
+        return "pending"
+    if approved and published > PENDING_SENTINEL:
+        return "public"
+    raise ValueError("Chocolatey approval and publication metadata disagree")
+
+
+def main() -> int:
+    args = parse_args()
+    print(package_status(args.document, args.expected_version))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, ValueError) as error:
+        print(f"chocolatey-package-status: {error}", file=sys.stderr)
+        raise SystemExit(1) from error

--- a/scripts/release/publish-chocolatey-package.ps1
+++ b/scripts/release/publish-chocolatey-package.ps1
@@ -40,49 +40,72 @@ if (
 }
 $package = $files[0].FullName
 $expectedHash = (Get-FileHash -LiteralPath $package -Algorithm SHA256).Hash.ToLowerInvariant()
+$metadataUrl = "https://community.chocolatey.org/api/v2/Packages(Id='rmux',Version='$version')"
 $packageUrl = "https://community.chocolatey.org/api/v2/package/rmux/$version"
 $pageUrl = "https://community.chocolatey.org/packages/rmux/$version"
+$metadata = Join-Path $env:RUNNER_TEMP "rmux-$version-chocolatey-metadata.xml"
 $download = Join-Path $env:RUNNER_TEMP "rmux-$version-public.nupkg"
 
-function Get-ExactPublicPackage {
+function Get-ExactPackageState {
     try {
-        Invoke-WebRequest -Uri $packageUrl -OutFile $download -MaximumRedirection 5
+        Invoke-WebRequest -Uri $metadataUrl -OutFile $metadata -MaximumRedirection 5
     }
     catch {
         if ($_.Exception.Response -and [int]$_.Exception.Response.StatusCode -eq 404) {
-            return $false
+            return "missing"
         }
         throw
     }
+
+    $statusLines = @(
+        python scripts/release/chocolatey-package-status.py `
+            --document $metadata `
+            --expected-version $version
+    )
+    if ($LASTEXITCODE -ne 0 -or $statusLines.Count -ne 1) {
+        throw "Chocolatey package metadata classification failed"
+    }
+    $packageState = $statusLines[0].Trim()
+    if ($packageState -notin @("pending", "public")) {
+        throw "Chocolatey package metadata returned an unknown state"
+    }
+
+    Invoke-WebRequest -Uri $packageUrl -OutFile $download -MaximumRedirection 5
     $actualHash = (Get-FileHash -LiteralPath $download -Algorithm SHA256).Hash.ToLowerInvariant()
     if ($actualHash -cne $expectedHash) {
         throw [ChocolateyPublicBytesMismatchException]::new(
-            "Public Chocolatey package bytes differ from the canonical payload"
+            "Existing Chocolatey package bytes differ from the canonical payload"
         )
     }
-    return $true
+    return $packageState
 }
 
 $mutationStarted = $false
 $remoteId = $null
 $state = $null
-$alreadyPublic = $false
+$packageState = $null
 try {
-    $alreadyPublic = Get-ExactPublicPackage
+    $packageState = Get-ExactPackageState
 }
 catch [ChocolateyPublicBytesMismatchException] {
     throw
 }
 catch {
-    Write-Warning "Chocolatey public package lookup failed before mutation"
+    Write-Warning "Chocolatey package lookup failed before mutation"
     $state = "failed-transient"
 }
 
-if ($null -eq $state -and $alreadyPublic) {
+if ($null -eq $state -and $packageState -eq "public") {
     $state = "no-op-exact"
     $remoteId = "rmux.$version"
 }
-elseif ($null -eq $state) {
+elseif ($null -eq $state -and $packageState -eq "pending") {
+    # The result contract uses this bit to prevent a duplicate retry once a remote submission exists.
+    $mutationStarted = $true
+    $state = "pending-moderation"
+    $remoteId = "rmux.$version"
+}
+elseif ($null -eq $state -and $packageState -eq "missing") {
     $mutationStarted = $true
     $remoteId = "rmux.$version"
     choco push $package `
@@ -97,6 +120,9 @@ elseif ($null -eq $state) {
     else {
         $state = "submitted"
     }
+}
+elseif ($null -eq $state) {
+    throw "Chocolatey package lookup returned an invalid state"
 }
 
 $observedAt = [DateTime]::UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ")

--- a/tests/release_downstream_retry_spec.rs
+++ b/tests/release_downstream_retry_spec.rs
@@ -3,9 +3,12 @@ mod python3;
 
 use std::fs;
 use std::path::PathBuf;
+use std::process::Output;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 const ACTIVATION: &str = include_str!("../.github/release/release-activation.json");
 const CHOCOLATEY: &str = include_str!("../.github/workflows/release-chocolatey-retry.yml");
+const CHOCOLATEY_STATUS: &str = include_str!("../scripts/release/chocolatey-package-status.py");
 const CHOCOLATEY_WRITER: &str = include_str!("../scripts/release/publish-chocolatey-package.ps1");
 const DISPATCH: &str = include_str!("../.github/workflows/release-channel-retry.yml");
 const PREPARE: &str = include_str!("../.github/actions/release-channel-retry-prepare/action.yml");
@@ -16,6 +19,44 @@ const SNAP_WRITER: &str =
 
 fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn temp_dir(label: &str) -> PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock before epoch")
+        .as_nanos();
+    let path = std::env::temp_dir().join(format!(
+        "rmux-chocolatey-{label}-{}-{nonce}",
+        std::process::id()
+    ));
+    fs::create_dir_all(&path).expect("create Chocolatey fixture directory");
+    path
+}
+
+fn chocolatey_entry(version: &str, approved: &str, published: &str) -> String {
+    format!(
+        r#"<?xml version="1.0" encoding="utf-8"?>
+<entry xmlns="http://www.w3.org/2005/Atom"
+       xmlns:d="http://schemas.microsoft.com/ado/2007/08/dataservices">
+  <content>
+    <d:Version>{version}</d:Version>
+    <d:IsApproved>{approved}</d:IsApproved>
+    <d:Published>{published}</d:Published>
+  </content>
+</entry>
+"#
+    )
+}
+
+fn chocolatey_status(document: &PathBuf, expected_version: &str) -> Output {
+    python3::command()
+        .args(["scripts/release/chocolatey-package-status.py", "--document"])
+        .arg(document)
+        .args(["--expected-version", expected_version])
+        .current_dir(repo_root())
+        .output()
+        .expect("run Chocolatey metadata classifier")
 }
 
 fn assert_reusable_only(workflow: &str) {
@@ -254,7 +295,19 @@ fn retries_share_channel_concurrency_and_only_use_store_mutations() {
     assert!(CHOCOLATEY.contains("publish-chocolatey-package.ps1"));
     assert!(CHOCOLATEY_WRITER.contains("$state = \"failed-transient\""));
     assert!(CHOCOLATEY_WRITER.contains("$state = \"failed-terminal\""));
+    assert!(CHOCOLATEY_WRITER.contains("$state = \"pending-moderation\""));
     assert!(CHOCOLATEY_WRITER.contains("ChocolateyPublicBytesMismatchException"));
+    assert!(CHOCOLATEY_WRITER.contains("chocolatey-package-status.py"));
+    assert!(CHOCOLATEY_WRITER.contains("Packages(Id='rmux',Version='$version')"));
+    assert!(CHOCOLATEY_STATUS.contains("IsApproved"));
+    assert!(
+        CHOCOLATEY_WRITER
+            .find("Invoke-WebRequest -Uri $metadataUrl")
+            .expect("metadata lookup")
+            < CHOCOLATEY_WRITER
+                .find("choco push $package")
+                .expect("package push")
+    );
     assert!(
         SNAP_WRITER.contains("snapcore/action-publish@214b86e5ca036ead1668c79afb81e550e6c54d40")
     );
@@ -267,6 +320,76 @@ fn retries_share_channel_concurrency_and_only_use_store_mutations() {
         assert!(workflow.contains("attestations: write"));
         assert!(workflow.contains("id-token: write"));
     }
+}
+
+#[test]
+fn chocolatey_metadata_distinguishes_pending_from_public_packages() {
+    let root = temp_dir("metadata");
+    let pending = root.join("pending.xml");
+    let public = root.join("public.xml");
+    fs::write(
+        &pending,
+        chocolatey_entry("0.10.0", "false", "1900-01-01T00:00:00"),
+    )
+    .expect("write pending Chocolatey fixture");
+    fs::write(
+        &public,
+        chocolatey_entry("0.10.0", "true", "2026-08-08T12:34:56.789"),
+    )
+    .expect("write public Chocolatey fixture");
+
+    let pending_output = chocolatey_status(&pending, "0.10.0");
+    assert!(pending_output.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&pending_output.stdout).trim(),
+        "pending"
+    );
+    let public_output = chocolatey_status(&public, "0.10.0");
+    assert!(public_output.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&public_output.stdout).trim(),
+        "public"
+    );
+
+    for (name, document, expected_version) in [
+        (
+            "mismatched-version",
+            chocolatey_entry("0.9.1", "true", "2026-08-08T12:34:56Z"),
+            "0.10.0",
+        ),
+        (
+            "approved-without-publication",
+            chocolatey_entry("0.10.0", "true", "1900-01-01T00:00:00"),
+            "0.10.0",
+        ),
+        (
+            "unapproved-with-publication",
+            chocolatey_entry("0.10.0", "false", "2026-08-08T12:34:56Z"),
+            "0.10.0",
+        ),
+        (
+            "duplicate-publication",
+            chocolatey_entry("0.10.0", "true", "2026-08-08T12:34:56Z").replace(
+                "</content>",
+                "<d:Published>2026-08-08T12:34:56Z</d:Published></content>",
+            ),
+            "0.10.0",
+        ),
+        (
+            "external-entity",
+            "<!DOCTYPE entry [<!ENTITY version SYSTEM 'file:///etc/passwd'>]><entry />".to_owned(),
+            "0.10.0",
+        ),
+    ] {
+        let path = root.join(format!("{name}.xml"));
+        fs::write(&path, document).expect("write rejected Chocolatey fixture");
+        assert!(
+            !chocolatey_status(&path, expected_version).status.success(),
+            "invalid Chocolatey metadata accepted: {name}"
+        );
+    }
+
+    fs::remove_dir_all(root).expect("remove Chocolatey fixture directory");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- classify exact Chocolatey OData metadata before treating a package as public
- keep pending packages unresolved without resubmitting them
- fail closed on inconsistent metadata or mismatched package bytes

## Validation

- live non-mutating check against rmux 0.10.0: `pending-moderation`, `public_live=false`
- exact downloaded package hashes matched
- release contract validation, targeted release suites, Rustfmt, Ruff, Clippy and PowerShell parsing passed

No Chocolatey package was resubmitted.