### PR TITLE
fix(renderer): avoid blanking popups before painting content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,5 @@
 # Changelog
 
-## Unreleased
-
-### Terminal rendering
-
-- Paint popup content rows directly in their final state instead of clearing
-  the whole popup first. Shorter and missing rows still erase stale content;
-  ANSI styles and Unicode clipping are preserved. This removes the blank
-  prepaint phase that can flash during popup updates over a PTY or SSH.
-
 ## 0.10.0
 
 ### SDK
@@ -52,6 +43,11 @@
   process left unstyled.
 
 ### Reliability and performance
+
+- Paint popup content rows directly in their final state instead of clearing
+  the whole popup first. Shorter and missing rows still erase stale content;
+  ANSI styles and Unicode clipping are preserved. This removes the blank
+  prepaint phase that can flash during popup updates over a PTY or SSH.
 
 - Linearize pane generation, output sequence, invalidation revision, transcript
   capture, and observer registration. Mutations without output bytes now wake

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Terminal rendering
+
+- Paint popup content rows directly in their final state instead of clearing
+  the whole popup first. Shorter and missing rows still erase stale content;
+  ANSI styles and Unicode clipping are preserved. This removes the blank
+  prepaint phase that can flash during popup updates over a PTY or SSH.
+
 ## 0.10.0
 
 ### SDK

--- a/crates/rmux-server/src/renderer/overlay.rs
+++ b/crates/rmux-server/src/renderer/overlay.rs
@@ -345,7 +345,8 @@ pub(crate) fn render_menu_overlay(spec: &MenuRenderSpec) -> Vec<u8> {
 
 pub(crate) fn render_popup_overlay(spec: &PopupRenderSpec) -> Vec<u8> {
     let mut frame = Vec::new();
-    fill_rect(&mut frame, spec.rect, &spec.style);
+    // Paint each content row in its final state. Clearing the whole rectangle
+    // first exposes a blank popup between PTY/SSH writes on every refresh.
     if spec.border_lines.visible() {
         draw_box(
             &mut frame,
@@ -358,20 +359,24 @@ pub(crate) fn render_popup_overlay(spec: &PopupRenderSpec) -> Vec<u8> {
     }
 
     let inner = inner_rect(spec.rect, spec.border_lines);
-    match &spec.content {
-        PopupContent::Surface(rows) => {
-            for (index, row) in rows.iter().enumerate() {
-                let Some(y) = content_row_y(inner, index) else {
-                    break;
-                };
-                draw_surface_row(&mut frame, inner.x, y, row, usize::from(inner.width));
+    for index in 0..usize::from(inner.height) {
+        let Some(y) = content_row_y(inner, index) else {
+            break;
+        };
+        match &spec.content {
+            PopupContent::Surface(rows) => {
+                let row = rows.get(index).map_or(&[][..], Vec::as_slice);
+                draw_surface_row(
+                    &mut frame,
+                    inner.x,
+                    y,
+                    row,
+                    usize::from(inner.width),
+                    &spec.style,
+                );
             }
-        }
-        PopupContent::Text(lines) => {
-            for (index, line) in lines.iter().enumerate() {
-                let Some(y) = content_row_y(inner, index) else {
-                    break;
-                };
+            PopupContent::Text(lines) => {
+                let line = lines.get(index).map_or("", String::as_str);
                 draw_formatted_text(
                     &mut frame,
                     inner.x,
@@ -588,8 +593,15 @@ fn draw_styled_text(frame: &mut Vec<u8>, x: u16, y: u16, text: &str, style: &Sty
 /// The row is clipped to the popup's inner width without splitting an escape
 /// sequence, and is bracketed by resets so neither the popup style nor a
 /// trailing attribute from the process bleeds into the rest of the frame.
-fn draw_surface_row(frame: &mut Vec<u8>, x: u16, y: u16, row: &[u8], width: usize) {
-    let clipped = super::truncate_rendered_pane_line(row, width, &rmux_core::Utf8Config::default());
+fn draw_surface_row(frame: &mut Vec<u8>, x: u16, y: u16, row: &[u8], width: usize, style: &Style) {
+    // Pad *after* the final text, using the popup background. This erases a
+    // shortened/missing row without blanking text we are about to repaint.
+    // Reuse the ANSI/grapheme-aware truncator for both clipping and padding.
+    let mut padded = row.to_vec();
+    padded.extend_from_slice(&super::style_sgr_bytes(style, true));
+    padded.resize(padded.len().saturating_add(width), b' ');
+    let clipped =
+        super::truncate_rendered_pane_line(&padded, width, &rmux_core::Utf8Config::default());
     if clipped.is_empty() {
         return;
     }

--- a/crates/rmux-server/src/renderer/overlay/tests.rs
+++ b/crates/rmux-server/src/renderer/overlay/tests.rs
@@ -283,7 +283,7 @@ fn popup_overlay_surface_rows_reset_around_each_row() {
         "a row must start from a known state: {row:?}"
     );
     assert!(
-        row.contains("red\u{1b}[0m\u{1b}8"),
+        row.ends_with("\u{1b}[0m\u{1b}8"),
         "a row must not leak its attributes into the frame: {row:?}"
     );
 }
@@ -391,4 +391,67 @@ fn status_layout_tracks_inline_range_changes_inside_status_left() {
         range.kind,
         crate::status_ranges::StatusRangeType::Control(7)
     ) && range.x == (1..=1)));
+}
+
+#[test]
+fn popup_surface_paints_final_rows_without_a_blank_pass() {
+    let spec = PopupRenderSpec {
+        rect: OverlayRect {
+            x: 2,
+            y: 1,
+            width: 8,
+            height: 2,
+        },
+        title: String::new(),
+        style: Style::default(),
+        border_style: Style::default(),
+        border_lines: BoxLines::None,
+        content: PopupContent::Surface(vec![b"abcdefgh".to_vec(), b"12345678".to_vec()]),
+    };
+    let frame = render_popup_overlay(&spec);
+    let frame = String::from_utf8(frame).unwrap();
+    // There must be no intermediate all-blank surface, even on terminals
+    // which paint the stream before the entire frame has arrived.
+    assert!(!frame.contains("        "));
+    assert_eq!(frame.matches("\x1b[2;3H").count(), 1);
+    assert_eq!(frame.matches("\x1b[3;3H").count(), 1);
+    assert!(frame.contains("abcdefgh"));
+    assert!(frame.contains("12345678"));
+}
+
+#[test]
+fn popup_surface_short_and_missing_rows_erase_old_cells() {
+    use rmux_core::{input::InputParser, Screen};
+    let size = TerminalSize { cols: 12, rows: 5 };
+    let mut screen = Screen::new(size, 0);
+    let mut parser = InputParser::new();
+    parser.parse(b"\x1b[2;3HXXXXXXXX\x1b[3;3HYYYYYYYY", &mut screen);
+    let spec = PopupRenderSpec {
+        rect: OverlayRect {
+            x: 2,
+            y: 1,
+            width: 8,
+            height: 2,
+        },
+        title: String::new(),
+        style: Style::default(),
+        border_style: Style::default(),
+        border_lines: BoxLines::None,
+        content: PopupContent::Surface(vec!["界e\u{301}".as_bytes().to_vec()]),
+    };
+    parser.parse(&render_popup_overlay(&spec), &mut screen);
+    let options = rmux_core::GridRenderOptions {
+        trim_spaces: false,
+        include_empty_cells: true,
+        ..Default::default()
+    };
+    let first = screen
+        .render_visible_line_independent_with_default_style(1, options, &Style::default())
+        .unwrap();
+    let second = screen
+        .render_visible_line_independent_with_default_style(2, options, &Style::default())
+        .unwrap();
+    assert!(!first.contains(&b'X'), "{first:?}");
+    assert!(!second.contains(&b'Y'), "{second:?}");
+    assert!(String::from_utf8(first).unwrap().contains("界e\u{301}"));
 }


### PR DESCRIPTION
## Problem and change

An updating `display-popup` currently paints a rectangle of spaces before repainting its content. Even a tiny TUI update therefore emits a complete blank popup followed by the actual rows. Terminals consuming the output incrementally (including over PTYs/SSH) can show that intermediate blank surface as a flash.

Render each popup content row directly in its final state instead. Surface rows are padded *after* their content, using the popup style and the existing ANSI/grapheme-aware truncator, so shorter/missing rows still erase stale cells. Static formatted text uses its existing fixed-width renderer for every row. Borders and process SGR remain supported.

Related to #216, but this does **not** fix its per-read-chunk refresh/backpressure issue or introduce incremental/delta popup frames. Host status ticks overwriting an open popup are reported separately in #225.

## Validation

- Regression tests check that a filled borderless popup has no all-blank prepaint and each row is positioned once.
- A screen-model test verifies that short Unicode/combining-character content and missing rows clear old text.
- Existing overlay tests cover SGR, literal format-like process output, clipping, row bounds, border variants, and static text.
- Linux x86_64, isolated 120x30 PTY clients, status disabled: six seconds of the same idle `muxa watch` popup emitted **57,624 bytes / 180 full-width blank runs** with stock rmux 0.10.0, versus **32,298 bytes / 0 full-width blank runs** with this patch. This measures removal of the blank phase; it is not a claim that all sources of terminal flicker or overlay backlog are fixed.

- `cargo build --workspace`: passed.
- `cargo clippy --workspace --all-targets -- -D warnings`: passed.
- `cargo fmt --all -- --check`: passed.
- `cargo test -p rmux-server --lib renderer::overlay`: 16 passed.
- `cargo test --workspace --all-targets`: stopped at the unchanged `rmux_manpage_renders_with_system_formatter` test. This Linux environment has Ubuntu's minimized-system `/usr/bin/man` stub, which returns success with a notice instead of rendering the page; the test consequently cannot find `RMUX`. No changes were made to that test or the manpage.
- The broader run `SHELL=/bin/sh cargo test --workspace --all-targets --no-fail-fast -- --skip rmux_manpage_renders_with_system_formatter` completed but was **not green**. Besides shell-name expectations and an unselected local Ruby version, it found a changelog release-heading violation (fixed in the follow-up commit), an attach redraw failure, and a server test process stack overflow.
- With `SHELL=/bin/bash RBENV_VERSION=3.1.1`, all four affected CLI/release test targets passed on rerun: `cli_attach_flow` (40), `cli_window_surface` (134), `release_downstream_writer_spec` (6), and `release_gate_python_floor_spec` (3).
- The server library rerun with `SHELL=/bin/bash RBENV_VERSION=3.1.1 RUST_MIN_STACK=16777216 cargo test -p rmux-server --lib` completed: **4,075 passed, 5 failed, 3 ignored**. The failures are `timed_out_attach_generation_cannot_consume_healthy_fallback_queries`, `display_message_expiry_preserves_an_open_bracketed_paste_boundary`, `managed_client_actions_fail_closed_when_a_pid_is_reregistered`, `rename_session_serializes_timer_rekey_before_source_name_reuse`, and `live_attach_clock_mode_reroutes_complete_bracketed_paste`. These failures have not been compared against an unmodified upstream checkout, so this PR does not assert they are baseline failures.

This PR remains **draft** because whole-workspace validation is not green, although the popup regression tests and the isolated PTY comparison pass. The user's running rmux daemon was not replaced or restarted.
