### PR TITLE
Depend on ratatui-core so hosts choose their own ratatui

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,7 +128,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -334,6 +334,20 @@ name = "compact_str"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fd622ebbb56a5b2ccb651b32b911cdeb2a9b4b11776b2473bf26a26a286244e"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
 dependencies = [
  "castaway",
  "cfg-if",
@@ -552,6 +566,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -634,7 +654,18 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -642,6 +673,11 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hax-lib"
@@ -803,6 +839,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -817,6 +862,16 @@ dependencies = [
  "cfg-if",
  "futures-util",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kasuari"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
+dependencies = [
+ "hashbrown 0.16.1",
+ "thiserror",
 ]
 
 [[package]]
@@ -901,6 +956,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "line-clipping"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e752191d037c44ad111a8caa762921926658402f01cc1253f7bef2020ece4f5e"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -934,6 +998,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
  "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "lru"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
+dependencies = [
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -1176,15 +1249,45 @@ checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
  "bitflags",
  "cassowary",
- "compact_str",
+ "compact_str 0.8.2",
  "indoc",
  "instability",
- "itertools",
- "lru",
+ "itertools 0.13.0",
+ "lru 0.12.5",
  "paste",
- "strum",
+ "strum 0.26.3",
  "unicode-segmentation",
- "unicode-truncate",
+ "unicode-truncate 1.1.0",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "ratatui"
+version = "0.30.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3274ba0a2c5e1bcad2a2005d20f4dc59dad26b2eb0940fb094500dba4099d57d"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbb175c433c8e28a809d1f5773a2ae96e68c0ce40db865cbab1020bf33ae479c"
+dependencies = [
+ "bitflags",
+ "compact_str 0.9.1",
+ "hashbrown 0.17.1",
+ "itertools 0.14.0",
+ "kasuari",
+ "lru 0.18.2",
+ "strum 0.28.0",
+ "thiserror",
+ "unicode-segmentation",
+ "unicode-truncate 2.0.1",
  "unicode-width 0.2.0",
 ]
 
@@ -1192,9 +1295,28 @@ dependencies = [
 name = "ratatui-rmux"
 version = "0.10.0"
 dependencies = [
- "ratatui",
+ "ratatui 0.30.2",
+ "ratatui-core",
  "rmux-sdk",
  "tokio",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66e3d19bcc9130ca376277d93b60767ff121ace3be06f5f95f81dd68956407d1"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.17.1",
+ "indoc",
+ "instability",
+ "itertools 0.14.0",
+ "line-clipping",
+ "ratatui-core",
+ "strum 0.28.0",
+ "unicode-segmentation",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -1244,7 +1366,7 @@ dependencies = [
  "embed-manifest",
  "libc",
  "qrcode",
- "ratatui",
+ "ratatui 0.29.0",
  "rmux-client",
  "rmux-core",
  "rmux-os",
@@ -1282,7 +1404,7 @@ name = "rmux-core"
 version = "0.10.0"
 dependencies = [
  "chrono",
- "compact_str",
+ "compact_str 0.8.2",
  "regex",
  "rmux-proto",
  "unicode-width 0.1.14",
@@ -1341,7 +1463,7 @@ dependencies = [
 name = "rmux-render-core"
 version = "0.10.0"
 dependencies = [
- "ratatui",
+ "ratatui 0.29.0",
  "serde",
 ]
 
@@ -1627,7 +1749,16 @@ version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros 0.28.0",
 ]
 
 [[package]]
@@ -1640,6 +1771,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
+ "syn",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 
@@ -1803,9 +1946,20 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
 dependencies = [
- "itertools",
+ "itertools 0.13.0",
  "unicode-segmentation",
  "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-truncate"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
+dependencies = [
+ "itertools 0.14.0",
+ "unicode-segmentation",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]

--- a/crates/ratatui-rmux/Cargo.toml
+++ b/crates/ratatui-rmux/Cargo.toml
@@ -10,11 +10,19 @@ categories = ["command-line-interface"]
 publish = true
 
 # Direct dependencies are intentionally minimal: `rmux-sdk` is the only
-# RMUX integration boundary, and one ratatui surface is linked under the
-# `ratatui-core` crate name for source compatibility.
+# RMUX integration boundary, and the ratatui surface is `ratatui-core` — the
+# crate ratatui 0.30 factors its buffer, layout, style and widget traits into.
+# Depending on it directly, rather than on a pinned `ratatui`, is what keeps
+# this crate's ratatui version out of its host's: a `Buffer` from any ratatui
+# 0.30.x is the same `ratatui_core::buffer::Buffer` this paints into.
 [dependencies]
-ratatui-core = { package = "ratatui", version = "=0.29.0", default-features = false }
+ratatui-core = { version = "0.1.2", default-features = false }
 rmux-sdk = { path = "../rmux-sdk", version = "0.10.0" }
 
+# `ratatui` itself is a dev-dependency and not a dependency: the crate builds
+# against `ratatui-core` alone, and this is here so `tests/ratatui_host_compat.rs`
+# can prove a host on the full ratatui can paint with the widget — the one claim
+# the other tests, which build their buffers from `ratatui-core`, cannot make.
 [dev-dependencies]
+ratatui = { version = "0.30.2", default-features = false }
 tokio = { version = "1.48.0", features = ["macros", "rt", "time"] }

--- a/crates/ratatui-rmux/README.md
+++ b/crates/ratatui-rmux/README.md
@@ -11,7 +11,7 @@ state.
 
 ```toml
 [dependencies]
-ratatui = "0.29"
+ratatui = "0.30"
 ratatui-rmux = "0.10.0"
 rmux-sdk = "0.10.0"
 ```

--- a/crates/ratatui-rmux/tests/ratatui_host_compat.rs
+++ b/crates/ratatui-rmux/tests/ratatui_host_compat.rs
@@ -1,0 +1,68 @@
+//! The property this crate exists for: a host on `ratatui` paints with it.
+//!
+//! Every other test here builds its `Buffer` from `ratatui_core` — the crate
+//! this one depends on — so all of them would keep passing if the dependency
+//! were re-pinned to a `ratatui` aliased under the `ratatui-core` name. That is
+//! what it used to be, and under it a host on ratatui 0.30 could not call
+//! `render` at all: its `Buffer` was a different type with the same path, and
+//! cargo reports that as a trait bound that "is not satisfied" against a type
+//! whose name is identical to the one required.
+//!
+//! So these go through `ratatui` itself, the way a host does. They assert
+//! nothing about the pixels — `render.rs` covers the projection — only that the
+//! types unify, which is a compile-time claim the test body cannot fake.
+
+use ratatui::backend::TestBackend;
+use ratatui::layout::Rect;
+use ratatui::widgets::Widget;
+use ratatui::Terminal;
+
+use ratatui_rmux::{PaneState, PaneWidget};
+use rmux_sdk::{PaneAttributes, PaneCell, PaneColor, PaneCursor, PaneGlyph, PaneSnapshot};
+
+fn cell(text: &str) -> PaneCell {
+    PaneCell {
+        glyph: PaneGlyph::new(text, 1),
+        attributes: PaneAttributes::EMPTY,
+        foreground: PaneColor::Default,
+        background: PaneColor::Default,
+        underline: PaneColor::Default,
+    }
+}
+
+fn two_by_one() -> PaneState {
+    let snapshot = PaneSnapshot::new(2, 1, vec![cell("h"), cell("i")], PaneCursor::default())
+        .expect("a 2x1 snapshot of two cells");
+    PaneState::from_snapshot(snapshot)
+}
+
+/// `ratatui::buffer::Buffer` is `ratatui_core::buffer::Buffer`, so a host can
+/// hand this widget the buffer it already has.
+#[test]
+fn a_ratatui_buffer_is_the_buffer_this_widget_paints() {
+    let state = two_by_one();
+    let area = Rect::new(0, 0, 2, 1);
+    let mut buffer = ratatui::buffer::Buffer::empty(area);
+
+    PaneWidget::new(&state).render(area, &mut buffer);
+
+    assert_eq!(buffer.cell((0, 0)).expect("a cell").symbol(), "h");
+    assert_eq!(buffer.cell((1, 0)).expect("a cell").symbol(), "i");
+}
+
+/// And the path a host actually takes: `Frame::render_widget` inside a draw
+/// closure, which is where the trait bound has to hold for this crate to be
+/// usable at all.
+#[test]
+fn a_frame_renders_the_widget_the_way_a_host_does() {
+    let state = two_by_one();
+    let mut terminal = Terminal::new(TestBackend::new(2, 1)).expect("a test terminal");
+
+    terminal
+        .draw(|frame| frame.render_widget(PaneWidget::new(&state), frame.area()))
+        .expect("the draw closure accepted the widget");
+
+    let buffer = terminal.backend().buffer();
+    assert_eq!(buffer.cell((0, 0)).expect("a cell").symbol(), "h");
+    assert_eq!(buffer.cell((1, 0)).expect("a cell").symbol(), "i");
+}


### PR DESCRIPTION
## What

`ratatui-rmux` depends on `ratatui-core`, the crate ratatui 0.30 factors its
`Buffer`, `Rect`, `Style` and `Widget` into, instead of on `ratatui = "=0.29.0"`
aliased under the `ratatui-core` name.

## Why

The alias makes the crate's ratatui version part of its public API, and pins it
to a release its hosts have moved off. A host on ratatui 0.30 cannot call
`render` at all:

```
error[E0277]: the trait bound `PaneWidget<'_>: Widget` is not satisfied
error[E0599]: no method named `render` found for struct `PaneWidget<'a>`
```

Both types are spelled `ratatui::widgets::Widget` and `ratatui::buffer::Buffer`,
so the message names a trait that is visibly implemented and a type that is
visibly correct. It took a while to work out that the two `Buffer`s were
different types with the same path.

Depending on `ratatui-core` directly is what decouples them: a `Buffer` from any
ratatui 0.30.x *is* `ratatui_core::buffer::Buffer`, so the widget paints into
whatever buffer its host already has, and this crate stops having an opinion
about the host's ratatui.

## Scope

Only `crates/ratatui-rmux`. It is a leaf — nothing in the workspace depends on
it — so this does not touch the `ratatui = "=0.29.0"` the `rmux` binary itself
uses, and the two coexist in the lock file without conflict.

`crates/rmux-render-core` carries the same alias and the same argument would
apply to it, but nothing depends on that crate either and I did not want to
widen an already-mechanical change. Happy to add it here or in a follow-up,
whichever you prefer.

## No source changes

The port is the dependency line. Every `use ratatui_core::…` in `src/` compiles
unchanged against the real crate, because the alias was already standing in for
exactly this API.

## Test

`tests/ratatui_host_compat.rs` is new, and is the reason `ratatui` appears as a
dev-dependency. Every existing test builds its `Buffer` from `ratatui-core` —
the crate under the alias — so all of them keep passing if the dependency is
re-pinned, and none of them can see the breakage a host sees. The new tests go
through `ratatui` itself: one paints into a `ratatui::buffer::Buffer`, one goes
through `Frame::render_widget` inside `Terminal::draw`, which is the path a host
actually takes. They assert almost nothing about pixels — `render.rs` covers the
projection — the claim is that the types unify, which is a compile-time property
the test body cannot fake.

Reverting just the `Cargo.toml` line makes both fail with the two errors quoted
above, which is what I wanted from a regression test for this.

The dev-dependency is `default-features = false` to keep it off the widget tree
and out of the lock file as far as possible.

## Gates

Linux x86_64, toolchain 1.96.1 from `rust-toolchain.toml`:

```
cargo fmt --all -- --check                            # clean
cargo build --workspace                               # clean
cargo clippy --workspace --all-targets -- -D warnings  # clean
cargo test -p ratatui-rmux --all-targets              # 66 passed, 0 failed
```

Being precise about the last line: I ran the test suite for the touched crate
rather than `cargo test --workspace --all-targets`. That crate's own suite
includes `ratatui_real_daemon_render_smoke`, which spins a daemon and takes
about seven minutes here, and `ratatui-rmux` is a leaf nothing else depends on,
so the rest of the workspace cannot see this change. Say the word if you would
like the full workspace run before merge and I will post it.

## CHANGELOG

Left alone: `CHANGELOG.md` has no unreleased section and
`scripts/check-changelog-release.py` validates the current release's headings,
so I did not want to invent one. Happy to add an entry wherever unreleased
notes belong.